### PR TITLE
Remove env vars for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,8 +54,8 @@ defaults:
 jobs:
     unit-tests:
         if: |
-            !contains(fromJSON(vars.SKIP_UNIT_TESTS), inputs.package) &&
-            inputs.skip-unit-tests == false
+            inputs.skip-unit-tests == false &&
+            !contains(fromJSON('["dbt-tests-adapter"]'), inputs.package)
         uses: ./.github/workflows/_unit-tests.yml
         with:
             package: ${{ inputs.package }}
@@ -63,8 +63,8 @@ jobs:
 
     integration-tests:
         if: |
-            !contains(fromJSON(vars.SKIP_INTEGRATION_TESTS), inputs.package) &&
-            inputs.skip-integration-tests == false
+            inputs.skip-integration-tests == false &&
+            !contains(fromJSON('["dbt-adapters", "dbt-tests-adapter"]'), inputs.package)
         uses: ./.github/workflows/_integration-tests.yml
         with:
             package: ${{ inputs.package }}
@@ -85,9 +85,9 @@ jobs:
     publish-internal:
         if: |
             always() &&
+            inputs.pypi-internal == true &&
             needs.publish-prep-checks.result == 'success' &&
-            !contains(fromJSON(vars.SKIP_PUBLISH_INTERNAL), inputs.package) &&
-            inputs.pypi-internal == true
+            !contains(fromJSON('["dbt-adapters", "dbt-tests-adapter", "dbt-athena-community"]'), inputs.package)
         needs: publish-prep-checks
         uses: ./.github/workflows/_publish-internal.yml
         with:
@@ -100,8 +100,8 @@ jobs:
         needs: publish-prep-checks
         if: |
             always() &&
-            needs.publish-prep-checks.result == 'success' &&
-            inputs.pypi-public == true
+            inputs.pypi-public == true &&
+            needs.publish-prep-checks.result == 'success'
         uses: ./.github/workflows/_generate-changelog.yml
         with:
             package: ${{ inputs.package }}
@@ -112,9 +112,9 @@ jobs:
     publish-pypi:
         if: |
             always() &&
+            inputs.pypi-public == true &&
             needs.publish-prep-checks.result == 'success' &&
-            needs.generate-changelog.result == 'success' &&
-            inputs.pypi-public == true
+            needs.generate-changelog.result == 'success'
         needs: [publish-prep-checks, generate-changelog]
         runs-on: ${{ vars.DEFAULT_RUNNER }}
         environment:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,11 +42,6 @@ on:
                 type: boolean
                 default: false
 
-env:
-    SKIP_UNIT_TESTS: '["dbt-tests-adapter"]'
-    SKIP_INTEGRATION_TESTS: '["dbt-adapters", "dbt-tests-adapter"]'
-    SKIP_PUBLISH_INTERNAL: '["dbt-adapters","dbt-tests-adapter","dbt-athena-community"]'
-
 # don't publish to the same target in parallel
 concurrency:
     group: ${{ github.workflow }}-${{ inputs.package }}-${{ inputs.deploy-to }}
@@ -59,7 +54,7 @@ defaults:
 jobs:
     unit-tests:
         if: |
-            !contains(fromJSON(env.SKIP_UNIT_TESTS), inputs.package) &&
+            !contains(fromJSON(vars.SKIP_UNIT_TESTS), inputs.package) &&
             inputs.skip-unit-tests == false
         uses: ./.github/workflows/_unit-tests.yml
         with:
@@ -68,7 +63,7 @@ jobs:
 
     integration-tests:
         if: |
-            !contains(fromJSON(env.SKIP_INTEGRATION_TESTS), inputs.package) &&
+            !contains(fromJSON(vars.SKIP_INTEGRATION_TESTS), inputs.package) &&
             inputs.skip-integration-tests == false
         uses: ./.github/workflows/_integration-tests.yml
         with:
@@ -91,7 +86,7 @@ jobs:
         if: |
             always() &&
             needs.publish-prep-checks.result == 'success' &&
-            !contains(fromJSON(env.SKIP_PUBLISH_INTERNAL), inputs.package) &&
+            !contains(fromJSON(vars.SKIP_PUBLISH_INTERNAL), inputs.package) &&
             inputs.pypi-internal == true
         needs: publish-prep-checks
         uses: ./.github/workflows/_publish-internal.yml


### PR DESCRIPTION
As it turns out, you cannot reference `env.` in the action itself, only in the container being used by the action, e.g. in a command in the `run` step. For now this will be hard coded so that it works. If we want to be able to configure it via GitHub environment variables, that will be a future PR.