### PR TITLE
Switch from environment variable to behavior flag for gating microbatch functionality

### DIFF
--- a/.changes/unreleased/Features-20241001-165406.yaml
+++ b/.changes/unreleased/Features-20241001-165406.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Use a behavior flag to gate microbatch functionality (instead of an environment
+  variable)
+time: 2024-10-01T16:54:06.121016-05:00
+custom:
+  Author: QMalcolm
+  Issue: "327"

--- a/dbt-tests-adapter/dbt/tests/adapter/incremental/test_incremental_microbatch.py
+++ b/dbt-tests-adapter/dbt/tests/adapter/incremental/test_incremental_microbatch.py
@@ -61,14 +61,6 @@ class BaseMicrobatch:
 
         assert len(result) == expected_row_count, f"{relation_name}:{pformat(result)}"
 
-    @pytest.fixture(scope="class")
-    def project_config_update(self):
-        return {
-            "flags": {
-                "require_batched_execution_for_custom_microbatch_strategy": True,
-            }
-        }
-
     def test_run_with_event_time(self, project, insert_two_rows_sql):
         # initial run -- backfills all data
         with patch_microbatch_end_time("2020-01-03 13:57:00"):

--- a/dbt-tests-adapter/dbt/tests/adapter/incremental/test_incremental_microbatch.py
+++ b/dbt-tests-adapter/dbt/tests/adapter/incremental/test_incremental_microbatch.py
@@ -1,6 +1,4 @@
-import os
 from pprint import pformat
-from unittest import mock
 
 import pytest
 
@@ -63,7 +61,14 @@ class BaseMicrobatch:
 
         assert len(result) == expected_row_count, f"{relation_name}:{pformat(result)}"
 
-    @mock.patch.dict(os.environ, {"DBT_EXPERIMENTAL_MICROBATCH": "True"})
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {
+                "require_batched_execution_for_custom_microbatch_strategy": True,
+            }
+        }
+
     def test_run_with_event_time(self, project, insert_two_rows_sql):
         # initial run -- backfills all data
         with patch_microbatch_end_time("2020-01-03 13:57:00"):

--- a/dbt/adapters/__about__.py
+++ b/dbt/adapters/__about__.py
@@ -1,1 +1,1 @@
-version = "1.8.0"
+version = "1.8.1"

--- a/dbt/adapters/__about__.py
+++ b/dbt/adapters/__about__.py
@@ -1,1 +1,1 @@
-version = "1.8.1"
+version = "1.8.0"

--- a/dbt/adapters/base/impl.py
+++ b/dbt/adapters/base/impl.py
@@ -23,7 +23,6 @@ from typing import (
     Union,
     TYPE_CHECKING,
 )
-import os
 import pytz
 from dbt_common.behavior_flags import Behavior, BehaviorFlag
 from dbt_common.clients.jinja import CallableMacroGenerator
@@ -316,7 +315,13 @@ class BaseAdapter(metaclass=AdapterMeta):
         """
         This method should be overwritten by adapter maintainers to provide platform-specific flags
         """
-        return []
+        return [
+            {
+                "name": "require_batched_execution_for_custom_microbatch_strategy",
+                "default": False,
+                "docs_url": "https://docs.getdbt.com/docs/build/incremental-microbatch",
+            }
+        ]
 
     ###
     # Methods that pass through to the connection manager
@@ -1574,7 +1579,7 @@ class BaseAdapter(metaclass=AdapterMeta):
 
     def builtin_incremental_strategies(self):
         builtin_strategies = ["append", "delete+insert", "merge", "insert_overwrite"]
-        if os.environ.get("DBT_EXPERIMENTAL_MICROBATCH"):
+        if self.behavior.require_batched_execution_for_custom_microbatch_strategy:
             builtin_strategies.append("microbatch")
 
         return builtin_strategies

--- a/dbt/adapters/base/impl.py
+++ b/dbt/adapters/base/impl.py
@@ -1586,6 +1586,17 @@ class BaseAdapter(metaclass=AdapterMeta):
 
     @available.parse_none
     def get_incremental_strategy_macro(self, model_context, strategy: str):
+        """Gets the macro for the given incremental strategy.
+
+        Additionally some validations are done:
+        1. Assert that if the given strategy is a "builtin" strategy, then it must
+           also be defined as a "valid" strategy for the associated adapter
+        2. Assert that the incremental strategy exists in the model context
+
+        Notably, something be defined by the adapter as "valid" without it being
+        a "builtin", and nothing will break (and that is desirable).
+        """
+
         # Construct macro_name from strategy name
         if strategy is None:
             strategy = "default"

--- a/dbt/adapters/base/impl.py
+++ b/dbt/adapters/base/impl.py
@@ -1579,7 +1579,7 @@ class BaseAdapter(metaclass=AdapterMeta):
 
     def builtin_incremental_strategies(self):
         builtin_strategies = ["append", "delete+insert", "merge", "insert_overwrite"]
-        if self.behavior.require_batched_execution_for_custom_microbatch_strategy:
+        if self.behavior.require_batched_execution_for_custom_microbatch_strategy.no_warn:
             builtin_strategies.append("microbatch")
 
         return builtin_strategies


### PR DESCRIPTION
resolves #327

### Problem

We're currently gating microbatch functionality via environment variables, and we should instead use a behavior flag

### Solution

Switch to behavior flag for gating microbatch functionality

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
