### PR TITLE
Pin Mashumaro to keep aligned with dbt core depedencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pytz>=2015.7",
     # installed via dbt-common but used directly
     "agate>=1.0,<2.0",
-    "mashumaro[msgpack]>=3.0,<4.0",
+    "mashumaro[msgpack]>=3.9,<3.15",
     "protobuf>=5.0,<6.0",
     "typing-extensions>=4.0,<5.0",
 ]


### PR DESCRIPTION
Per https://github.com/dbt-labs/dbt-core/commit/407f6caa1c70a8ba3d8fdbddb5edb4c7afed35bc\#diff-7c83d4c4b82698e2b510b737d\[…\]5b0c1e3c0cb3353460e73bcae29R54

### Problem

Mashumaro 3.15 broke core builds. https://github.com/dbt-labs/dbt-core/pull/11046


We need to mirror that dependency resolution.

### Solution

Pin using Core's standard.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
