### PR TITLE
Adap 821/support for redshift 821

### DIFF
--- a/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
+++ b/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
@@ -22,6 +22,7 @@
     {%- do default_row.update({column_name: (safe_cast("null", column_type) | trim )}) -%}
 {%- endfor -%}
 
+{%- validate_row(rows, 0) -%}
 
 {%- for row in rows -%}
 {%-   set formatted_row = format_row(row, column_name_to_data_types) -%}
@@ -92,4 +93,12 @@ union all
         {%- do formatted_row.update(row_update) -%}
     {%- endfor -%}
     {{ return(formatted_row) }}
+{%- endmacro -%}
+
+
+
+{%- macro validate_row(rows, row_number) -%}
+    {{ log(rows, info=True) }}
+    {%- if rows -%}
+    {%- endif -%}
 {%- endmacro -%}

--- a/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
+++ b/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
@@ -22,7 +22,7 @@
     {%- do default_row.update({column_name: (safe_cast("null", column_type) | trim )}) -%}
 {%- endfor -%}
 
-{%- validate_row(rows, 0) -%}
+{{ validate_fixture_rows(rows, row_number) }}
 
 {%- for row in rows -%}
 {%-   set formatted_row = format_row(row, column_name_to_data_types) -%}
@@ -95,10 +95,10 @@ union all
     {{ return(formatted_row) }}
 {%- endmacro -%}
 
+{%- macro validate_fixture_rows(rows, row_number) -%}
+  {{ return(adapter.dispatch('validate_fixture_rows', 'dbt')(rows, row_number)) }}
+{%- endmacro -%}
 
-
-{%- macro validate_row(rows, row_number) -%}
-    {{ log(rows, info=True) }}
-    {%- if rows -%}
-    {%- endif -%}
+{%- macro default__validate_fixture_rows(rows, row_number) -%}
+  {# This is an abstract method for adapter overrides as needed #}
 {%- endmacro -%}


### PR DESCRIPTION
This is a followon Pr [to this core PR](https://github.com/dbt-labs/dbt-core/pull/10448) already merged

### Problem

The Redshift [PR here](https://github.com/dbt-labs/dbt-redshift/pull/885) has no way for us to throw a user facing error in the case the unit test fixture cannot provide sufficient type interpolation data to redshift.

### Solution

Add an abstract macro which Redshift can override as needed.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
