### PR TITLE
Update `setup-python` action to `v5` to move off of a deprecated version of Node (`node16`)

### DIFF
--- a/.github/actions/setup-hatch/action.yml
+++ b/.github/actions/setup-hatch/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
 


### PR DESCRIPTION
### Problem

We're out of date for this action.

### Solution

Bump to the next version.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
