### PR TITLE
Check if warning exists, for compatibility with 1.8

### DIFF
--- a/dbt/include/global_project/macros/materializations/snapshots/helpers.sql
+++ b/dbt/include/global_project/macros/materializations/snapshots/helpers.sql
@@ -199,6 +199,8 @@
   {% set dbt_updated_at_data_type = get_updated_at_column_data_type(sql) %}
   {% set snapshot_get_time_data_type = get_snapshot_get_time_data_type() %}
   {% if snapshot_get_time_data_type is not none and dbt_updated_at_data_type is not none and snapshot_get_time_data_type != dbt_updated_at_data_type %}
-  {{  exceptions.warn_snapshot_timestamp_data_types(snapshot_get_time_data_type, dbt_updated_at_data_type) }}
+  {%   if exceptions.warn_snapshot_timestamp_data_types %}
+  {{     exceptions.warn_snapshot_timestamp_data_types(snapshot_get_time_data_type, dbt_updated_at_data_type) }}
+  {%   endif %}
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
resolves #242 (follow-on)

### Problem

1.8 of dbt-core pulls in current dbt-adapters code, but the warning doesn't exist.

### Solution

Check for existence of warning before issuing it.

### Checklist

- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
