### PR TITLE
Update scheduled tests notification configuration

### DIFF
--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -89,10 +89,10 @@ jobs:
             with:
                 token: ${{ secrets.GITHUB_TOKEN }}
                 status: ${{ job.status }}
-                notification_title: "{workflow} has {status_message}"
-                message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
-                footer: "View run: {workflow_url}"
-                mention_users: "S066LNHS2N6"
-                mention_users_when: "failure,warnings"
+                notification_title: "{workflow} {status_message}"
+                message_format: "{emoji} *{workflow}* {status_message} for <{repo_url}|{repo}>"
+                footer: "View run: {run_url}"
+                mention_groups: ${{ vars.SLACK_ON_CALL }}
+                mention_groups_when: "failure"
             env:
                 SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_ADAPTER_ALERTS }}


### PR DESCRIPTION
We were using `mention_users` instead of `mention_groups` for the Slack notification, which was causing it to just print the user group ID instead of the appropriate ref. This was updated and the ref was pulled into a repo variable so that it can be updated in the future.

The Slack notification was referencing the workflow file instead of the run. This has been updated.

Some grammar was tweaked.