### PR TITLE
Add behavior flags to jinja context

### DIFF
--- a/dbt/adapters/base/impl.py
+++ b/dbt/adapters/base/impl.py
@@ -55,7 +55,7 @@ from dbt.adapters.base.connections import (
     BaseConnectionManager,
     Connection,
 )
-from dbt.adapters.base.meta import AdapterMeta, available
+from dbt.adapters.base.meta import AdapterMeta, available, available_property
 from dbt.adapters.base.relation import (
     BaseRelation,
     ComponentName,
@@ -273,7 +273,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         self._macro_resolver: Optional[MacroResolverProtocol] = None
         self._macro_context_generator: Optional[MacroContextGeneratorCallable] = None
         # this will be updated to include global behavior flags once they exist
-        self.behavior = []
+        self.behavior = []  # type: ignore
 
     ###
     # Methods to set / access a macro resolver
@@ -294,12 +294,11 @@ class BaseAdapter(metaclass=AdapterMeta):
     ) -> None:
         self._macro_context_generator = macro_context_generator
 
-    @property
-    @available
+    @available_property
     def behavior(self) -> Behavior:
         return self._behavior
 
-    @behavior.setter
+    @behavior.setter  # type: ignore
     def behavior(self, flags: List[BehaviorFlag]) -> None:
         """
         This can't be set with a setter/getter because we need to make `self.behavior`

--- a/dbt/adapters/base/impl.py
+++ b/dbt/adapters/base/impl.py
@@ -300,10 +300,6 @@ class BaseAdapter(metaclass=AdapterMeta):
 
     @behavior.setter  # type: ignore
     def behavior(self, flags: List[BehaviorFlag]) -> None:
-        """
-        This can't be set with a setter/getter because we need to make `self.behavior`
-        available in the jinja context.
-        """
         flags.extend(self._behavior_flags)
         try:
             # we don't always get project flags, for example during `dbt debug`

--- a/dbt/adapters/base/impl.py
+++ b/dbt/adapters/base/impl.py
@@ -294,6 +294,7 @@ class BaseAdapter(metaclass=AdapterMeta):
         self._macro_context_generator = macro_context_generator
 
     @property
+    @available
     def behavior(self) -> Behavior:
         return self._behavior
 

--- a/dbt/adapters/base/meta.py
+++ b/dbt/adapters/base/meta.py
@@ -15,9 +15,9 @@ class _Available:
         func._is_available_ = True  # type: ignore
         return func
 
-    def __get__(self, obj, objtype=None) -> Any:
-        obj._is_available_ = True  # type: ignore
-        return obj
+    def __getattr__(self, item) -> Any:
+        item._is_available_ = True  # type: ignore
+        return item
 
     def parse(self, parse_replacement: Callable) -> Decorator:
         """A decorator factory to indicate that a method on the adapter will be

--- a/dbt/adapters/base/meta.py
+++ b/dbt/adapters/base/meta.py
@@ -15,6 +15,10 @@ class _Available:
         func._is_available_ = True  # type: ignore
         return func
 
+    def __get__(self, obj, objtype=None) -> Any:
+        obj._is_available_ = True  # type: ignore
+        return obj
+
     def parse(self, parse_replacement: Callable) -> Decorator:
         """A decorator factory to indicate that a method on the adapter will be
         exposed to the database wrapper, and will be stubbed out at parse time

--- a/dbt/adapters/base/meta.py
+++ b/dbt/adapters/base/meta.py
@@ -15,7 +15,7 @@ class _Available:
         func._is_available_ = True  # type: ignore
         return func
 
-    def __getattr__(self, item) -> Any:
+    def __getattribute__(self, item) -> Any:
         item._is_available_ = True  # type: ignore
         return item
 

--- a/dbt/adapters/base/meta.py
+++ b/dbt/adapters/base/meta.py
@@ -15,10 +15,6 @@ class _Available:
         func._is_available_ = True  # type: ignore
         return func
 
-    def __getattribute__(self, item) -> Any:
-        item._is_available_ = True  # type: ignore
-        return item
-
     def parse(self, parse_replacement: Callable) -> Decorator:
         """A decorator factory to indicate that a method on the adapter will be
         exposed to the database wrapper, and will be stubbed out at parse time

--- a/dbt/adapters/base/meta.py
+++ b/dbt/adapters/base/meta.py
@@ -93,6 +93,21 @@ available = _Available()
 
 
 class available_property(property):
+    """
+    This supports making dynamic properties (`@property`) available in the jinja context.
+
+    We use `@available` to make methods available in the jinja context, but this mechanism relies on the method being callable.
+    Intuitively, we should be able to use both `@available` and `@property` to create a dynamic property that's available in the jinja context.
+
+    Using the `@property` decorator as the inner decorator supplies `@available` with something that is not callable.
+    Instead of returning the method, `@property` returns the value itself, not the method that is called to create the value.
+
+    Using the `@available` decorator as the inner decorator adds `_is_available_ = True` to the function.
+    However, when the `@property` decorator executes, it returns a `property` object which does not have the `_is_available_` attribute.
+
+    This decorator solves this problem by simply adding `_is_available_ = True` as an attribute on the `property` built-in.
+    """
+
     _is_available_ = True
 
 

--- a/dbt/adapters/base/meta.py
+++ b/dbt/adapters/base/meta.py
@@ -92,6 +92,10 @@ class _Available:
 available = _Available()
 
 
+class available_property(property):
+    _is_available_ = True
+
+
 class AdapterMeta(abc.ABCMeta):
     _available_: FrozenSet[str]
     _parse_replacements_: Dict[str, Callable]


### PR DESCRIPTION
### Problem

`BaseAdapters.behavior` is a dynamic property (uses `@property`). We use `@available` to make methods available in the jinja context, but this mechanism relies on the method being callable. Using the `@property` decorator first supplies `@available` with something that is not callable. Using the `@available` decorator first adds `_is_available_` to the value of the property, but the `property` object that `@property` returns does not have the `_is_available_` attribute.

### Solution

Subclass `property` and hard code `_is_available_ = True` on it.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
