### PR TITLE
Generalize actions for reuse across adapters

### DIFF
--- a/.github/actions/build-hatch/action.yml
+++ b/.github/actions/build-hatch/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: "./"
   artifacts-dir:
     description: Where to upload the artifacts
-    default: "/dist"
+    default: "dist"
 
 runs:
   using: composite

--- a/.github/actions/build-hatch/action.yml
+++ b/.github/actions/build-hatch/action.yml
@@ -1,0 +1,36 @@
+name: Build - `hatch`
+description: Build artifacts using the `hatch` build backend
+
+inputs:
+  build-command:
+    description: The command to build distributable artifacts
+    default: "hatch build"
+  check-command:
+    description: The command to check built artifacts
+    default: "hatch run build:check-all"
+  working-dir:
+    description: Where to run commands from, supports namespace packaging
+    default: "./"
+  artifacts-dir:
+    description: Where to upload the artifacts
+    default: "/dist"
+
+runs:
+  using: composite
+  steps:
+
+    - name: Build artifacts
+      run: ${{ inputs.build-command }}
+      shell: bash
+      working-directory: ${{ inputs.working-dir }}
+
+    - name: Check artifacts
+      run: ${{ inputs.check-command }}
+      shell: bash
+      working-directory: ${{ inputs.working-dir }}
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.artifacts-dir}}
+        path: ${{ inputs.working-dir }}dist/

--- a/.github/actions/publish-pypi/action.yml
+++ b/.github/actions/publish-pypi/action.yml
@@ -25,4 +25,4 @@ runs:
     - name: Publish artifacts
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        url: ${{ inputs.pypi-repository-url }}
+        repository-url: ${{ inputs.pypi-repository-url }}

--- a/.github/actions/publish-pypi/action.yml
+++ b/.github/actions/publish-pypi/action.yml
@@ -4,7 +4,7 @@ description: Publish artifacts saved during build step to PyPI
 inputs:
   artifacts-dir:
     description: Where to download the artifacts
-    default: "/dist"
+    default: "dist"
   pypi-repository-url:
     description: The PyPI index to publish to, test or prod
     required: true

--- a/.github/actions/publish-pypi/action.yml
+++ b/.github/actions/publish-pypi/action.yml
@@ -22,12 +22,7 @@ runs:
       run: ${{ inputs.check-command }}
       shell: bash
 
-    - name: Publish artifacts to PyPI Prod
-      if: ${{ inputs.deploy-to }} == prod
-      uses: pypa/gh-action-pypi-publish@release/v1
-
-    - name: Publish artifacts to PyPI Test
-      if: ${{ inputs.deploy-to }} == test
+    - name: Publish artifacts
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        url: https://test.pypi.org/legacy
+        url: ${{ vars.PYPI_REPOSITORY_URL }}

--- a/.github/actions/publish-pypi/action.yml
+++ b/.github/actions/publish-pypi/action.yml
@@ -1,10 +1,9 @@
-# requires github environment with PYPI_REPOSITORY_URL defined
 name: Publish PyPI
 
 inputs:
-  deploy-to:
+  pypi-repository-url:
     description: The PyPI index to publish to, test or prod
-    default: "prod"
+    required: true
   build-command:
     description: The command to build distributable artifacts
     default: "hatch build"
@@ -26,4 +25,4 @@ runs:
     - name: Publish artifacts
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        url: ${{ vars.PYPI_REPOSITORY_URL }}
+        url: ${{ inputs.pypi-repository-url }}

--- a/.github/actions/publish-pypi/action.yml
+++ b/.github/actions/publish-pypi/action.yml
@@ -1,3 +1,4 @@
+# requires github environment with PYPI_REPOSITORY_URL defined
 name: Publish PyPI
 
 inputs:

--- a/.github/actions/publish-pypi/action.yml
+++ b/.github/actions/publish-pypi/action.yml
@@ -10,23 +10,26 @@ inputs:
   check-command:
     description: The command to check built artifacts
     default: "hatch run build:check-all"
+  working-dir:
+    description: Where to run commands from, supports namespace packaging
+    default: "/"
 
 runs:
   using: composite
   steps:
-    - name: Check current directory
-      run: pwd
-      shell: bash
 
     - name: Build artifacts
       run: ${{ inputs.build-command }}
       shell: bash
+      working-directory: ${{ inputs.working-dir }}
 
     - name: Check artifacts
       run: ${{ inputs.check-command }}
       shell: bash
+      working-directory: ${{ inputs.working-dir }}
 
     - name: Publish artifacts
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: ${{ inputs.pypi-repository-url }}
+        packages-dir: ${{ inputs.working-dir }}dist

--- a/.github/actions/publish-pypi/action.yml
+++ b/.github/actions/publish-pypi/action.yml
@@ -5,7 +5,7 @@ inputs:
   artifacts-dir:
     description: Where to download the artifacts
     default: "dist"
-  pypi-repository-url:
+  repository-url:
     description: The PyPI index to publish to, test or prod
     required: true
 
@@ -22,4 +22,4 @@ runs:
     - name: Publish artifacts to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository-url: ${{ inputs.pypi-repository-url }}
+        repository-url: ${{ inputs.repository-url }}

--- a/.github/actions/publish-pypi/action.yml
+++ b/.github/actions/publish-pypi/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: "hatch run build:check-all"
   working-dir:
     description: Where to run commands from, supports namespace packaging
-    default: "/"
+    default: "./"
 
 runs:
   using: composite

--- a/.github/actions/publish-pypi/action.yml
+++ b/.github/actions/publish-pypi/action.yml
@@ -1,25 +1,33 @@
 name: Publish PyPI
 
 inputs:
-  python-version:
-    description: Create an environment with the appropriate version of python and hatch installed
-    default: "3.11"
+  deploy-to:
+    description: The PyPI index to publish to, test or prod
+    default: "prod"
+  build-command:
+    description: The command to build distributable artifacts
+    default: "hatch build"
+  check-command:
+    description: The command to check built artifacts
+    default: "hatch run build:check-all"
 
 runs:
   using: composite
   steps:
-    - name: Setup environment
-      uses: ./.github/actions/setup-environment
-      with:
-        python-version: ${{ inputs.python-version }}
-
     - name: Build artifacts
-      run: hatch build
+      run: ${{ inputs.build-command }}
       shell: bash
 
     - name: Check artifacts
-      run: hatch run build:check-all
+      run: ${{ inputs.check-command }}
       shell: bash
 
-    - name: Publish artifacts to PyPI
+    - name: Publish artifacts to PyPI Prod
+      if: ${{ inputs.deploy-to }} == prod
       uses: pypa/gh-action-pypi-publish@release/v1
+
+    - name: Publish artifacts to PyPI Test
+      if: ${{ inputs.deploy-to }} == test
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        url: https://test.pypi.org/legacy

--- a/.github/actions/publish-pypi/action.yml
+++ b/.github/actions/publish-pypi/action.yml
@@ -1,35 +1,25 @@
-name: Publish PyPI
+name: Publish - PyPI
+description: Publish artifacts saved during build step to PyPI
 
 inputs:
+  artifacts-dir:
+    description: Where to download the artifacts
+    default: "/dist"
   pypi-repository-url:
     description: The PyPI index to publish to, test or prod
     required: true
-  build-command:
-    description: The command to build distributable artifacts
-    default: "hatch build"
-  check-command:
-    description: The command to check built artifacts
-    default: "hatch run build:check-all"
-  working-dir:
-    description: Where to run commands from, supports namespace packaging
-    default: "./"
 
 runs:
   using: composite
   steps:
 
-    - name: Build artifacts
-      run: ${{ inputs.build-command }}
-      shell: bash
-      working-directory: ${{ inputs.working-dir }}
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.artifacts-dir }}
+        path: dist/
 
-    - name: Check artifacts
-      run: ${{ inputs.check-command }}
-      shell: bash
-      working-directory: ${{ inputs.working-dir }}
-
-    - name: Publish artifacts
+    - name: Publish artifacts to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: ${{ inputs.pypi-repository-url }}
-        packages-dir: ${{ inputs.working-dir }}dist

--- a/.github/actions/publish-pypi/action.yml
+++ b/.github/actions/publish-pypi/action.yml
@@ -14,6 +14,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Check current directory
+      run: pwd
+      shell: bash
+
     - name: Build artifacts
       run: ${{ inputs.build-command }}
       shell: bash

--- a/.github/actions/publish-results/action.yml
+++ b/.github/actions/publish-results/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: File type for file name stub (e.g. "unit-tests")
     required: true
   python-version:
-    description: Create an environment with the appropriate version of python and hatch installed
+    description: Python version for the file name stub (e.g. "3.8")
     required: true
   source-file:
     description: File to be uploaded
@@ -16,10 +16,10 @@ runs:
   steps:
     - name: Get timestamp
       id: timestamp
-      run: echo "ts=$(date +'%Y-%m-%dT%H_%M_%S')" >> $GITHUB_OUTPUT #no colons allowed for artifacts
+      run: echo "ts=$(date +'%Y-%m-%dT%H-%M-%S')" >> $GITHUB_OUTPUT #no colons allowed for artifacts
       shell: bash
 
     - uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.file-name }}_${{ inputs.python-version }}-${{ steps.timestamp.outputs.ts }}.csv
+        name: ${{ inputs.file-name }}_python-${{ inputs.python-version }}_${{ steps.timestamp.outputs.ts }}.csv
         path: ${{ inputs.source-file }}

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -4,14 +4,17 @@ inputs:
   setup-command:
     description: The command to setup development dependencies
     default: "python -m pip install hatch"
+  python-version:
+    description: The python version to use
+    required: true
 
 runs:
   using: composite
   steps:
-    - name: Set up Python ${{ vars.PYTHON_VERSION }}
+    - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ vars.PYTHON_VERSION }}
+        python-version: ${{ inputs.python-version }}
 
     - name: Install dev dependencies
       run: ${{ inputs.setup-command }}

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -5,8 +5,8 @@ inputs:
     description: The command to setup development dependencies
     default: "python -m pip install hatch"
   python-version:
-    description: The python version to use
-    required: true
+    description: The version of python to install
+    default: "3.11"
 
 runs:
   using: composite

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,9 +1,6 @@
 name: Setup `hatch`
 
 inputs:
-  python-version:
-    description: Create an environment with the appropriate version of python and hatch installed
-    default: "3.11"
   setup-command:
     description: The command to setup development dependencies
     default: "python -m pip install hatch"
@@ -11,11 +8,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up Python ${{ inputs.python-version }}
+    - name: Set up Python ${{ vars.PYTHON_VERSION }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ inputs.python-version }}
+        python-version: ${{ vars.PYTHON_VERSION }}
 
-    - name: Install hatch
+    - name: Install dev dependencies
       run: ${{ inputs.setup-command }}
       shell: bash

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -3,7 +3,10 @@ name: Setup `hatch`
 inputs:
   python-version:
     description: Create an environment with the appropriate version of python and hatch installed
-    required: true
+    default: "3.11"
+  setup-command:
+    description: The command to setup development dependencies
+    default: "python -m pip install hatch"
 
 runs:
   using: composite
@@ -14,5 +17,5 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Install hatch
-      run: python -m pip install hatch
+      run: ${{ inputs.setup-command }}
       shell: bash

--- a/.github/actions/setup-hatch/action.yml
+++ b/.github/actions/setup-hatch/action.yml
@@ -1,4 +1,5 @@
-name: Setup `hatch`
+name: Setup - `hatch`
+description: Setup a python environment with `hatch` installed
 
 inputs:
   setup-command:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Code Quality
 
 on:
   push:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment
+      - name: Setup `hatch`
+        uses: ./.github/actions/setup-hatch
 
       - name: Run linters
         run: hatch run lint:all

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -10,6 +10,10 @@ on:
 
 permissions: read-all
 
+defaults:
+  run:
+    shell: bash
+
 # will cancel previous workflows triggered by the same event and for the same ref for PRs or same SHA otherwise
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.ref || github.sha }}
@@ -17,8 +21,10 @@ concurrency:
 
 jobs:
   lint:
-    name: Python 3.8
+    name: Python ${{ vars.PYTHON_DEFAULT_VERSION }}
     runs-on: ubuntu-latest
+    environment:
+      name: ci
 
     steps:
       - name: Check out repository
@@ -29,12 +35,10 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:
-          python-version: "3.8"
+          python-version: ${{ vars.PYTHON_DEFAULT_VERSION }}
 
       - name: Run linters
         run: hatch run lint:all
-        shell: bash
 
       - name: Run typechecks
         run: hatch run typecheck:all
-        shell: bash

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,10 +21,8 @@ concurrency:
 
 jobs:
   lint:
-    name: Python ${{ vars.PYTHON_DEFAULT_VERSION }}
+    name: Python 3.8
     runs-on: ubuntu-latest
-    environment:
-      name: ci
 
     steps:
       - name: Check out repository
@@ -35,7 +33,7 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:
-          python-version: ${{ vars.PYTHON_DEFAULT_VERSION }}
+          python-version: "3.8"
 
       - name: Run linters
         run: hatch run lint:all

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
-        with:
-          python-version: "3.8"
 
       - name: Run linters
         run: hatch run lint:all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,4 +60,4 @@ jobs:
         uses: ./.github/actions/publish-pypi
         with:
           pypi-repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
-          working-dir: dbt-tests-adapter/
+          working-dir: ./dbt-tests-adapter/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,14 @@ jobs:
         uses: ./.github/actions/setup-hatch
 
       - name: Build `dbt-adapters`
-        if: ${{ inputs.package }} == dbt-adapters
+        if: ${{ inputs.package == 'dbt-adapters' }}
         uses: ./.github/actions/build-hatch
 
       - name: Build `dbt-tests-adapter`
-        if: ${{ inputs.package }} == dbt-tests-adapter
+        if: ${{ inputs.package == 'dbt-tests-adapter' }}
         uses: ./.github/actions/build-hatch
         with:
-          working-dir: "./dbt-tests-adapter"
+          working-dir: "./dbt-tests-adapter/"
 
       - name: Publish to PyPI
         uses: ./.github/actions/publish-pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
+        with:
+          python-version: ${{ vars.PYTHON_VERSION }}
 
       # keep this in the workflow so that the publishing actions are generic
       - name: Change working directory if `dbt-tests-adapter`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
-        with:
-          python-version: ${{ vars.PYTHON_VERSION }}
 
       # keep this in the workflow so that the publishing actions are generic
       - name: Change working directory if `dbt-tests-adapter`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,18 +51,18 @@ jobs:
 
       - name: Build `dbt-adapters`
         if: ${{ inputs.package }} == dbt-adapters
-        uses: ./.github/actions/publish-pypi
+        uses: ./.github/actions/build-hatch
         with:
           pypi-repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
 
       - name: Build `dbt-tests-adapter`
         if: ${{ inputs.package }} == dbt-tests-adapter
-        uses: ./.github/actions/publish-pypi
+        uses: ./.github/actions/build-hatch
         with:
           pypi-repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
           working-dir: "./dbt-tests-adapter"
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: ./.github/actions/publish-pypi
         with:
           repository-url: ${{ vars.PYPI_REPOSITORY_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,18 +46,23 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment
+      - name: Setup `hatch`
+        uses: ./.github/actions/setup-hatch
 
-      - name: Publish dbt-adapters to PyPI
+      - name: Build `dbt-adapters`
         if: ${{ inputs.package }} == dbt-adapters
         uses: ./.github/actions/publish-pypi
         with:
           pypi-repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
 
-      - name: Publish dbt-adapters to PyPI
+      - name: Build `dbt-tests-adapter`
         if: ${{ inputs.package }} == dbt-tests-adapter
         uses: ./.github/actions/publish-pypi
         with:
           pypi-repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
-          working-dir: ./dbt-tests-adapter/
+          working-dir: "./dbt-tests-adapter"
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: ${{ vars.PYPI_REPOSITORY_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,16 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
+      package:
+        type: choice
+        description: Choose what to publish
+        options:
+        - dbt-adapters
+        - dbt-tests-adapter
+        default: dbt-adapters
       deploy-to:
         type: choice
-        description: Choose where to publish (test/prod)
+        description: Choose where to publish
         options:
         - prod
         - test
@@ -39,7 +46,17 @@ jobs:
         with:
           persist-credentials: false
 
+      # keep this in the workflow so that the publish actions are generic
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+
+      # keep this in the workflow so that the publish actions is generic
+      - name: Change working directory if `dbt-tests-adapter`
+        if: ${{ inputs.package }} == dbt-tests-adapter
+        run: cd dbt-tests-adapter
+        shell: bash
+
       - name: Publish to PyPI
         uses: ./.github/actions/publish-pypi
         with:
-          python-version: "3.11"
+          deploy-to: ${{ inputs.deploy-to }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.deploy-to }}
-      url: ${{ vars.PYPI_URL }}
+      url: ${{ vars.PYPI_PROJECT_URL }}
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
@@ -46,11 +46,10 @@ jobs:
         with:
           persist-credentials: false
 
-      # keep this in the workflow so that the publish actions are generic
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
-      # keep this in the workflow so that the publish actions is generic
+      # keep this in the workflow so that the publishing actions are generic
       - name: Change working directory if `dbt-tests-adapter`
         if: ${{ inputs.package }} == dbt-tests-adapter
         run: cd dbt-tests-adapter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
 
       # keep this in the workflow so that the publishing actions are generic
       - name: Change working directory if `dbt-tests-adapter`
-        if: ${{ inputs.package }} == dbt-tests-adapter
-        run: cd dbt-tests-adapter
+        if: ${{ inputs.package }} == 'dbt-tests-adapter'
+        run: cd dbt-tests-adapter && pwd
         shell: bash
 
       - name: Publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,4 @@ jobs:
       - name: Publish to PyPI
         uses: ./.github/actions/publish-pypi
         with:
-          deploy-to: ${{ inputs.deploy-to }}
+          pypi-repository-url: ${{ vars.PYPI_REPOSITORY_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,15 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
-      # keep this in the workflow so that the publishing actions are generic
-      - name: Change working directory if `dbt-tests-adapter`
-        if: ${{ inputs.package }} == 'dbt-tests-adapter'
-        run: cd dbt-tests-adapter && pwd
-        shell: bash
-
-      - name: Publish to PyPI
+      - name: Publish dbt-adapters to PyPI
+        if: ${{ inputs.package }} == dbt-adapters
         uses: ./.github/actions/publish-pypi
         with:
           pypi-repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
+
+      - name: Publish dbt-adapters to PyPI
+        if: ${{ inputs.package }} == dbt-tests-adapter
+        uses: ./.github/actions/publish-pypi
+        with:
+          pypi-repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
+          working-dir: dbt-tests-adapter/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ defaults:
 
 # will cancel previous workflows triggered by the same event and for the same ref for PRs or same SHA otherwise
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.ref || github.sha }}-${{ inputs.package }}-${{ inputs.deploy-to }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,14 +52,11 @@ jobs:
       - name: Build `dbt-adapters`
         if: ${{ inputs.package }} == dbt-adapters
         uses: ./.github/actions/build-hatch
-        with:
-          pypi-repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
 
       - name: Build `dbt-tests-adapter`
         if: ${{ inputs.package }} == dbt-tests-adapter
         uses: ./.github/actions/build-hatch
         with:
-          pypi-repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
           working-dir: "./dbt-tests-adapter"
 
       - name: Publish to PyPI

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment
+      - name: Setup `hatch`
+        uses: ./.github/actions/setup-hatch
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,11 +19,13 @@ jobs:
   unit:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    environment:
+      name: ci
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ${{ vars.PYTHON_SUPPORTED_VERSIONS }}
 
     steps:
       - name: Check out repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ vars.PYTHON_SUPPORTED_VERSIONS }}
+        python-version: ${{ fromJSON(vars.PYTHON_SUPPORTED_VERSIONS) }}
 
     steps:
       - name: Check out repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,13 +19,11 @@ jobs:
   unit:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
-    environment:
-      name: ci
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(vars.PYTHON_SUPPORTED_VERSIONS) }}
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Check out repository

--- a/dbt-tests-adapter/pyproject.toml
+++ b/dbt-tests-adapter/pyproject.toml
@@ -52,9 +52,11 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist.force-include]
 "../dbt/tests" = "dbt/tests"
+"../dbt/__init__.py" = "dbt/__init__.py"
 
 [tool.hatch.build.targets.wheel.force-include]
 "../dbt/tests" = "dbt/tests"
+"../dbt/__init__.py" = "dbt/__init__.py"
 
 [tool.hatch.version]
 path = "../dbt/tests/__about__.py"

--- a/dbt-tests-adapter/pyproject.toml
+++ b/dbt-tests-adapter/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core",
+    "dbt-core",
     # `dbt-tests-adapter` will ultimately depend on the packages below
     # `dbt-tests-adapter` temporarily uses `dbt-core` for a dbt runner
     # `dbt-core` takes the packages below as dependencies, so they are unpinned to avoid conflicts
@@ -49,9 +49,6 @@ Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/CHANGELOG.md"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.build.targets.sdist.force-include]
 "../dbt/tests" = "dbt/tests"


### PR DESCRIPTION
### Problem

We would like to reuse the same actions across all adapters for the release process.

### Solution

- Pull repo-specific items out of the action and put into the workflow
- Parameterize the actions with sensible defaults
- Add ability to publish to PyPI test
- Add ability to publish `dbt-tests-adapter` or dbt-adapters`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX