### PR TITLE
Add optional `should_release_connection` parameter to `connection_named` method

### DIFF
--- a/.changes/unreleased/Under the Hood-20240624-161108.yaml
+++ b/.changes/unreleased/Under the Hood-20240624-161108.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add optional release_connection parameter to connection_named method
+time: 2024-06-24T16:11:08.773419+01:00
+custom:
+    Author: aranke
+    Issue: "247"

--- a/dbt/adapters/base/impl.py
+++ b/dbt/adapters/base/impl.py
@@ -320,7 +320,7 @@ class BaseAdapter(metaclass=AdapterMeta):
 
     @contextmanager
     def connection_named(
-        self, name: str, query_header_context: Any = None, release_connection=True
+        self, name: str, query_header_context: Any = None, should_release_connection=True
     ) -> Iterator[None]:
         try:
             if self.connections.query_header is not None:
@@ -328,7 +328,7 @@ class BaseAdapter(metaclass=AdapterMeta):
             self.acquire_connection(name)
             yield
         finally:
-            if release_connection:
+            if should_release_connection:
                 self.release_connection()
 
             if self.connections.query_header is not None:

--- a/dbt/adapters/base/impl.py
+++ b/dbt/adapters/base/impl.py
@@ -319,14 +319,18 @@ class BaseAdapter(metaclass=AdapterMeta):
         return conn.name
 
     @contextmanager
-    def connection_named(self, name: str, query_header_context: Any = None) -> Iterator[None]:
+    def connection_named(
+        self, name: str, query_header_context: Any = None, release_connection=True
+    ) -> Iterator[None]:
         try:
             if self.connections.query_header is not None:
                 self.connections.query_header.set(name, query_header_context)
             self.acquire_connection(name)
             yield
         finally:
-            self.release_connection()
+            if release_connection:
+                self.release_connection()
+
             if self.connections.query_header is not None:
                 self.connections.query_header.reset()
 


### PR DESCRIPTION
### Problem

There's no way to stop the `connection_named` context manager from releasing its connection at the end.

### Solution

Add an optional `should_release_connection` parameter that allows holding on to the connection.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
