### PR TITLE
Change pin type to avoid pip resolver issue with ~=

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ dependencies = [
     "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
     "pytz>=2015.7",
     # installed via dbt-common but used directly, unpin minor to avoid version conflicts
-    "agate~=1.7",
-    "mashumaro[msgpack]~=3.9",
-    "protobuf~=4.0",
-    "typing-extensions~=4.4",
+    "agate<2.0",
+    "mashumaro[msgpack]<4.0",
+    "protobuf<5.0",
+    "typing-extensions<5.0",
 ]
 [project.optional-dependencies]
 lint = [


### PR DESCRIPTION
### Problem

`pip` can't handle using `~=` with different "grains", e.g. `agate~=1.7` and `agate~=1.7.0`. See https://github.com/pypa/pip/issues/12229 for more information.

### Solution

Adjust the pins to be upper bounds. The lower bounds are managed by `dbt-common`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
