### PR TITLE
[Feature] Enable user to provide custom adapter via profiles.yml

### DIFF
--- a/dbt/adapters/contracts/connection.py
+++ b/dbt/adapters/contracts/connection.py
@@ -127,6 +127,7 @@ class LazyHandle:
 class Credentials(ExtensibleDbtClassMixin, Replaceable, metaclass=abc.ABCMeta):
     database: str
     schema: str
+    adapter_class: str
     _ALIASES: ClassVar[Dict[str, str]] = field(default={}, init=False)
 
     @abc.abstractproperty


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-core/issues/3962

### Problem
Currently customizing dbt adapters and dbt functionalities is very hard to not possible. This PR enables end user to extend exsting adapters and add his/her own customization(special needs) to to it

### Solution
Enabling end user to provide his/her  custom adapter, using the  `adapter_class` setting in `profiles.yml` 

```yaml
snowflake:
  target: dev
  outputs:
    dev:
      type: snowflake
      adapter_class: my.customized.adapter.SnowflakeAdapterV2Customized
```
and user adapter could be something like
```python
class SnowflakeAdapterV2Customized(SnowflakeAdapter):
    def __init__(self, config) -> None:
        print(f"WARNING: Using User Provided DBT Adapter: {type(self).__module__}.{type(self).__name__}")
        super().__init__(config=config)

    @available
    def my_custom_method(self, arg1: str, arg2: str):
        print('do something here')
```
 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
