### PR TITLE
Use model alias for the CTE identifier generated during ephemeral materialization

### DIFF
--- a/.changes/unreleased/Fixes-20240610-195300.yaml
+++ b/.changes/unreleased/Fixes-20240610-195300.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Use model alias for the CTE identifier generated during ephemeral materialization
+time: 2024-06-10T19:53:00.086488231Z
+custom:
+    Author: jeancochrane
+    Issue: "5273"

--- a/dbt/adapters/base/relation.py
+++ b/dbt/adapters/base/relation.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Hashable
 from dataclasses import dataclass, field
 from typing import (
@@ -233,8 +232,8 @@ class BaseRelation(FakeAPIObject, Hashable):
         )
 
     @staticmethod
-    def add_ephemeral_prefix(alias: str):
-        return re.sub(r"\W+", "", f"__dbt__cte__{alias}")
+    def add_ephemeral_prefix(name: str):
+        return f"__dbt__cte__{name}"
 
     @classmethod
     def create_ephemeral_from(
@@ -242,9 +241,11 @@ class BaseRelation(FakeAPIObject, Hashable):
         relation_config: RelationConfig,
         limit: Optional[int] = None,
     ) -> Self:
-        # Note that ephemeral models are based on the alias to give the user
-        # more control over the way that the CTE name is constructed
-        identifier = cls.add_ephemeral_prefix(relation_config.alias)
+        # Note that ephemeral models are based on the identifier, which will
+        # point to the model's alias if one exists and otherwise fall back to
+        # the filename. This is intended to give the user more control over
+        # the way that the CTE name is constructed
+        identifier = cls.add_ephemeral_prefix(relation_config.identifier)
         return cls.create(
             type=cls.CTE,
             identifier=identifier,

--- a/dbt/adapters/base/relation.py
+++ b/dbt/adapters/base/relation.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Hashable
 from dataclasses import dataclass, field
 from typing import (
@@ -232,8 +233,8 @@ class BaseRelation(FakeAPIObject, Hashable):
         )
 
     @staticmethod
-    def add_ephemeral_prefix(name: str):
-        return f"__dbt__cte__{name}"
+    def add_ephemeral_prefix(alias: str):
+        return re.sub(r"\W+", "", f"__dbt__cte__{alias}")
 
     @classmethod
     def create_ephemeral_from(
@@ -241,8 +242,9 @@ class BaseRelation(FakeAPIObject, Hashable):
         relation_config: RelationConfig,
         limit: Optional[int] = None,
     ) -> Self:
-        # Note that ephemeral models are based on the name.
-        identifier = cls.add_ephemeral_prefix(relation_config.name)
+        # Note that ephemeral models are based on the alias to give the user
+        # more control over the way that the CTE name is constructed
+        identifier = cls.add_ephemeral_prefix(relation_config.alias)
         return cls.create(
             type=cls.CTE,
             identifier=identifier,

--- a/dbt/adapters/contracts/relation.py
+++ b/dbt/adapters/contracts/relation.py
@@ -49,7 +49,6 @@ class MaterializationConfig(Mapping, ABC):
 class RelationConfig(Protocol):
     resource_type: str
     name: str
-    alias: str
     description: str
     database: str
     schema: str

--- a/dbt/adapters/contracts/relation.py
+++ b/dbt/adapters/contracts/relation.py
@@ -49,6 +49,7 @@ class MaterializationConfig(Mapping, ABC):
 class RelationConfig(Protocol):
     resource_type: str
     name: str
+    alias: str
     description: str
     database: str
     schema: str

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, replace
 import pytest
 
 from dbt.adapters.base import BaseRelation
-from dbt.adapters.contracts.relation import RelationConfig, RelationType
+from dbt.adapters.contracts.relation import RelationType
 
 
 @pytest.mark.parametrize(
@@ -81,20 +81,14 @@ def test_render_limited(limit, require_alias, expected_result):
     assert str(my_relation) == expected_result
 
 
-@pytest.mark.parametrize(
-    "alias,expected_cte_id",
-    [
-        ("table", "table"),
-        ("test.<>*~!@#$%^&*table", "testtable")
-    ]
-)
-def test_create_ephemeral_from_uses_alias(alias, expected_cte_id):
+def test_create_ephemeral_from_uses_identifier():
     @dataclass
     class Node:
         """Dummy implementation of RelationConfig protocol"""
-        name: str
-        alias: str
 
-    node = Node(name="name should not be used", alias=alias)
+        name: str
+        identifier: str
+
+    node = Node(name="name_should_not_be_used", identifier="test")
     ephemeral_relation = BaseRelation.create_ephemeral_from(node)
-    assert str(ephemeral_relation) == f"__dbt__cte__{expected_cte_id}"
+    assert str(ephemeral_relation) == "__dbt__cte__test"

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -1,9 +1,9 @@
-from dataclasses import replace
+from dataclasses import dataclass, replace
 
 import pytest
 
 from dbt.adapters.base import BaseRelation
-from dbt.adapters.contracts.relation import RelationType
+from dbt.adapters.contracts.relation import RelationConfig, RelationType
 
 
 @pytest.mark.parametrize(
@@ -79,3 +79,22 @@ def test_render_limited(limit, require_alias, expected_result):
     actual_result = my_relation.render_limited()
     assert actual_result == expected_result
     assert str(my_relation) == expected_result
+
+
+@pytest.mark.parametrize(
+    "alias,expected_cte_id",
+    [
+        ("table", "table"),
+        ("test.<>*~!@#$%^&*table", "testtable")
+    ]
+)
+def test_create_ephemeral_from_uses_alias(alias, expected_cte_id):
+    @dataclass
+    class Node:
+        """Dummy implementation of RelationConfig protocol"""
+        name: str
+        alias: str
+
+    node = Node(name="name should not be used", alias=alias)
+    ephemeral_relation = BaseRelation.create_ephemeral_from(node)
+    assert str(ephemeral_relation) == f"__dbt__cte__{expected_cte_id}"


### PR DESCRIPTION
Partially resolves https://github.com/dbt-labs/dbt-core/issues/5273. Reimplementation of https://github.com/dbt-labs/dbt-core/pull/5488 to match the new split between adapter and core repos.

### Problem

Ephemeral model materializations do not currently support using special characters like dots in file names, even if these special characters are sanitized using model aliases.

### Solution

Prioritize using the model alias (if specified) via `model.identifier` when creating a node identifier for ephemeral models.

This change requires a corresponding change to `dbt-core` to fix the bug in the special case of unit testing, which will be implemented in a separate PR.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX