### PR TITLE
Improve memory efficiency of process_results by iterating.

### DIFF
--- a/.changes/unreleased/Under the Hood-20240516-105757.yaml
+++ b/.changes/unreleased/Under the Hood-20240516-105757.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Improve memory efficiency of process_results()
+time: 2024-05-16T10:57:57.480672-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "217"

--- a/dbt/adapters/sql/connections.py
+++ b/dbt/adapters/sql/connections.py
@@ -1,6 +1,6 @@
 import abc
 import time
-from typing import Any, Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, TYPE_CHECKING
 
 from dbt_common.events.contextvars import get_node_info
 from dbt_common.events.functions import fire_event
@@ -112,27 +112,24 @@ class SQLConnectionManager(BaseConnectionManager):
     @classmethod
     def process_results(
         cls, column_names: Iterable[str], rows: Iterable[Any]
-    ) -> List[Dict[str, Any]]:
-        # TODO CT-211
+    ) -> Iterator[Dict[str, Any]]:
         unique_col_names = dict()  # type: ignore[var-annotated]
-        # TODO CT-211
         for idx in range(len(column_names)):  # type: ignore[arg-type]
-            # TODO CT-211
             col_name = column_names[idx]  # type: ignore[index]
             if col_name in unique_col_names:
                 unique_col_names[col_name] += 1
-                # TODO CT-211
                 column_names[idx] = f"{col_name}_{unique_col_names[col_name]}"  # type: ignore[index] # noqa
             else:
-                # TODO CT-211
                 unique_col_names[column_names[idx]] = 1  # type: ignore[index]
-        return [dict(zip(column_names, row)) for row in rows]
+
+        for row in rows:
+            yield dict(zip(column_names, row))
 
     @classmethod
     def get_result_from_cursor(cls, cursor: Any, limit: Optional[int]) -> "agate.Table":
         from dbt_common.clients.agate_helper import table_from_data_flat
 
-        data: List[Any] = []
+        data: Iterable[Any] = []
         column_names: List[str] = []
 
         if cursor.description is not None:

--- a/tests/unit/test_sql_result.py
+++ b/tests/unit/test_sql_result.py
@@ -8,13 +8,13 @@ class TestProcessSQLResult(unittest.TestCase):
         cols_with_one_dupe = ["a", "b", "a", "d"]
         rows = [(1, 2, 3, 4)]
         self.assertEqual(
-            SQLConnectionManager.process_results(cols_with_one_dupe, rows),
+            list(SQLConnectionManager.process_results(cols_with_one_dupe, rows)),
             [{"a": 1, "b": 2, "a_2": 3, "d": 4}],
         )
 
         cols_with_more_dupes = ["a", "a", "a", "b"]
         rows = [(1, 2, 3, 4)]
         self.assertEqual(
-            SQLConnectionManager.process_results(cols_with_more_dupes, rows),
+            list(SQLConnectionManager.process_results(cols_with_more_dupes, rows)),
             [{"a": 1, "a_2": 2, "a_3": 3, "b": 4}],
         )


### PR DESCRIPTION
resolves #218 

### Problem

The process of returning query results from execute() is memory inefficient, as multiple intermediate copies of the result data are maintained simultaneously.

In the case of `docs generate`, we are sometimes querying for information about every column in a schema. This can mean that a million or more records are returned in more extreme cases, resulting in gigabytes of memory allocation. In this scenario, maintaining multiple copies of the results, even temporarily, is untenable.

### Solution

Yield data rows one by one from process_results() rather than returning every row as a list, to eliminate one full copy of the result table. We could still do more work in this direction, but I documented a 33% reduction in memory associated with the `get_catalog` query with this approach.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapter/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
