### PR TITLE
Add `sql_header` to data tests

### DIFF
--- a/dbt/include/global_project/macros/materializations/tests/helpers.sql
+++ b/dbt/include/global_project/macros/materializations/tests/helpers.sql
@@ -3,6 +3,10 @@
 {%- endmacro %}
 
 {% macro default__get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}
+    {%- set sql_header = config.get('sql_header', none) -%}
+
+    {{ sql_header if sql_header is not none }}
+
     select
       {{ fail_calc }} as failures,
       {{ fail_calc }} {{ warn_if }} as should_warn,


### PR DESCRIPTION
part of addressing https://github.com/dbt-labs/dbt-core/issues/9775

This is part of proof-of-concept (POC). See https://github.com/dbt-labs/dbt-core/pull/9854 for the other piece.

### Problem

Currently, any [`sql_header`](https://docs.getdbt.com/reference/resource-configs/sql_header) config doesn't have any effect for:
- [generic](https://docs.getdbt.com/docs/build/data-tests#generic-data-tests) data tests
- [singular](https://docs.getdbt.com/docs/build/data-tests#singular-data-tests) data tests when failures aren't [stored](https://docs.getdbt.com/reference/resource-configs/store_failures_as)

And it _only_ has effect for:
- [singular](https://docs.getdbt.com/docs/build/data-tests#singular-data-tests) data tests when failures are [stored](https://docs.getdbt.com/reference/resource-configs/store_failures_as)

#### Put another way

The [`sql_header`](https://docs.getdbt.com/reference/resource-configs/sql_header) configuration only works for [singular](https://docs.getdbt.com/docs/build/data-tests#singular-data-tests) data tests that have [`store_failures_as="table"`](https://docs.getdbt.com/reference/resource-configs/store_failures_as) (or [`store_failures=true`](https://docs.getdbt.com/reference/resource-configs/store_failures)).

### Solution

Enable `sql_header` to apply to both singular and generic data tests regardless if they are storing failures or not.

### Kicking the tires

<details>
<summary>
Example project and commands to try this out
</summary>

Project files:

`models/model_with_singular_data_test.sql`

```sql
select 1 as id
```

`models/model_with_generic_data_test.sql`

```sql
select 2 as id
```

`tests/singular_data_test__store_failures_as_table.sql`

```sql
{{ config(store_failures_as="table") }}

{%- call set_sql_header(config) -%}
    -- CREATE TEMP FUNCTION 1.2 singular store_failures_as table ...
{%- endcall -%}

select 1 as id
from {{ ref("model_with_singular_data_test") }}
where 1=0
```

`tests/singular_data_test__store_failures_as_ephemeral.sql`

```sql
{{ config(store_failures_as="ephemeral") }}

{%- call set_sql_header(config) -%}
    -- CREATE TEMP FUNCTION 1.1 singular store_failures_as ephemeral ...
{%- endcall -%}

select 1 as id
from {{ ref("model_with_singular_data_test") }}
where 1=0
```

`models/_models.yml`

```yaml
models:
  - name: model_with_generic_data_test
    columns:
      - name: id
        data_tests:
          - unique:
              name: generic_data_test__store_failures_as_ephemeral
              config:
                sql_header: "-- CREATE TEMP FUNCTION 2.1 generic store_failures_as ephemeral ..."
                store_failures_as: ephemeral
          - unique:
              name: generic_data_test__store_failures_as_table
              config:
                sql_header: "-- CREATE TEMP FUNCTION 2.2 generic store_failures_as table ..."
                store_failures_as: table
```

Build the project (run the models and tests):

```shell
rm -rf logs
rm -rf target
dbt build
```

Open the logs file (`logs/dbt.log`).

Then search for `-- CREATE TEMP FUNCTION`.

All of the following should show up in the search (at the _beginning_ of separate SQL statements) corresponding to each of the (4) main test cases:
- 1.1 - singular store_failures_as ephemeral
- 1.2 - singular store_failures_as table
- 2.1 - generic store_failures_as ephemeral
- 2.2 - generic store_failures_as table

</details>

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development, and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
