### PR TITLE
Better handle nested Array types

### DIFF
--- a/dbt/adapters/base/column.py
+++ b/dbt/adapters/base/column.py
@@ -135,29 +135,31 @@ class Column:
         if size_info is not None:
             # strip out the parentheses
             size_info = size_info[1:-1]
-            parts = size_info.split(",")
-            if len(parts) == 1:
-                try:
-                    char_size = int(parts[0])
-                except ValueError:
-                    raise DbtRuntimeError(
-                        f'Could not interpret data_type "{raw_data_type}": '
-                        f'could not convert "{parts[0]}" to an integer'
-                    )
-            elif len(parts) == 2:
-                try:
-                    numeric_precision = int(parts[0])
-                except ValueError:
-                    raise DbtRuntimeError(
-                        f'Could not interpret data_type "{raw_data_type}": '
-                        f'could not convert "{parts[0]}" to an integer'
-                    )
-                try:
-                    numeric_scale = int(parts[1])
-                except ValueError:
-                    raise DbtRuntimeError(
-                        f'Could not interpret data_type "{raw_data_type}": '
-                        f'could not convert "{parts[1]}" to an integer'
-                    )
+            # If it contains a nested type structure, ignore further size processing
+            if not re.search(r"[A-Z]+\(", size_info):
+                parts = size_info.split(",")
+                if len(parts) == 1:
+                    try:
+                        char_size = int(parts[0])
+                    except ValueError:
+                        raise DbtRuntimeError(
+                            f'Could not interpret data_type "{raw_data_type}": '
+                            f'could not convert "{parts[0]}" to an integer'
+                        )
+                elif len(parts) == 2:
+                    try:
+                        numeric_precision = int(parts[0])
+                    except ValueError:
+                        raise DbtRuntimeError(
+                            f'Could not interpret data_type "{raw_data_type}": '
+                            f'could not convert "{parts[0]}" to an integer'
+                        )
+                    try:
+                        numeric_scale = int(parts[1])
+                    except ValueError:
+                        raise DbtRuntimeError(
+                            f'Could not interpret data_type "{raw_data_type}": '
+                            f'could not convert "{parts[1]}" to an integer'
+                        )
 
         return cls(name, data_type, char_size, numeric_precision, numeric_scale)


### PR DESCRIPTION
resolves #310


### Problem

When a model uses `get_columns_in_relation` on a table which includes columns of complex array types like `ARRAY(VARCHAR(16777216))`, we raise an error because the pre-existing logic only expects there to be an int inside the parentheses. In this case we have nested types so `VARCHAR(16777216)` cannot be converted to an `int` and processing fails.

### Solution

Before we try to convert to an int, we run some new regex to check if this is a nested type, as in some alphabet chars followed by an open parentheses. If so, we do not try to extract a `char_size`, `numeric_precision`, or `numeric_scale` and instead allow the code to return with those variables left as `None`. 

In the case of ``VARCHAR(16777216)``, we would have  `data_type = ARRAY,  char_size = None, numeric_precision = None, numeric_scale = None`.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development, and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
