### PR TITLE
Avoid false positives in `date_spine` macro

### DIFF
--- a/dbt-tests-adapter/dbt/tests/adapter/utils/fixture_date_spine.py
+++ b/dbt-tests-adapter/dbt/tests/adapter/utils/fixture_date_spine.py
@@ -3,29 +3,17 @@
 models__test_date_spine_sql = """
 with generated_dates as (
     {% if target.type == 'postgres' %}
-        {{ date_spine("day", "'2023-09-01'::date", "'2023-09-10'::date") }}
+        {{ date_spine("day", "'2023-09-07'::date", "'2023-09-10'::date") }}
 
     {% elif target.type == 'bigquery' or target.type == 'redshift' %}
         select cast(date_day as date) as date_day
-        from ({{ date_spine("day", "'2023-09-01'", "'2023-09-10'") }})
+        from ({{ date_spine("day", "'2023-09-07'", "'2023-09-10'") }})
 
     {% else %}
-        {{ date_spine("day", "'2023-09-01'", "'2023-09-10'") }}
+        {{ date_spine("day", "'2023-09-07'", "'2023-09-10'") }}
     {% endif %}
 ), expected_dates as (
     {% if target.type == 'postgres' %}
-        select '2023-09-01'::date as expected
-        union all
-        select '2023-09-02'::date as expected
-        union all
-        select '2023-09-03'::date as expected
-        union all
-        select '2023-09-04'::date as expected
-        union all
-        select '2023-09-05'::date as expected
-        union all
-        select '2023-09-06'::date as expected
-        union all
         select '2023-09-07'::date as expected
         union all
         select '2023-09-08'::date as expected
@@ -33,18 +21,6 @@ with generated_dates as (
         select '2023-09-09'::date as expected
 
     {% elif target.type == 'bigquery' or target.type == 'redshift' %}
-        select cast('2023-09-01' as date) as expected
-        union all
-        select cast('2023-09-02' as date) as expected
-        union all
-        select cast('2023-09-03' as date) as expected
-        union all
-        select cast('2023-09-04' as date) as expected
-        union all
-        select cast('2023-09-05' as date) as expected
-        union all
-        select cast('2023-09-06' as date) as expected
-        union all
         select cast('2023-09-07' as date) as expected
         union all
         select cast('2023-09-08' as date) as expected
@@ -52,18 +28,6 @@ with generated_dates as (
         select cast('2023-09-09' as date) as expected
 
     {% else %}
-        select '2023-09-01' as expected
-        union all
-        select '2023-09-02' as expected
-        union all
-        select '2023-09-03' as expected
-        union all
-        select '2023-09-04' as expected
-        union all
-        select '2023-09-05' as expected
-        union all
-        select '2023-09-06' as expected
-        union all
         select '2023-09-07' as expected
         union all
         select '2023-09-08' as expected

--- a/dbt-tests-adapter/dbt/tests/adapter/utils/fixture_date_spine.py
+++ b/dbt-tests-adapter/dbt/tests/adapter/utils/fixture_date_spine.py
@@ -39,7 +39,7 @@ with generated_dates as (
         generated_dates.date_day,
         expected_dates.expected
     from generated_dates
-    left join expected_dates on generated_dates.date_day = expected_dates.expected
+    full outer join expected_dates on generated_dates.date_day = expected_dates.expected
 )
 
 SELECT * from joined


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-adapters/issues/210
resolves https://github.com/dbt-labs/dbt-adapters/issues/208

### Problem

While working on https://github.com/dbt-labs/dbt-core/issues/10075, I noticed a few things about [this](https://github.com/dbt-labs/dbt-adapters/blob/d831caa33bc1a31d1162f1d1b3ccd6caaec08fd5/dbt-tests-adapter/dbt/tests/adapter/utils/fixture_date_spine.py) test case:
1. The test can give a false positives
1. The date range is larger than needed
1. There are hard-coded adapter types

The first one is the most impactful. This PR solves the first two but leaves the last one unsolved.

### Solution

1. Use a `full outer join` rather than a `left join` to eliminate possibility of a false positive
1. Reduce the date range from 9 down to 3 (which gets rid of 36 lines of code)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] New tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.)