### PR TITLE
Fix changelog generation during the release process

### DIFF
--- a/.github/workflows/_generate-changelog.yml
+++ b/.github/workflows/_generate-changelog.yml
@@ -198,6 +198,9 @@ jobs:
         if: ${{ needs.temp-branch.outputs.name != '' && inputs.merge }}
         runs-on: ${{ vars.DEFAULT_RUNNER }}
         steps:
+        -   uses: actions/checkout@v4
+            with:
+                ref: ${{ needs.temp-branch.outputs.name }}
         -   uses: everlytic/branch-merge@1.1.5
             with:
                 source_ref: ${{ needs.temp-branch.outputs.name }}


### PR DESCRIPTION
### Problem

The changelog generation process tries to delete a remote branch using `git` before the repo is checked out.

### Solution

Checkout the repo so `git` knows where to delete the branch from.