### PR TITLE
Update `download-artifact` to `v4`

### DIFF
--- a/.github/actions/publish-pypi/action.yml
+++ b/.github/actions/publish-pypi/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
 
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.archive-name }}
         path: dist/


### PR DESCRIPTION
### Problem

The actions `upload-artifact` and `download-artifact` need to be on the same version. But we upload the built packages with v4 and try to download them with v3 to publish, which fails.

### Solution

Upgrade `download-artifact` to `v4`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
