### PR TITLE
Append `model.batch.id` to suffix in `make_temp_relation` when present

### DIFF
--- a/dbt/include/global_project/macros/adapters/relation.sql
+++ b/dbt/include/global_project/macros/adapters/relation.sql
@@ -7,6 +7,11 @@
 {% endmacro %}
 
 {% macro make_temp_relation(base_relation, suffix='__dbt_tmp') %}
+  {#-- This ensures microbatch batches get unique temp relations to avoid clobbering --#}
+  {% if suffix == '__dbt_tmp' and model.batch %}
+    {% set suffix = suffix ~ '_' ~ model.batch.id %}
+  {% endif %}
+
   {{ return(adapter.dispatch('make_temp_relation', 'dbt')(base_relation, suffix)) }}
 {% endmacro %}
 


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-adapters/issues/360

### Problem

Batches for a microbatch model were all getting the same temp relation name. This is fine if batches are running sequentially. However, we're enabling concurrent batch execution support. In which case, if the batches have the same temp relation name, they may clobber each other and result in "bad things"™️ 

### Solution

Append the `model.batch.id` to the suffix of the temporary relation name when present

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development, and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
