### PR TITLE
Use `defer_relation` for unit test type detection if available

### DIFF
--- a/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
+++ b/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
@@ -3,7 +3,7 @@
 {% set default_row = {} %}
 
 {%- if not column_name_to_data_types -%}
-{%-   set columns_in_relation = adapter.get_columns_in_relation(this) -%}
+{%-   set columns_in_relation = adapter.get_columns_in_relation(defer_relation or this) -%}
 {%-   set column_name_to_data_types = {} -%}
 {%-   for column in columns_in_relation -%}
 {%-     do column_name_to_data_types.update({column.name: column.dtype}) -%}


### PR DESCRIPTION
needed for https://github.com/dbt-labs/dbt-core/pull/9199

### Problem

https://github.com/dbt-labs/dbt-core/pull/9199
 moves deferral logic to `RefResolver`. But it won't apply for unit test fixtures [because they are materialized `ephemeral`](https://github.com/dbt-labs/dbt-core/blob/95a0f8e25481c583b670981e5f9492f2059a88e1/core/dbt/context/providers.py#L537).

### Solution

Within `get_fixture_sql` itself, use `defer_relation` if available, then fall back to `this`.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
