### PR TITLE
Add test prompt in PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,17 @@ resolves #
   tradeoffs you considered.
 -->
 
+### Concrete Adapter Testing
+
+Before marking your pull request `Ready for Review`, please use an integration test workflow in each of the following repos to confirm that your feature ad or bug (1) achieves the desired behavior (2) does not disrupt other concrete adapters:
+* [ ] Postgres
+* [ ] Snowflake
+* [ ] Spark
+* [ ] Redshift
+* [ ] Bigquery
+
+Please link each CI workflow in this checklist here or in a separate PR comment.
+
 ### Checklist
 
 - [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me


### PR DESCRIPTION


### Problem

We don't have a solid process around testing adapter changes in this repo.  This can lead to partial testing, which gives a false sense of security as to the safety of a code change.

### Solution

Let's formalize that by encouraging folks to include CI runs in every request opened.

Each adapter has an integration test, action, and this action can specify pull request names directly so that anyone can easily test their code in concrete repos. This will be even easier once we are in mono repo.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development, and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX
