### PR TITLE
download archive to the expected directory

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -211,7 +211,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.archive_name }}
-          path: .
+          path: dist/
 
       - name: "[DEBUG] Display Structure Of Expected Files"
         run: |


### PR DESCRIPTION
### Problem

We downloaded the archive to the working directory, but we expect that the artifacts are in `./dist/`.

### Solution

Update the download step to reference `./dist/`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
