### PR TITLE
Fix concurrency test

### DIFF
--- a/dbt-tests-adapter/dbt/tests/adapter/concurrency/test_concurrency.py
+++ b/dbt-tests-adapter/dbt/tests/adapter/concurrency/test_concurrency.py
@@ -1,11 +1,13 @@
+from collections import Counter
+
 import pytest
 
+from dbt.artifacts.schemas.results import RunStatus
 from dbt.tests.util import (
     check_relations_equal,
     check_table_does_not_exist,
     rm_file,
     run_dbt,
-    run_dbt_and_capture,
     write_file,
 )
 
@@ -317,8 +319,8 @@ class BaseConcurrency:
         rm_file(project.project_root, "seeds", "seed.csv")
         write_file(seeds__update_csv, project.project_root, "seeds", "seed.csv")
 
-        results, output = run_dbt_and_capture(["run"], expect_pass=False)
-        assert len(results) == 7
+        results = run_dbt(["run"], expect_pass=False)
+
         check_relations_equal(project.adapter, ["seed", "view_model"])
         check_relations_equal(project.adapter, ["seed", "dep"])
         check_relations_equal(project.adapter, ["seed", "table_a"])
@@ -326,7 +328,13 @@ class BaseConcurrency:
         check_table_does_not_exist(project.adapter, "invalid")
         check_table_does_not_exist(project.adapter, "skip")
 
-        assert "PASS=5 WARN=0 ERROR=1 SKIP=1 TOTAL=7" in output
+        result_statuses = Counter([result.status for result in results])
+        expected_statuses = {
+            RunStatus.Success: 5,
+            RunStatus.Error: 1,
+            RunStatus.Skipped: 1,
+        }
+        assert result_statuses == expected_statuses
 
 
 class TestConcurenncy(BaseConcurrency):

--- a/dbt-tests-adapter/pyproject.toml
+++ b/dbt-tests-adapter/pyproject.toml
@@ -52,6 +52,16 @@ include = ["dbt/tests", "dbt/__init__.py"]
 [tool.hatch.build.targets.wheel]
 include = ["dbt/tests", "dbt/__init__.py"]
 
+[tool.hatch.envs.default]
+python = "3.9"
+dependencies = [
+    "dbt_common @ git+https://github.com/dbt-labs/dbt-common.git",
+    "dbt-adapters @ {root:uri}/..",
+    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
+    "pre-commit==3.7.0",
+    "pytest"
+]
+
 [tool.hatch.envs.build]
 detached = true
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ include = ["dbt/adapters", "dbt/include", "dbt/__init__.py"]
 include = ["dbt/adapters", "dbt/include", "dbt/__init__.py"]
 
 [tool.hatch.envs.default]
+python = "3.9"
 dependencies = [
     "dbt_common @ git+https://github.com/dbt-labs/dbt-common.git",
     'pre-commit==3.7.0;python_version>="3.9"',


### PR DESCRIPTION
### Problem

We're verifying the expected run results for concurrency tests by parsing the logs. This creates a brittle test as the log structure could change over time. This happened recently, breaking this test and causing a false positive.

### Solution

Replace the verification via logs with a verification via run results.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
