### PR TITLE
Changes to support unit test sql format

### DIFF
--- a/.changes/unreleased/Features-20240409-084844.yaml
+++ b/.changes/unreleased/Features-20240409-084844.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support for sql fixtures in unit testing
+time: 2024-04-09T08:48:44.441106-04:00
+custom:
+  Author: gshank
+  Issue: "148"

--- a/dbt/include/global_project/macros/materializations/tests/unit.sql
+++ b/dbt/include/global_project/macros/materializations/tests/unit.sql
@@ -3,6 +3,7 @@
   {% set relations = [] %}
 
   {% set expected_rows = config.get('expected_rows') %}
+  {% set expected_sql = config.get('expected_sql') %}
   {% set tested_expected_column_names = expected_rows[0].keys() if (expected_rows | length ) > 0 else get_columns_in_query(sql) %} %}
 
   {%- set target_relation = this.incorporate(type='table') -%}
@@ -11,10 +12,14 @@
   {%- set columns_in_relation = adapter.get_columns_in_relation(temp_relation) -%}
   {%- set column_name_to_data_types = {} -%}
   {%- for column in columns_in_relation -%}
-  {%- do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}
+  {%-   do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}
   {%- endfor -%}
 
-  {% set unit_test_sql = get_unit_test_sql(sql, get_expected_sql(expected_rows, column_name_to_data_types), tested_expected_column_names) %}
+  {%- if expected_rows -%}
+    {%- set expected_sql = get_expected_sql(expected_rows, column_name_to_data_types) -%}
+  {%- endif -%}
+
+  {%- set unit_test_sql = get_unit_test_sql(sql, expected_sql, tested_expected_column_names) -%}
 
   {% call statement('main', fetch_result=True) -%}
 

--- a/dbt/include/global_project/macros/materializations/tests/unit.sql
+++ b/dbt/include/global_project/macros/materializations/tests/unit.sql
@@ -15,11 +15,10 @@
   {%-   do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}
   {%- endfor -%}
 
-  {%- if expected_rows -%}
-    {%- set expected_sql = get_expected_sql(expected_rows, column_name_to_data_types) -%}
-  {%- endif -%}
-
-  {%- set unit_test_sql = get_unit_test_sql(sql, expected_sql, tested_expected_column_names) -%}
+  {% if not expected_sql %}
+  {%   set expected_sql = get_expected_sql(expected_rows, column_name_to_data_types) %}
+  {% endif %}
+  {% set unit_test_sql = get_unit_test_sql(sql, expected_sql, tested_expected_column_names) %}
 
   {% call statement('main', fetch_result=True) -%}
 


### PR DESCRIPTION
Support for resolving [#9405](https://github.com/dbt-labs/dbt-core/issues/9405)


Handles sql strings in a unit test in addition to dictionaries and csv files

