### PR TITLE
Fix pull request integration tests

### DIFF
--- a/.github/filters/integration-tests.yml
+++ b/.github/filters/integration-tests.yml
@@ -29,7 +29,7 @@ dbt-redshift:
 -   'dbt-redshift/pyproject.toml'
 -   'dbt-adapters/src/**'
 -   'dbt-adapters/pyproject.toml'
--   'dbt-postgres/src/include/**'
+-   'dbt-postgres/src/dbt/include/**'
 -   'dbt-redshift/tests/functional/**'
 -   'dbt-redshift/tests/__init__.py'
 -   'dbt-redshift/tests/conftest.py'

--- a/.github/filters/integration-tests.yml
+++ b/.github/filters/integration-tests.yml
@@ -29,6 +29,7 @@ dbt-redshift:
 -   'dbt-redshift/pyproject.toml'
 -   'dbt-adapters/src/**'
 -   'dbt-adapters/pyproject.toml'
+-   'dbt-postgres/src/include/**'
 -   'dbt-redshift/tests/functional/**'
 -   'dbt-redshift/tests/__init__.py'
 -   'dbt-redshift/tests/conftest.py'

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -98,7 +98,7 @@ jobs:
         needs: affected-packages
         if: ${{ toJSON(fromJSON(needs.affected-packages.outputs.integration-tests)) != '[]' }}
         with:
-            packages: ${{ fromJSON(needs.affected-packages.outputs.integration-tests) }}
+            packages: ${{ needs.affected-packages.outputs.integration-tests }}
             branch: ${{ github.event.pull_request.head.ref }}
             repository: ${{ github.event.pull_request.head.repo.full_name }}
             os: ${{ vars.DEFAULT_RUNNER }}

--- a/dbt-athena-community/pyproject.toml
+++ b/dbt-athena-community/pyproject.toml
@@ -36,7 +36,7 @@ Issues = "https://github.com/dbt-labs/dbt-adapters/issues"
 Changelog = "https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-athena/CHANGELOG.md"
 
 [tool.pytest.ini_options]
-testpaths = ["tests/unit", "tests/functional"]
+testpaths = ["../tests/unit", "../tests/functional"]
 env_files = ["../dbt-athena/test.env"]
 addopts = "-v --color=yes -n auto"
 filterwarnings = [


### PR DESCRIPTION
We deserialized the affected adapters JSON too early, resulting in passing a sequence instead of a raw JSON string.

While making this change, I noticed that `dbt-athena-community` was not pointing at `dbt-athena`'s tests and `dbt-redshift` integration tests were not triggered by macros updates in `dbt-postgres`.