### PR TITLE
Fix typo in CONTRIBUTING.md (unit-test -> unit-tests)

### DIFF
--- a/dbt-adapters/CONTRIBUTING.md
+++ b/dbt-adapters/CONTRIBUTING.md
@@ -105,13 +105,13 @@ Unit tests can be run locally without setting up a database connection:
 # Note: replace $strings with valid names
 
 # run all unit tests
-hatch run unit-test
+hatch run unit-tests
 
 # run all unit tests in a module
-hatch run unit-test tests/unit/$test_file_name.py
+hatch run unit-tests tests/unit/$test_file_name.py
 
 # run a specific unit test
-hatch run unit-test tests/unit/$test_file_name.py::$test_class_name::$test_method_name
+hatch run unit-tests tests/unit/$test_file_name.py::$test_class_name::$test_method_name
 ```
 
 ### Testing against a development branch


### PR DESCRIPTION
resolves N/A

### Problem

In the `CONTRIBUTING.md` file, there is a typo where `unit-test` should be `unit-tests`. This does not affect end-users, but it helps keep the documentation consistent.

### Solution

Corrected the typo from `unit-test` to `unit-tests` for consistency.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
