### PR TITLE
Make `get_catalog_for_single_relation` a concrete method in `BaseAdapter`

### DIFF
--- a/dbt/adapters/base/impl.py
+++ b/dbt/adapters/base/impl.py
@@ -629,7 +629,6 @@ class BaseAdapter(metaclass=AdapterMeta):
         """Get a list of the columns in the given Relation."""
         raise NotImplementedError("`get_columns_in_relation` is not implemented for this adapter!")
 
-    @abc.abstractmethod
     def get_catalog_for_single_relation(self, relation: BaseRelation) -> Optional[CatalogTable]:
         """Get catalog information including table-level and column-level metadata for a single relation."""
         raise NotImplementedError(


### PR DESCRIPTION
### Problem

`dbt-adapters==1.3.0` had to be yanked because adapters didn't implement the new abstract method `get_catalog_for_single_relation`.
This method should be opt-in, so adapters shouldn't need to implement this.

### Solution

Make the `get_catalog_for_single_relation` concrete in `BaseAdapter` so adapters can default to this implementation.
Sample PR with passing tests in `dbt-bigquery` that has not implemented this capability: https://github.com/dbt-labs/dbt-bigquery/pull/1262

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
