### PR TITLE
Enable authorization of materialized views

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fixes-20250202-105422.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20250202-105422.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix silently ignoring materialized view authorization
+time: 2025-02-02T10:54:22.12198+01:00
+custom:
+  Author: kubikb
+  Issue: "1471"

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/relations/materialized_view/create.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/relations/materialized_view/create.sql
@@ -2,6 +2,12 @@
 
     {%- set materialized_view = adapter.Relation.materialized_view_from_relation_config(config.model) -%}
 
+    {% if config.get('grant_access_to') %}
+      {% for grant_target_dict in config.get('grant_access_to') %}
+        {% do adapter.grant_access_to(this, 'view', None, grant_target_dict) %}
+      {% endfor %}
+    {% endif %}
+
     create materialized view if not exists {{ relation }}
     {% if materialized_view.partition %}{{ partition_by(materialized_view.partition) }}{% endif %}
     {% if materialized_view.cluster %}{{ cluster_by(materialized_view.cluster.fields) }}{% endif %}

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/relations/materialized_view/replace.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/relations/materialized_view/replace.sql
@@ -2,6 +2,12 @@
 
     {%- set materialized_view = adapter.Relation.materialized_view_from_relation_config(config.model) -%}
 
+    {% if config.get('grant_access_to') %}
+      {% for grant_target_dict in config.get('grant_access_to') %}
+        {% do adapter.grant_access_to(this, 'view', None, grant_target_dict) %}
+      {% endfor %}
+    {% endif %}
+
     create or replace materialized view if not exists {{ relation }}
     {% if materialized_view.partition %}{{ partition_by(materialized_view.partition) }}{% endif %}
     {% if materialized_view.cluster %}{{ cluster_by(materialized_view.cluster.fields) }}{% endif %}

--- a/dbt-bigquery/tests/functional/adapter/test_grant_access_to.py
+++ b/dbt-bigquery/tests/functional/adapter/test_grant_access_to.py
@@ -21,6 +21,24 @@ def select_1(dataset: str, materialized: str):
     )
 
 
+def select_1_materialized_view(dataset: str):
+    config = f"""config(
+                materialized='materialized_view',
+                grant_access_to=[
+                  {{'project': 'dbt-test-env', 'dataset': '{dataset}'}},
+                ]
+            )"""
+    return (
+        "{{"
+        + config
+        + "}}"
+        + """
+           SELECT one, COUNT(1) AS count_one
+           FROM {{ ref('select_1_table') }}
+           GROUP BY one"""
+    )
+
+
 BAD_CONFIG_TABLE_NAME = "bad_view"
 BAD_CONFIG_TABLE = """
 {{ config(
@@ -75,15 +93,32 @@ class TestAccessGrantSucceeds:
         return {
             "select_1.sql": select_1(dataset=dataset, materialized="view"),
             "select_1_table.sql": select_1(dataset=dataset, materialized="table"),
+            "select_1_materialized_view.sql": select_1_materialized_view(dataset=dataset),
         }
 
-    def test_grant_access_succeeds(self, project, setup_grant_schema, teardown_grant_schema):
+    def test_grant_access_succeeds(self, project, setup_grant_schema, teardown_grant_schema, unique_schema):
         # Need to run twice to validate idempotency
         results = run_dbt(["run"])
-        assert len(results) == 2
+        assert len(results) == 3
         time.sleep(10)
-        results = run_dbt(["run"])
+        # Materialized view excluded since it would produce an error since source table is replaced
+        results = run_dbt(["run", "--exclude", "select_1_materialized_view"])
         assert len(results) == 2
+
+        with project.adapter.connection_named("__test_grants"):
+            client = project.adapter.connections.get_thread_connection().handle
+            dataset_name = get_schema_name(unique_schema)
+            dataset_id = "{}.{}".format("dbt-test-env", dataset_name)
+            bq_dataset = client.get_dataset(dataset_id)
+
+            authorized_view_names = []
+            for access_entry in bq_dataset.access_entries:
+                if access_entry.entity_type != "view":
+                    continue
+
+                authorized_view_names.append(access_entry.entity_id["tableId"])
+
+            assert set(authorized_view_names) == set(["select_1", "select_1_materialized_view"])
 
 
 class TestAccessGrantFails:


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-adapters/issues/773.

### Problem
Similarly to BigQuery views, [BigQuery materialized views can also be authorized to access the data in another dataset(s)](https://cloud.google.com/bigquery/docs/authorized-views). However, providing the `grant_access_to` configuration to a model with `materialized_view` materialization goes silently ignored and the materialized view does NOT get authorized to access data in another dataset. With models with `view` materialization, the `grant_access_to` configuration leads to the desired behavior, namely the view gets authorized to access data in another dataset.

### Solution
This pull request add logic to handle the config `grant_access_to` also for models with materialization `materialized_view`. The PR also extends currently existing tests.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX

Moved from https://github.com/dbt-labs/dbt-bigquery/pull/1470