### PR TITLE
Quickfix: force publish action to use aws profile

### DIFF
--- a/.github/workflows/_publish-internal.yml
+++ b/.github/workflows/_publish-internal.yml
@@ -80,6 +80,7 @@ jobs:
                     --format pypi \
                     --package ${{ inputs.package }} \
                     --output json \
+                    --region ${{ vars.AWS_REGION }} \
                     --query 'versions[*].version' | jq -r '.[]' | grep "^${{ steps.package.outputs.version }}" || true )"  # suppress pipefail only here
                 echo "versions=$(echo "${versions_published[*]}"| tr '\n' ',')" >> $GITHUB_OUTPUT
         -   id: next

--- a/.github/workflows/_publish-internal.yml
+++ b/.github/workflows/_publish-internal.yml
@@ -75,6 +75,7 @@ jobs:
         -   id: published
             run: |
                 versions_published="$(aws codeartifact list-package-versions \
+                    --profile ${{ env.TEMP_PROFILE_NAME }} \
                     --domain ${{ vars.AWS_DOMAIN }} \
                     --repository ${{ vars.AWS_REPOSITORY }} \
                     --format pypi \


### PR DESCRIPTION
### Problem

In the publish internal action, the step that fetches previous package versions appears to ignore the aws params configured previously. See [this log](https://github.com/dbt-labs/dbt-adapters/actions/runs/13076216781/job/36489015539#step:7:21) for an example

### Solution

This PR specifies the --region and --profile params, so this thing works as intended.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
