### PR TITLE
Allow adapter version to be specified in `__about__.py` for hatch support

### DIFF
--- a/.changes/unreleased/Under the Hood-20240123-121220.yaml
+++ b/.changes/unreleased/Under the Hood-20240123-121220.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Allow version to be specified in either __version__.py or __about__.py
+time: 2024-01-23T12:12:20.529147-05:00
+custom:
+  Author: mikealfare
+  Issue: "44"


### PR DESCRIPTION
### Problem

`hatch` docs demonstrate using `__about__.py` to store the package version, similar to `__version__.py`.

#### Options

1. This is configurable in `hatch` and we could force maintainers to use `__version__.py`
2. It is slightly more overhead to support both, but it would be more flexible for maintainers, in particular when building new adapters

### Solution

Support Option 2., and allow `version` to be specified in either `__version__.py` or `__about__.py`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
