### PR TITLE
Add required 'begin' config for testing microbatch models

### DIFF
--- a/.changes/unreleased/Under the Hood-20240923-184719.yaml
+++ b/.changes/unreleased/Under the Hood-20240923-184719.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: 'dbt-tests-adapters: Add required begin to microbatch model config to BaseMicrobatch
+  test'
+time: 2024-09-23T18:47:19.171618+01:00
+custom:
+  Author: michelleark
+  Issue: "315"

--- a/dbt-tests-adapter/dbt/tests/adapter/incremental/test_incremental_microbatch.py
+++ b/dbt-tests-adapter/dbt/tests/adapter/incremental/test_incremental_microbatch.py
@@ -22,7 +22,7 @@ select 3 as id, TIMESTAMP '2020-01-03 00:00:00-0' as event_time
 """
 
 _microbatch_model_sql = """
-{{ config(materialized='incremental', incremental_strategy='microbatch', unique_key='id', event_time='event_time', batch_size='day') }}
+{{ config(materialized='incremental', incremental_strategy='microbatch', unique_key='id', event_time='event_time', batch_size='day', begin=modules.datetime.datetime(2020, 1, 1, 0, 0, 0)) }}
 select * from {{ ref('input_model') }}
 """
 


### PR DESCRIPTION
resolves #315 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

dbt-core is adding a required config, named `begin` for microbatch models in https://github.com/dbt-labs/dbt-core/pull/10756. 

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Add required begin config so tests continue to pass once the above dbt-core PR is in.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
