### PR TITLE
Update project URLs for all adapters

### DIFF
--- a/dbt-adapters/pyproject.toml
+++ b/dbt-adapters/pyproject.toml
@@ -36,11 +36,11 @@ dependencies = [
     "typing-extensions>=4.0,<5.0",
 ]
 [project.urls]
-Homepage = "https://github.com/dbt-labs/dbt-adapters"
+Homepage = "https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-adapters"
 Documentation = "https://docs.getdbt.com"
-Repository = "https://github.com/dbt-labs/dbt-adapters.git"
+Repository = "https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-adapters"
 Issues = "https://github.com/dbt-labs/dbt-adapters/issues"
-Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/CHANGELOG.md"
 
 [tool.mypy]
 mypy_path = "third-party-stubs/"

--- a/dbt-athena-community/pyproject.toml
+++ b/dbt-athena-community/pyproject.toml
@@ -29,10 +29,11 @@ classifiers = [
 dependencies = ["dbt-athena==1.9.0"]
 version = "1.9.0"
 [project.urls]
-Homepage = "https://github.com/dbt-labs/dbt-athena/dbt-athena"
+Homepage = "https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-athena"
 Documentation = "https://docs.getdbt.com"
-Repository = "https://github.com/dbt-labs/dbt-athena.git#subdirectory=dbt-athena"
-Issues = "https://github.com/dbt-labs/dbt-athena/issues"
+Repository = "https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-athena"
+Issues = "https://github.com/dbt-labs/dbt-adapters/issues"
+Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-athena/CHANGELOG.md"
 
 [tool.pytest]
 testpaths = [

--- a/dbt-athena/pyproject.toml
+++ b/dbt-athena/pyproject.toml
@@ -39,11 +39,11 @@ dependencies=[
     "tenacity>=8.2,<10.0",
 ]
 [project.urls]
-Homepage = "https://github.com/dbt-labs/dbt-athena/dbt-athena"
+Homepage = "https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-athena"
 Documentation = "https://docs.getdbt.com"
-Repository = "https://github.com/dbt-labs/dbt-athena.git#subdirectory=dbt-athena"
-Issues = "https://github.com/dbt-labs/dbt-athena/issues"
-Changelog = "https://github.com/dbt-labs/dbt-athena/blob/main/dbt-athena/CHANGELOG.md"
+Repository = "https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-athena"
+Issues = "https://github.com/dbt-labs/dbt-adapters/issues"
+Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-athena/CHANGELOG.md"
 
 [tool.pytest]
 testpaths = ["tests/unit", "tests/functional"]

--- a/dbt-bigquery/pyproject.toml
+++ b/dbt-bigquery/pyproject.toml
@@ -37,11 +37,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/dbt-labs/dbt-bigquery"
+Homepage = "https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-bigquery"
 Documentation = "https://docs.getdbt.com"
-Repository = "https://github.com/dbt-labs/dbt-bigquery.git"
-Issues = "https://github.com/dbt-labs/dbt-bigquery/issues"
-Changelog = "https://github.com/dbt-labs/dbt-bigquery/blob/main/CHANGELOG.md"
+Repository = "https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-bigquery"
+Issues = "https://github.com/dbt-labs/dbt-adapters/issues"
+Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-bigquery/CHANGELOG.md"
 
 [tool.mypy]
 mypy_path = "third-party-stubs/"

--- a/dbt-postgres/pyproject.toml
+++ b/dbt-postgres/pyproject.toml
@@ -36,11 +36,11 @@ dependencies = [
     "agate>=1.0,<2.0",
 ]
 [project.urls]
-Homepage = "https://github.com/dbt-labs/dbt-postgres"
+Homepage = "https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-postgres"
 Documentation = "https://docs.getdbt.com"
-Repository = "https://github.com/dbt-labs/dbt-postgres.git"
-Issues = "https://github.com/dbt-labs/dbt-postgres/issues"
-Changelog = "https://github.com/dbt-labs/dbt-postgres/blob/main/CHANGELOG.md"
+Repository = "https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-postgres"
+Issues = "https://github.com/dbt-labs/dbt-adapters/issues"
+Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-postgres/CHANGELOG.md"
 
 [tool.pytest]
 testpaths = [

--- a/dbt-redshift/pyproject.toml
+++ b/dbt-redshift/pyproject.toml
@@ -38,11 +38,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/dbt-labs/dbt-redshift"
+Homepage = "https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-redshift"
 Documentation = "https://docs.getdbt.com"
-Repository = "https://github.com/dbt-labs/dbt-redshift.git"
-Issues = "https://github.com/dbt-labs/dbt-redshift/issues"
-Changelog = "https://github.com/dbt-labs/dbt-redshift/blob/main/CHANGELOG.md"
+Repository = "https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-redshift"
+Issues = "https://github.com/dbt-labs/dbt-adapters/issues"
+Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-redshift/CHANGELOG.md"
 
 [tool.mypy]
 mypy_path = "third-party-stubs/"

--- a/dbt-snowflake/pyproject.toml
+++ b/dbt-snowflake/pyproject.toml
@@ -33,11 +33,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/dbt-labs/dbt-snowflake"
+Homepage = "https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-snowflake"
 Documentation = "https://docs.getdbt.com"
-Repository = "https://github.com/dbt-labs/dbt-snowflake.git"
-Issues = "https://github.com/dbt-labs/dbt-snowflake/issues"
-Changelog = "https://github.com/dbt-labs/dbt-snowflake/blob/main/CHANGELOG.md"
+Repository = "https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-snowflake"
+Issues = "https://github.com/dbt-labs/dbt-adapters/issues"
+Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-snowflake/CHANGELOG.md"
 
 [tool.pytest.ini_options]
 testpaths = ["tests/functional", "tests/unit"]

--- a/dbt-spark/pyproject.toml
+++ b/dbt-spark/pyproject.toml
@@ -44,11 +44,11 @@ all = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/dbt-labs/dbt-spark"
+Homepage = "https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-spark"
 Documentation = "https://docs.getdbt.com"
-Repository = "https://github.com/dbt-labs/dbt-spark.git"
-Issues = "https://github.com/dbt-labs/dbt-spark/issues"
-Changelog = "https://github.com/dbt-labs/dbt-spark/blob/main/CHANGELOG.md"
+Repository = "https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-spark"
+Issues = "https://github.com/dbt-labs/dbt-adapters/issues"
+Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-spark/CHANGELOG.md"
 
 [tool.pytest.ini_options]
 testpaths = ["tests/functional", "tests/unit"]

--- a/dbt-tests-adapter/pyproject.toml
+++ b/dbt-tests-adapter/pyproject.toml
@@ -37,8 +37,8 @@ dependencies = [
     "freezegun",
 ]
 [project.urls]
-Homepage = "https://github.com/dbt-labs/dbt-adapters"
+Homepage = "https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-tests-adapter"
 Documentation = "https://docs.getdbt.com"
-Repository = "https://github.com/dbt-labs/dbt-adapters.git"
+Repository = "https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter"
 Issues = "https://github.com/dbt-labs/dbt-adapters/issues"
-Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-tests-adapter/CHANGELOG.md"

--- a/dbt-tests-adapter/pyproject.toml
+++ b/dbt-tests-adapter/pyproject.toml
@@ -41,4 +41,4 @@ Homepage = "https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-tests-adapter
 Documentation = "https://docs.getdbt.com"
 Repository = "https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter"
 Issues = "https://github.com/dbt-labs/dbt-adapters/issues"
-Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-tests-adapter/CHANGELOG.md"
+Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/CHANGELOG.md"


### PR DESCRIPTION
The project URLs point to the legacy repos and need to be updated to point to this repository.