### PR TITLE
Update internal issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/implementation-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/implementation-ticket.yml
@@ -1,0 +1,66 @@
+name: 🛠️ Implementation
+description: This is an implementation ticket intended for use by the maintainers of `dbt-adapters`
+title: "[<project>] <title>"
+labels: ["user docs","refinement"]
+body:
+  - type: markdown
+    attributes:
+      value: This is an implementation ticket intended for use by the maintainers of `dbt-adapters`
+
+  - type: checkboxes
+    attributes:
+      label: Housekeeping
+      description: >
+        A couple friendly reminders:
+          1. Remove the `user docs` label if the scope of this work does not require changes to https://docs.getdbt.com/docs: no end-user interface (e.g. yml spec, CLI, error messages, etc) or functional changes.
+          2. Will this change need to be backported? Add the appropriate `backport 1.x.latest` label(s).
+          3. Is this an `enhancement`, `bug`, or `regression`? Add the appropriate label.
+      options:
+        - label: I am a maintainer of `dbt-adapters`
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Short description
+      description: |
+        Describe the scope of the ticket, a high-level implementation approach and any tradeoffs to consider.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Context
+      description: |
+        Provide the "why", motivation, and alternative approaches considered -- linking to previous refinement issues, spikes and documentation as appropriate
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Acceptance criteria
+      description: |
+        What is the definition of done for this ticket? Include any relevant edge cases and/or test cases.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Suggested tests
+      description: |
+        Provide scenarios to test. Include both positive and negative tests if possible. Link to existing similar tests if appropriate.
+      placeholder: |
+         1. Test with no `materialized` field in the model config. Expect pass.
+         2. Test with a `materialized` field in the model config that is not valid. Expect ConfigError.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Consequences
+      description: |
+        Will this change impact other teams? Include details of the kinds of changes required (new tests, code changes, related tickets) and add the relevant `Impact:[team]` label.
+        Will this limit/enhance our ability to make a related change? Call that out for discussion.
+      placeholder: |
+        Example: This change impacts `dbt-redshift` because the tests will need to be modified. The `Impact:[Adapter]` label has been added.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/internal-epic.yml
+++ b/.github/ISSUE_TEMPLATE/internal-epic.yml
@@ -1,0 +1,66 @@
+name: 🧠️ Epic
+description: This is an epic ticket intended for use by the maintainers and product managers of `dbt-adapters`
+title: "[<project>] <title>"
+labels: ["epic"]
+body:
+  - type: markdown
+    attributes:
+      value: This is an epic ticket intended for use by the maintainers and product managers of `dbt-adapters`
+
+  - type: input
+    attributes:
+      label: Short description
+      description: |
+        What's the one-liner that would tell everyone what we're doing?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Context
+      description: |
+        Provide the "why". What's the motivation? Why are we doing it now?
+        Will this apply to all adapters or does this support a specific subset (e.g. only SQL adapters, only Snowflake, etc.)?
+        Is this updating existing functionality or providing all new functionality?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Objectives
+      description: |
+        What are the goals we are trying to achieve? Provide use cases if available.
+      placeholder: |
+        - [ ] Add option to ...
+        - [ ] Allow adapter maintainers to configure ...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Consequences
+      description: |
+        Will this impact dbt Labs' ability, or a partner's ability, to make a related change? Call that out for discussion.
+        Review `Impact:<team>` labels to ensure they capture these consequences.
+      placeholder: |
+        Example:
+        - This change impacts `dbt-core` because we updated how relations are managed. (Add the `Impact:[Core]` label.)
+        - This allows internal analytics to do more robust analysis of infrastructure usage (Add the `Impact:[Analytics]` label.)
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Implementation tasks
+      description: |
+        Provide a list of GH issues that will build out this functionality. This may start empty.
+      placeholder: |
+        - [ ] https://github.com/dbt-labs/dbt-adapters/issues/123
+        - [ ] https://github.com/dbt-labs/dbt-postgres/issues/456
+      value: |
+        ```[tasklist]
+        ### Implementation tasks
+        - [ ]
+        ```
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/internal-epic.yml
+++ b/.github/ISSUE_TEMPLATE/internal-epic.yml
@@ -29,12 +29,35 @@ body:
     attributes:
       label: Objectives
       description: |
-        What are the goals we are trying to achieve? Provide use cases if available.
-      placeholder: |
-        - [ ] Add option to ...
-        - [ ] Allow adapter maintainers to configure ...
+        What are the high level goals we are trying to achieve? Provide use cases if available.
+        
+        Example:
+        - [ ] Allow adapter maintainers to support custom materializations
+        - [ ] Reduce maintenance burden for incremental users by offering materialized views
+      value: |
+        ```[tasklist]
+        - [ ] Objective
+        ```
     validations:
       required: true
+
+  - type: textarea
+    attributes:
+      label: Implementation tasks
+      description: |
+        Provide a list of GH issues that will build out this functionality.
+        This may start empty, or as a checklist of items.
+        However, it should eventually become a list of Feature Implementation tickets.
+        
+        Example:
+        - [ ] Create new macro to select warehouse
+        - [ ] https://github.com/dbt-labs/dbt-adapters/issues/42
+      value: |
+        ```[tasklist]
+        - [ ] Task
+        ```
+    validations:
+      required: false
 
   - type: textarea
     attributes:
@@ -48,19 +71,3 @@ body:
         - This allows internal analytics to do more robust analysis of infrastructure usage (Add the `Impact:[Analytics]` label.)
     validations:
       required: true
-
-  - type: textarea
-    attributes:
-      label: Implementation tasks
-      description: |
-        Provide a list of GH issues that will build out this functionality. This may start empty.
-      placeholder: |
-        - [ ] https://github.com/dbt-labs/dbt-adapters/issues/123
-        - [ ] https://github.com/dbt-labs/dbt-postgres/issues/456
-      value: |
-        ```[tasklist]
-        ### Implementation tasks
-        - [ ]
-        ```
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/internal-feature-implementation.yml
+++ b/.github/ISSUE_TEMPLATE/internal-feature-implementation.yml
@@ -1,11 +1,11 @@
-name: 🛠️ Implementation
-description: This is an implementation ticket intended for use by the maintainers of `dbt-adapters`
+name: 🛠️ Feature Implementation
+description: This is a feature implementation ticket intended for use by the maintainers of `dbt-adapters`
 title: "[<project>] <title>"
-labels: ["user docs","refinement"]
+labels: ["user docs","enhancement","refinement"]
 body:
   - type: markdown
     attributes:
-      value: This is an implementation ticket intended for use by the maintainers of `dbt-adapters`
+      value: This is a feature implementation ticket intended for use by the maintainers of `dbt-adapters`
 
   - type: checkboxes
     attributes:
@@ -13,8 +13,9 @@ body:
       description: >
         A couple friendly reminders:
           1. Remove the `user docs` label if the scope of this work does not require changes to https://docs.getdbt.com/docs: no end-user interface (e.g. yml spec, CLI, error messages, etc) or functional changes.
-          2. Will this change need to be backported? Add the appropriate `backport 1.x.latest` label(s).
-          3. Is this an `enhancement`, `bug`, or `regression`? Add the appropriate label.
+          2. Only remove the `refinement` label if you're confident this is ready to estimate and/or you've received feedback from at least one other engineer.
+          3. Will this change need to be backported? Add the appropriate `backport 1.x.latest` label(s).
+          4. Will this impact other teams? Add the appropriate `Impact:[Team]` labels.
       options:
         - label: I am a maintainer of `dbt-adapters`
           required: true
@@ -23,7 +24,7 @@ body:
     attributes:
       label: Short description
       description: |
-        Describe the scope of the ticket, a high-level implementation approach and any tradeoffs to consider.
+        Describe the scope of this feature, a high-level implementation approach and any tradeoffs to consider.
     validations:
       required: true
 
@@ -31,7 +32,7 @@ body:
     attributes:
       label: Context
       description: |
-        Provide the "why", motivation, and alternative approaches considered -- linking to previous refinement issues, spikes and documentation as appropriate
+        Provide the "why", motivation, and alternative approaches considered -- linking to previous refinement issues, spikes and documentation as appropriate.
     validations:
       required: false
 
@@ -39,7 +40,7 @@ body:
     attributes:
       label: Acceptance criteria
       description: |
-        What is the definition of done for this ticket? Include any relevant edge cases and/or test cases.
+        What is the definition of done for this feature? Include any relevant edge cases and/or test cases.
     validations:
       required: true
 
@@ -58,9 +59,9 @@ body:
     attributes:
       label: Consequences
       description: |
-        Will this change impact other teams? Include details of the kinds of changes required (new tests, code changes, related tickets) and add the relevant `Impact:[team]` label.
-        Will this limit/enhance our ability to make a related change? Call that out for discussion.
+        Will this impact dbt Labs' ability, or a partner's ability, to make a related change? Call that out for discussion.
+        Review `Impact:<team>` labels to ensure they capture these consequences.
       placeholder: |
-        Example: This change impacts `dbt-redshift` because the tests will need to be modified. The `Impact:[Adapter]` label has been added.
+        Example: This change impacts `dbt-databricks` because we added a new macro to the global space. The `Impact:[Databricks]` label has been added.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/internal-feature-implementation.yml
+++ b/.github/ISSUE_TEMPLATE/internal-feature-implementation.yml
@@ -41,6 +41,14 @@ body:
       label: Acceptance criteria
       description: |
         What is the definition of done for this feature? Include any relevant edge cases and/or test cases.
+        
+        Example:
+        - [ ] If there are no config changes, don't alter the materialized view
+        - [ ] If the materialized view is scheduled to refresh, a manual refresh should not be issued
+      value: |
+        ```[tasklist]
+        - [ ] Criterion
+        ```
     validations:
       required: true
 
@@ -48,10 +56,16 @@ body:
     attributes:
       label: Suggested tests
       description: |
-        Provide scenarios to test. Include both positive and negative tests if possible. Link to existing similar tests if appropriate.
-      placeholder: |
-         1. Test with no `materialized` field in the model config. Expect pass.
-         2. Test with a `materialized` field in the model config that is not valid. Expect ConfigError.
+        Provide scenarios to test. Include both positive and negative tests if possible.
+        Link to existing similar tests if appropriate.
+        
+        Example:
+         - [ ] Test with no `materialized` field in the model config. Expect pass.
+         - [ ] Test with a `materialized` field in the model config that is not valid. Expect ConfigError.
+      value: |
+        ```[tasklist]
+         - [ ] Test
+        ```
     validations:
       required: true
 
@@ -62,6 +76,7 @@ body:
         Will this impact dbt Labs' ability, or a partner's ability, to make a related change? Call that out for discussion.
         Review `Impact:<team>` labels to ensure they capture these consequences.
       placeholder: |
-        Example: This change impacts `dbt-databricks` because we updated a macro in `dbt-spark`. (Add the `Impact:[Databricks]` label.)
+        Example:
+        - This change impacts `dbt-databricks` because we updated a macro in `dbt-spark`. (Add the `Impact:[Databricks]` label.)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/internal-feature-implementation.yml
+++ b/.github/ISSUE_TEMPLATE/internal-feature-implementation.yml
@@ -62,6 +62,6 @@ body:
         Will this impact dbt Labs' ability, or a partner's ability, to make a related change? Call that out for discussion.
         Review `Impact:<team>` labels to ensure they capture these consequences.
       placeholder: |
-        Example: This change impacts `dbt-databricks` because we added a new macro to the global space. The `Impact:[Databricks]` label has been added.
+        Example: This change impacts `dbt-databricks` because we updated a macro in `dbt-spark`. (Add the `Impact:[Databricks]` label.)
     validations:
       required: true


### PR DESCRIPTION
If both `placeholder` and `value` properties are provided, `value` wins. This means examples cannot be put in the `placeholder` property in these scenarios. Examples were moved into the `description` property.

A header is not needed for `tasklist` fields as it duplicates the field header. They were removed.

More fields were updated to `tasklist` fields. All `tasklist` fields use the `value` property to setup the tasklist structure.

Implementation tasks were moved up to be after Objectives for epics. These fields are more closely related than the previous structure suggested.

It may be easier to see the new versions by looking at the rendered forms:
- [epic](https://github.com/dbt-labs/dbt-adapters/blob/config/internal-issue-template/.github/ISSUE_TEMPLATE/internal-epic.yml)
- [feature](https://github.com/dbt-labs/dbt-adapters/blob/config/internal-issue-template/.github/ISSUE_TEMPLATE/internal-feature-implementation.yml)

Note that these rendered forms show the description below the input field. This is not how it appears when using the form.