### PR TITLE
Fix import statement for `--empty` tests

### DIFF
--- a/dbt-tests-adapter/dbt/tests/adapter/empty/test_empty.py
+++ b/dbt-tests-adapter/dbt/tests/adapter/empty/test_empty.py
@@ -1,7 +1,7 @@
 from dbt.tests.util import relation_from_name, run_dbt
 import pytest
 
-from tests.functional.adapter.empty import _models
+from dbt.tests.adapter.empty import _models
 
 
 class BaseTestEmpty:


### PR DESCRIPTION
### Problem

When tests were copied over from `dbt-snowflake` into `dbt-tests-adapter`, the relative import for models was not updated.

### Solution

Fix the import statement.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
