### PR TITLE
Readd removed logic for deferral fail-over

### DIFF
--- a/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
+++ b/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
@@ -3,7 +3,7 @@
 {% set default_row = {} %}
 
 {%- if not column_name_to_data_types -%}
-{%-   set columns_in_relation = adapter.get_columns_in_relation(this) -%}
+{%-   set columns_in_relation = adapter.get_columns_in_relation(load_relation(this) or defer_relation) -%}
 {%-   set column_name_to_data_types = {} -%}
 {%-   for column in columns_in_relation -%}
 {#-- This needs to be a case-insensitive comparison --#}
@@ -44,7 +44,7 @@ union all
 {% macro get_expected_sql(rows, column_name_to_data_types) %}
 
 {%- if (rows | length) == 0 -%}
-    select * FROM dbt_internal_unit_test_actual
+    select * from dbt_internal_unit_test_actual
     limit 0
 {%- else -%}
 {%- for row in rows -%}


### PR DESCRIPTION
The logic added in #60 (to support https://github.com/dbt-labs/dbt-core/pull/9199) was removed in #55.

I'm not sure if there's a good way to test this within `dbt-adapters` by itself...

### Problem

Logic added to failover to `defer_relation` if `this` is not present in the target schema. (I realize that the logic I added in #60 wasn't quite right, either!)

### Solution

Check to see if `this` exists (cache lookup), then fail over to using `defer_relation` instead for column type detection.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
