### PR TITLE
Install local packages in editable format

### DIFF
--- a/dbt-athena-community/hatch.toml
+++ b/dbt-athena-community/hatch.toml
@@ -8,10 +8,12 @@ packages = ["src/dbt"]
 # the only build dependency is dbt-athena, which will never be published when running this
 # because the versions need to be identical
 detached = true
+pre-install-commands = [
+  "pip install -e ../dbt-adapters",
+  "pip install -e ../dbt-tests-adapter",
+  "pip install -e ../dbt-athena",
+]
 dependencies = [
-    "dbt-athena @ {root:uri}/../dbt-athena",
-    "dbt-adapters @ {root:uri}/../dbt-adapters",
-    "dbt-tests-adapter @ {root:uri}/../dbt-tests-adapter",
     "isort~=5.13",
     "moto~=5.0.13",
     "pre-commit~=3.5",

--- a/dbt-athena/hatch.toml
+++ b/dbt-athena/hatch.toml
@@ -10,9 +10,11 @@ packages = ["src/dbt/adapters", "src/dbt/include"]
 sources = ["src"]
 
 [envs.default]
+pre-install-commands = [
+  "pip install -e ../dbt-adapters",
+  "pip install -e ../dbt-tests-adapter",
+]
 dependencies = [
-    "dbt-adapters @ {root:uri}/../dbt-adapters",
-    "dbt-tests-adapter @ {root:uri}/../dbt-tests-adapter",
     "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
     "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "moto~=5.0.13",

--- a/dbt-bigquery/hatch.toml
+++ b/dbt-bigquery/hatch.toml
@@ -10,10 +10,11 @@ packages = ["src/dbt"]
 sources = ["src"]
 
 [envs.default]
-python = "3.9"
+pre-install-commands = [
+  "pip install -e ../dbt-adapters",
+  "pip install -e ../dbt-tests-adapter",
+]
 dependencies = [
-    "dbt-adapters @ {root:uri}/../dbt-adapters",
-    "dbt-tests-adapter @ {root:uri}/../dbt-tests-adapter",
     "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
     "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",

--- a/dbt-postgres/hatch.toml
+++ b/dbt-postgres/hatch.toml
@@ -10,9 +10,11 @@ packages = ["src/dbt/adapters", "src/dbt/include"]
 sources = ["src"]
 
 [envs.default]
+pre-install-commands = [
+  "pip install -e ../dbt-adapters",
+  "pip install -e ../dbt-tests-adapter",
+]
 dependencies = [
-    "dbt-adapters @ {root:uri}/../dbt-adapters",
-    "dbt-tests-adapter @ {root:uri}/../dbt-tests-adapter",
     "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
     "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",

--- a/dbt-redshift/hatch.toml
+++ b/dbt-redshift/hatch.toml
@@ -10,9 +10,12 @@ packages = ["src/dbt"]
 sources = ["src"]
 
 [envs.default]
+pre-install-commands = [
+  "pip install -e ../dbt-adapters",
+  "pip install -e ../dbt-tests-adapter",
+  "pip install -e ../dbt-postgres",
+]
 dependencies = [
-    "dbt-adapters @ {root:uri}/../dbt-adapters",
-    "dbt-tests-adapter @ {root:uri}/../dbt-tests-adapter",
     "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
     "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",

--- a/dbt-snowflake/hatch.toml
+++ b/dbt-snowflake/hatch.toml
@@ -10,9 +10,11 @@ packages = ["src/dbt"]
 sources = ["src"]
 
 [envs.default]
+pre-install-commands = [
+  "pip install -e ../dbt-adapters",
+  "pip install -e ../dbt-tests-adapter",
+]
 dependencies = [
-    "dbt-adapters @ {root:uri}/../dbt-adapters",
-    "dbt-tests-adapter @ {root:uri}/../dbt-tests-adapter",
     "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
     "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",

--- a/dbt-tests-adapter/hatch.toml
+++ b/dbt-tests-adapter/hatch.toml
@@ -10,9 +10,10 @@ packages = ["src/dbt/tests"]
 sources = ["src"]
 
 [envs.default]
-python = "3.9"
+pre-install-commands = [
+  "pip install -e ../dbt-adapters",
+]
 dependencies = [
-    "dbt-adapters @ {root:uri}/../dbt-adapters",
     "dbt_common @ git+https://github.com/dbt-labs/dbt-common.git",
     "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pre-commit==3.7.0",


### PR DESCRIPTION
The local packages are not installing correctly. Even if they did, they install in non-editable mode, making development across packages clunky. `hatch` doesn't have a built-in way to handle this. The best workaround proposed is to install via `hatch` pre-install commands.