### PR TITLE
Update changelogs with links to prior versions

### DIFF
--- a/dbt-bigquery/.changes/0.0.0.md
+++ b/dbt-bigquery/.changes/0.0.0.md
@@ -1,5 +1,8 @@
 ## Previous Releases
 For information on prior major and minor releases, see their changelogs:
+- [1.9](https://github.com/dbt-labs/dbt-bigquery/blob/1.9.latest/CHANGELOG.md)
+- [1.8](https://github.com/dbt-labs/dbt-bigquery/blob/1.8.latest/CHANGELOG.md)
+- [1.7](https://github.com/dbt-labs/dbt-bigquery/blob/1.7.latest/CHANGELOG.md)
 - [1.6](https://github.com/dbt-labs/dbt-bigquery/blob/1.6.latest/CHANGELOG.md)
 - [1.5](https://github.com/dbt-labs/dbt-bigquery/blob/1.5.latest/CHANGELOG.md)
 - [1.4](https://github.com/dbt-labs/dbt-bigquery/blob/1.4.latest/CHANGELOG.md)

--- a/dbt-bigquery/CHANGELOG.md
+++ b/dbt-bigquery/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## Previous Releases
 For information on prior major and minor releases, see their changelogs:
+- [1.9](https://github.com/dbt-labs/dbt-bigquery/blob/1.9.latest/CHANGELOG.md)
+- [1.8](https://github.com/dbt-labs/dbt-bigquery/blob/1.8.latest/CHANGELOG.md)
+- [1.7](https://github.com/dbt-labs/dbt-bigquery/blob/1.7.latest/CHANGELOG.md)
 - [1.6](https://github.com/dbt-labs/dbt-bigquery/blob/1.6.latest/CHANGELOG.md)
 - [1.5](https://github.com/dbt-labs/dbt-bigquery/blob/1.5.latest/CHANGELOG.md)
 - [1.4](https://github.com/dbt-labs/dbt-bigquery/blob/1.4.latest/CHANGELOG.md)

--- a/dbt-redshift/.changes/0.0.0.md
+++ b/dbt-redshift/.changes/0.0.0.md
@@ -1,5 +1,8 @@
 ## Previous Releases
 For information on prior major and minor releases, see their changelogs:
+- [1.9](https://github.com/dbt-labs/dbt-redshift/blob/1.9.latest/CHANGELOG.md)
+- [1.8](https://github.com/dbt-labs/dbt-redshift/blob/1.8.latest/CHANGELOG.md)
+- [1.7](https://github.com/dbt-labs/dbt-redshift/blob/1.7.latest/CHANGELOG.md)
 - [1.6](https://github.com/dbt-labs/dbt-redshift/blob/1.6.latest/CHANGELOG.md)
 - [1.5](https://github.com/dbt-labs/dbt-redshift/blob/1.5.latest/CHANGELOG.md)
 - [1.4](https://github.com/dbt-labs/dbt-redshift/blob/1.4.latest/CHANGELOG.md)

--- a/dbt-redshift/CHANGELOG.md
+++ b/dbt-redshift/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## Previous Releases
 For information on prior major and minor releases, see their changelogs:
+- [1.9](https://github.com/dbt-labs/dbt-redshift/blob/1.9.latest/CHANGELOG.md)
+- [1.8](https://github.com/dbt-labs/dbt-redshift/blob/1.8.latest/CHANGELOG.md)
+- [1.7](https://github.com/dbt-labs/dbt-redshift/blob/1.7.latest/CHANGELOG.md)
 - [1.6](https://github.com/dbt-labs/dbt-redshift/blob/1.6.latest/CHANGELOG.md)
 - [1.5](https://github.com/dbt-labs/dbt-redshift/blob/1.5.latest/CHANGELOG.md)
 - [1.4](https://github.com/dbt-labs/dbt-redshift/blob/1.4.latest/CHANGELOG.md)

--- a/dbt-snowflake/.changes/0.0.0.md
+++ b/dbt-snowflake/.changes/0.0.0.md
@@ -1,5 +1,8 @@
 ## Previous Releases
 For information on prior major and minor releases, see their changelogs:
+- [1.9](https://github.com/dbt-labs/dbt-snowflake/blob/1.9.latest/CHANGELOG.md)
+- [1.8](https://github.com/dbt-labs/dbt-snowflake/blob/1.8.latest/CHANGELOG.md)
+- [1.7](https://github.com/dbt-labs/dbt-snowflake/blob/1.7.latest/CHANGELOG.md)
 - [1.6](https://github.com/dbt-labs/dbt-snowflake/blob/1.6.latest/CHANGELOG.md)
 - [1.5](https://github.com/dbt-labs/dbt-snowflake/blob/1.5.latest/CHANGELOG.md)
 - [1.4](https://github.com/dbt-labs/dbt-snowflake/blob/1.4.latest/CHANGELOG.md)

--- a/dbt-snowflake/CHANGELOG.md
+++ b/dbt-snowflake/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## Previous Releases
 For information on prior major and minor releases, see their changelogs:
+- [1.9](https://github.com/dbt-labs/dbt-snowflake/blob/1.9.latest/CHANGELOG.md)
+- [1.8](https://github.com/dbt-labs/dbt-snowflake/blob/1.8.latest/CHANGELOG.md)
+- [1.7](https://github.com/dbt-labs/dbt-snowflake/blob/1.7.latest/CHANGELOG.md)
 - [1.6](https://github.com/dbt-labs/dbt-snowflake/blob/1.6.latest/CHANGELOG.md)
 - [1.5](https://github.com/dbt-labs/dbt-snowflake/blob/1.5.latest/CHANGELOG.md)
 - [1.4](https://github.com/dbt-labs/dbt-snowflake/blob/1.4.latest/CHANGELOG.md)

--- a/dbt-spark/.changes/0.0.0.md
+++ b/dbt-spark/.changes/0.0.0.md
@@ -1,5 +1,8 @@
 ## Previous Releases
 For information on prior major and minor releases, see their changelogs:
+- [1.9](https://github.com/dbt-labs/dbt-spark/blob/1.9.latest/CHANGELOG.md)
+- [1.8](https://github.com/dbt-labs/dbt-spark/blob/1.8.latest/CHANGELOG.md)
+- [1.7](https://github.com/dbt-labs/dbt-spark/blob/1.7.latest/CHANGELOG.md)
 - [1.6](https://github.com/dbt-labs/dbt-spark/blob/1.6.latest/CHANGELOG.md)
 - [1.5](https://github.com/dbt-labs/dbt-spark/blob/1.5.latest/CHANGELOG.md)
 - [1.4](https://github.com/dbt-labs/dbt-spark/blob/1.4.latest/CHANGELOG.md)

--- a/dbt-spark/CHANGELOG.md
+++ b/dbt-spark/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## Previous Releases
 For information on prior major and minor releases, see their changelogs:
+- [1.9](https://github.com/dbt-labs/dbt-spark/blob/1.9.latest/CHANGELOG.md)
+- [1.8](https://github.com/dbt-labs/dbt-spark/blob/1.8.latest/CHANGELOG.md)
+- [1.7](https://github.com/dbt-labs/dbt-spark/blob/1.7.latest/CHANGELOG.md)
 - [1.6](https://github.com/dbt-labs/dbt-spark/blob/1.6.latest/CHANGELOG.md)
 - [1.5](https://github.com/dbt-labs/dbt-spark/blob/1.5.latest/CHANGELOG.md)
 - [1.4](https://github.com/dbt-labs/dbt-spark/blob/1.4.latest/CHANGELOG.md)


### PR DESCRIPTION
We missed adding links back to changelogs for 1.7-1.9 for BQ, RS, SF, and Spark.