### PR TITLE
feat(python): allows to use prj. vars

### DIFF
--- a/.changes/unreleased/Features-20241031-160641.yaml
+++ b/.changes/unreleased/Features-20241031-160641.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: allows to use prj. vars in python models
+time: 2024-10-31T16:06:41.214334214-03:00
+custom:
+    Author: devmessias
+    Issue: 5617 10914


### PR DESCRIPTION
resolves #
Resolves https://github.com/dbt-labs/dbt-core/issues/5617, Resolves https://github.com/dbt-labs/dbt-core/issues/10914

### Problem
Python models are not friendly when we need to use project variables. This will allow to use project variables without to define that inside the model.yaml 


### Solution



### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
