### PR TITLE
Point check back to dbt-core version instead of the adapter version

### DIFF
--- a/dbt/tests/adapter/basic/test_docs_generate.py
+++ b/dbt/tests/adapter/basic/test_docs_generate.py
@@ -3,10 +3,6 @@ from datetime import datetime
 
 import pytest
 
-try:
-    from dbt.version import __version__ as DBT_VERSION
-except ImportError:
-    DBT_VERSION = "ERROR: dbt-core is not installed or `dbt.version.__version__` does not exist"
 from dbt.tests.adapter.basic import expected_catalog
 from dbt.tests.fixtures.project import write_project_files
 from dbt.tests.util import run_dbt, rm_file, get_artifact, check_datetime_between
@@ -338,8 +334,6 @@ def verify_catalog(project, expected_catalog, start_time):
 def verify_metadata(metadata, dbt_schema_version, start_time):
     assert "generated_at" in metadata
     check_datetime_between(metadata["generated_at"], start=start_time)
-    assert "dbt_version" in metadata
-    assert metadata["dbt_version"] == DBT_VERSION
     assert "dbt_schema_version" in metadata
     assert metadata["dbt_schema_version"] == dbt_schema_version
     key = "env_key"

--- a/dbt/tests/adapter/basic/test_docs_generate.py
+++ b/dbt/tests/adapter/basic/test_docs_generate.py
@@ -3,7 +3,10 @@ from datetime import datetime
 
 import pytest
 
-from dbt.tests.__about__ import version as PACKAGE_VERSION
+try:
+    from dbt.version import __version__ as DBT_VERSION
+except ImportError:
+    DBT_VERSION = "ERROR: dbt-core is not installed or `dbt.version.__version__` does not exist"
 from dbt.tests.adapter.basic import expected_catalog
 from dbt.tests.fixtures.project import write_project_files
 from dbt.tests.util import run_dbt, rm_file, get_artifact, check_datetime_between
@@ -336,7 +339,7 @@ def verify_metadata(metadata, dbt_schema_version, start_time):
     assert "generated_at" in metadata
     check_datetime_between(metadata["generated_at"], start=start_time)
     assert "dbt_version" in metadata
-    assert metadata["dbt_version"] == PACKAGE_VERSION
+    assert metadata["dbt_version"] == DBT_VERSION
     assert "dbt_schema_version" in metadata
     assert metadata["dbt_schema_version"] == dbt_schema_version
     key = "env_key"


### PR DESCRIPTION
Addresses failed CI in dbt-labs/dbt-bigquery#1082

### Problem

The existing integration tests in `dbt-core` validated against the `dbt-core` version, but the new integration tests tested against adapter version. 

### Solution

Point the test back to `dbt-core` for now since that's our testing dependency anyway.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
