### PR TITLE
Ignore adapter-level support for `custom` constraints

### DIFF
--- a/.changes/unreleased/Fixes-20240215-141545.yaml
+++ b/.changes/unreleased/Fixes-20240215-141545.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ignore adapter-level support warnings for 'custom' constraints
+time: 2024-02-15T14:15:45.764145+01:00
+custom:
+  Author: jtcohen6
+  Issue: "90"

--- a/dbt/adapters/base/impl.py
+++ b/dbt/adapters/base/impl.py
@@ -1535,6 +1535,9 @@ class BaseAdapter(metaclass=AdapterMeta):
         parsed_constraint: Union[ColumnLevelConstraint, ModelLevelConstraint],
         render_func,
     ) -> Optional[str]:
+        # skip checking enforcement if this is a 'custom' constraint
+        if parsed_constraint.type == ConstraintType.custom:
+            return render_func(parsed_constraint)
         if (
             parsed_constraint.warn_unsupported
             and cls.CONSTRAINT_SUPPORT[parsed_constraint.type] == ConstraintSupport.NOT_SUPPORTED

--- a/tests/unit/test_base_adapter.py
+++ b/tests/unit/test_base_adapter.py
@@ -40,6 +40,7 @@ class TestBaseAdapterConstraintRendering:
             ["column_name integer references other_table (c1)"],
         ),
         ([{"type": "check"}, {"type": "unique"}], ["column_name integer unique"]),
+        ([{"type": "custom", "expression": "-- noop"}], ["column_name integer -- noop"]),
     ]
 
     @pytest.mark.parametrize("constraints,expected_rendered_constraints", column_constraints)


### PR DESCRIPTION
resolves #90

I believe that fixing this bug would enable a workaround for defining tags / masking policies as part of Snowflake model contracts. This has recently come up as a blocking issue for multiple folks internally (see [internal slack thread](https://dbt-labs.slack.com/archives/C05CJT5MJF2/p1707781284556729)).

### Problem

`ConstraintType.custom` is missing from `CONSTRAINT_SUPPORT`, leading to a `KeyError` during `process_parsed_constraint`.

### Solution

Completely ignore "custom" constraints when checking for adapter-specific support in `process_parsed_constraint`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
