### PR TITLE
Update the environment dropdown to a hard coded list

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,8 @@ on:
                 -   "dbt-spark"
             deploy-to:
                 description: "Choose whether to publish to test or prod"
-                type: environment
-                default: "prod"
+                type: choice
+                options: ["prod", "test"]
             branch:
                 description: "Choose the branch to publish from"
                 type: string


### PR DESCRIPTION
We use environments for managing each package's variables and secrets for integration testing. All of these environments are displaying in the release dropdown, which is confusing. We don't anticipate this list of environments changing, so we should just hard code it.