### PR TITLE
remove reference to node.deffered in seed assertion for clone test

### DIFF
--- a/.changes/unreleased/Fixes-20240502-150038.yaml
+++ b/.changes/unreleased/Fixes-20240502-150038.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Update Clone test to reflect core change removing `deferred` attribute from
+  nodes
+time: 2024-05-02T15:00:38.882727-07:00
+custom:
+  Author: colin-rogers-dbt
+  Issue: "194"

--- a/dbt-tests-adapter/dbt/tests/adapter/dbt_clone/test_dbt_clone.py
+++ b/dbt-tests-adapter/dbt/tests/adapter/dbt_clone/test_dbt_clone.py
@@ -73,7 +73,6 @@ class BaseClone:
     def run_and_save_state(self, project_root, with_snapshot=False):
         results = run_dbt(["seed"])
         assert len(results) == 1
-        assert not any(r.node.deferred for r in results)
         results = run_dbt(["run"])
         assert len(results) == 2
         assert not any(r.node.deferred for r in results)

--- a/dbt-tests-adapter/dbt/tests/adapter/dbt_clone/test_dbt_clone.py
+++ b/dbt-tests-adapter/dbt/tests/adapter/dbt_clone/test_dbt_clone.py
@@ -211,6 +211,7 @@ class BaseCloneSameTargetAndState(BaseClone):
 
         clone_args = [
             "clone",
+            "--defer",
             "--state",
             "target",
         ]

--- a/dbt-tests-adapter/dbt/tests/adapter/dbt_clone/test_dbt_clone.py
+++ b/dbt-tests-adapter/dbt/tests/adapter/dbt_clone/test_dbt_clone.py
@@ -75,14 +75,12 @@ class BaseClone:
         assert len(results) == 1
         results = run_dbt(["run"])
         assert len(results) == 2
-        assert not any(r.node.deferred for r in results)
         results = run_dbt(["test"])
         assert len(results) == 2
 
         if with_snapshot:
             results = run_dbt(["snapshot"])
             assert len(results) == 1
-            assert not any(r.node.deferred for r in results)
 
         # copy files
         self.copy_state(project_root)


### PR DESCRIPTION
Updating based on: https://github.com/dbt-labs/dbt-core/pull/9199/files#diff-914c001b555fa1b60fe4e32f4d11cd3df13dca81b701e219abe212b9abd3508e
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development, and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
