### PR TITLE
Solve issue with local docker setup

### DIFF
--- a/dbt-spark/docker/spark-defaults.conf
+++ b/dbt-spark/docker/spark-defaults.conf
@@ -4,6 +4,7 @@ spark.hadoop.datanucleus.autoCreateTables	true
 spark.hadoop.datanucleus.schema.autoCreateTables	true
 spark.hadoop.datanucleus.fixedDatastore 	false
 spark.serializer	org.apache.spark.serializer.KryoSerializer
-spark.jars.packages	org.apache.hudi:hudi-spark3-bundle_2.12:0.10.0
+spark.jars.packages	org.apache.hudi:hudi-spark3.3-bundle_2.12:0.12.1
 spark.sql.extensions	org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+spark.sql.catalog.spark_catalog	org.apache.spark.sql.hudi.catalog.HoodieCatalog
 spark.driver.userClassPathFirst true


### PR DESCRIPTION
resolves: https://discourse.getdbt.com/t/connection-issue-with-documented-local-spark-dbt-docker-setup/17977

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
```
java.lang.NoSuchMethodError: org.apache.spark.sql.catalyst.parser.ParserUtils$.withOrigin(Lorg/antlr/v4/runtime/ParserRuleContext;Lscala/Function0;)Ljava/lang/Object;
```
when running `dbt debug` with documented Docker setup and profile.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Bumping the version of the spark hudi bundle (see https://hudi.apache.org/docs/0.12.1/quick-start-guide/).
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
