### PR TITLE
Fix snowflake testing

### DIFF
--- a/dbt-snowflake/hatch.toml
+++ b/dbt-snowflake/hatch.toml
@@ -32,7 +32,7 @@ dependencies = [
 setup = "pre-commit install"
 code-quality = "pre-commit run --all-files"
 unit-tests = "python -m pytest {args:tests/unit}"
-integration-tests = "- python -m pytest {args:tests/functional}"
+integration-tests = "python -m pytest {args:tests/functional}"
 docker-dev = [
     "docker build -f docker/dev.Dockerfile -t dbt-snowflake-dev .",
 	"docker run --rm -it --name dbt-snowflake-dev -v $(pwd):/opt/code dbt-snowflake-dev",

--- a/dbt-snowflake/tests/functional/iceberg/models.py
+++ b/dbt-snowflake/tests/functional/iceberg/models.py
@@ -70,8 +70,9 @@ select * from {{ ref('first_table') }}
 _MODEL_BASIC_DYNAMIC_TABLE_MODEL_WITH_PATH = """
 {{
   config(
-    transient = "transient",
     materialized = "dynamic_table",
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='1 minute',
     cluster_by=['id'],
     table_format="iceberg",
     external_volume="s3_iceberg_snow",
@@ -85,8 +86,9 @@ select * from {{ ref('first_table') }}
 _MODEL_BASIC_DYNAMIC_TABLE_MODEL_WITH_PATH_SUBPATH = """
 {{
   config(
-    transient = "true",
     materialized = "dynamic_table",
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='1 minute',
     cluster_by=['id'],
     table_format="iceberg",
     external_volume="s3_iceberg_snow",


### PR DESCRIPTION
We inadvertently prefixed the integration tests command with `- `, which tells `hatch` to proceed to the next command regardless of the result of the prior command. This made it so that integration tests were passing in CI despite the tests themselves failing. This hid a few broken tests. In particular, we supplied an incorrect config for Iceberg dynamic tables in one test and we failed to notice that our OAuth tokens expired. Functional code was not impacted and is working as intended.