### PR TITLE
Amendment for run_query macro

### DIFF
--- a/dbt-adapters/src/dbt/include/global_project/macros/etc/statement.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/etc/statement.sql
@@ -43,9 +43,22 @@ The macro override naming method (spark__statement) only works for macros which 
 
 
 {# a user-friendly interface into statements #}
-{% macro run_query(sql) %}
+{% macro run_query(sql, bulk=False) %}
+  {%- if bulk -%}
+    {%- for query in sql.split(';') -%}
+      {%- if query | trim | length > 0 -%}
+        {% do return(exec_statement(query)) %}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- else -%}
+    {% do return(exec_statement(sql)) %}
+  {%- endif -%}
+{% endmacro %}
+
+
+{% macro exec_statement(sql_statement) %}
   {% call statement("run_query_statement", fetch_result=true, auto_begin=false) %}
-    {{ sql }}
+    {{ sql_statement }}
   {% endcall %}
 
   {% do return(load_result("run_query_statement").table) %}


### PR DESCRIPTION
### Problem

Different DBT backends treat SQL query differently. For example, BigQuery can run several SQL statements as a single SQL-script.
Snowflake and Databricks can't behave in that way and require to run single SQL statement at a time.
Thus what we can do if we need to run several SQL statements?
Here you can see several options available atb the moment:

- 1st
```sql
{{ config(
    materialized = 'table',
) }}

{%- call statement('1') -%}

  select 1

{%- endcall -%}

{%- call statement('2') -%}

  select 2

{%- endcall -%}

select 111
```
- 2nd
```sql
{{ config(
    materialized = 'table',
) }}

{%- set statements = ["
    select 1
  ", "
    select 2
  "
]-%}

{% for stmt in statements %}
  {% do run_query(stmt) %}
{% endfor %}

select 111
```
- 3rd
```sql
{{ config(
    materialized = 'table',
) }}

{%- set full_query %}
  select 1;
  select 2;
  select 3;

{% endset -%}

{%- set statements = full_query.split(';') -%}
{%- for stmt in statements -%}
  {%- if stmt | trim | length > 0 -%}
    {%- do run_query(stmt) -%}
  {%- endif -%}
{%- endfor -%}

select 111
```
Can we treat that as convenient? Probably not

### Solution

Let's amend existing `run_query` macro to let it be executed in either single statement/script or bulk mode. Default execution mode is `script`. If someone wants to use it in `bulk` mode then the only thing needs to be added is a macro's parameter `bulk=True`.
**_Proposed change is not breaking. Not even single existing macro invocation will be jeopardized._**

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to meet desire functionality
- [x] Specific tests are not required because there is just a wrapper to existing functionality
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
