### PR TITLE
Revert the version bump on dbt-adapters

### DIFF
--- a/dbt/adapters/__about__.py
+++ b/dbt/adapters/__about__.py
@@ -1,1 +1,1 @@
-version = "1.11.0"
+version = "1.9.0b"


### PR DESCRIPTION
We accidentally bumped `dbt-adapters` to 1.11. We need to revert that to properly release.