### PR TITLE
Fix microbatch behavior flag check

### DIFF
--- a/.changes/unreleased/Fixes-20241112-141109.yaml
+++ b/.changes/unreleased/Fixes-20241112-141109.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Negate the check for microbatch behavior flag in determining builtins
+time: 2024-11-12T14:11:09.341634-06:00
+custom:
+  Author: QMalcolm
+  Issue: 349

--- a/dbt/adapters/base/impl.py
+++ b/dbt/adapters/base/impl.py
@@ -1579,7 +1579,7 @@ class BaseAdapter(metaclass=AdapterMeta):
 
     def builtin_incremental_strategies(self):
         builtin_strategies = ["append", "delete+insert", "merge", "insert_overwrite"]
-        if self.behavior.require_batched_execution_for_custom_microbatch_strategy.no_warn:
+        if not self.behavior.require_batched_execution_for_custom_microbatch_strategy.no_warn:
             builtin_strategies.append("microbatch")
 
         return builtin_strategies

--- a/dbt/adapters/base/impl.py
+++ b/dbt/adapters/base/impl.py
@@ -1580,6 +1580,12 @@ class BaseAdapter(metaclass=AdapterMeta):
         return ["append"]
 
     def builtin_incremental_strategies(self):
+        """
+        List of possible builtin strategies for adapters
+
+        Microbatch is added by _default_. It is only not added when the behavior flag
+        `require_batched_execution_for_custom_microbatch_strategy` is True.
+        """
         builtin_strategies = ["append", "delete+insert", "merge", "insert_overwrite"]
         if not self.behavior.require_batched_execution_for_custom_microbatch_strategy.no_warn:
             builtin_strategies.append("microbatch")


### PR DESCRIPTION
resolves #349

### Problem

Previously we were adding `microbatch` to the list of `builtin_incremental_strategies` only when the behavior flag `require_batched_execution_for_custom_microbatch_strategy` was set to True. However in reality, we only want to set it True when that flag evaluates to False. This is because having the flag set to True implies by the transitive property that the project has a custom microbatch macro defined. In this situation, we _don't_ want `microbatch` to be in the list of `builtins` because if the adapter doesn't have a builtin `microbatch` macro, things will break. Said another way, the only time that having `microbatch` in the list of builtin incremental strategies is relevant is when the flag is False.

### Solution

Only add `microbatch` to the list of `builtin_incremental_strategies` when the behavior flag `require_batched_execution_for_custom_microbatch_strategy` is `False`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development, and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
