### PR TITLE
Unpin minor on transient dependencies from dbt-common that are used directly to avoid version conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ classifiers = [
 dependencies = [
     "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
     "pytz>=2015.7",
-    # installed via dbt-common but used directly, unpin to avoid version conflicts
-    "agate",
-    "mashumaro[msgpack]",
-    "protobuf",
-    "typing-extensions",
+    # installed via dbt-common but used directly, unpin minor to avoid version conflicts
+    "agate~=1.7",
+    "mashumaro[msgpack]~=3.9",
+    "protobuf~=4.0",
+    "typing-extensions~=4.4",
 ]
 [project.optional-dependencies]
 lint = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,13 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "agate~=1.9.1",
     "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "mashumaro[msgpack]~=3.9",
-    "protobuf>=4.0.0",
     "pytz>=2015.7",
-    "typing-extensions~=4.4",
+    # installed via dbt-common but used directly, unpin to avoid version conflicts
+    "agate",
+    "mashumaro[msgpack]",
+    "protobuf",
+    "typing-extensions",
 ]
 [project.optional-dependencies]
 lint = [


### PR DESCRIPTION
### Problem

`dbt-adapters` uses packages that are also used in `dbt-common`. In order to avoid version conflicts, these packages should be pinned to the major, with their minors managed in `dbt-common`. They should remain in `pyproject.toml` to explicitly state their dependency. This affects `agate` and `protobuf`, which were pinned to the minor.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
