### PR TITLE
Improving message description for compile error in get_fixtu…

### DIFF
--- a/.changes/unreleased/Features-20240511-032253.yaml
+++ b/.changes/unreleased/Features-20240511-032253.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Improvement of the compile error message in the get_fixture-sql.sql when the
+  relation or the model not exist
+time: 2024-05-11T03:22:53.40817477-05:00
+custom:
+  Author: AlejandroBlanco2001
+  Issue: "10014"

--- a/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
+++ b/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
@@ -15,7 +15,7 @@
 {%- endif -%}
 
 {%- if not column_name_to_data_types -%}
-    {{ exceptions.raise_compiler_error("Not able to get columns for unit test '" ~ model.name ~ "' from relation " ~ this) }}
+    {{ exceptions.raise_compiler_error("Not able to get columns for unit test '" ~ model.name ~ "' from relation " ~ this ~ " because the relation doesn't exist") }}
 {%- endif -%}
 
 {%- for column_name, column_type in column_name_to_data_types.items() -%}


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/10014

### Problem
When running SQL unit tests, when a relation does not exist (or the model does not exist), a compilation error is thrown which does not give any idea why this is happening.

### Solution
Therefore, a small new feature is added where the error message is improved to give a better idea on how to resolve the error when running the test.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development, and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
