### PR TITLE
ADAP-1231: Automate internal releases

### DIFF
--- a/.github/workflows/_publish-internal.yml
+++ b/.github/workflows/_publish-internal.yml
@@ -6,11 +6,7 @@ on:
             package:
                 description: "Choose the package to publish"
                 type: string
-                default: "dbt-adapters"
-            deploy-to:
-                description: "Choose whether to publish to test or prod"
-                type: string
-                default: "prod"
+                required: true
             branch:
                 description: "Choose the branch to publish"
                 type: string
@@ -21,21 +17,21 @@ on:
                 description: "Choose the package to publish"
                 type: choice
                 options:
-                -   "dbt-adapters"
                 -   "dbt-athena"
                 -   "dbt-bigquery"
                 -   "dbt-postgres"
                 -   "dbt-redshift"
                 -   "dbt-snowflake"
                 -   "dbt-spark"
-            deploy-to:
-                description: "Choose whether to publish to test or prod"
-                type: environment
-                default: "test"
             branch:
                 description: "Choose the branch to publish"
                 type: string
                 default: "main"
+
+# don't publish to the same target in parallel
+concurrency:
+    group: PyPI_Internal-${{ inputs.package }}
+    cancel-in-progress: true
 
 defaults:
     run:
@@ -48,7 +44,7 @@ jobs:
     publish:
         runs-on: ${{ vars.DEFAULT_RUNNER }}
         environment:
-            name: ${{ inputs.deploy-to }}
+            name: "prod"
         steps:
         -   uses: actions/checkout@v4
             with:

--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -1,0 +1,68 @@
+name: "Publish to internal"
+run-name: "Publish to internal - ${{ inputs.package }} - ${{ github.actor }}"
+
+on:
+    workflow_dispatch:
+        inputs:
+            package:
+                description: "Choose the package to publish"
+                type: choice
+                options:
+                -   "dbt-athena"
+                -   "dbt-bigquery"
+                -   "dbt-postgres"
+                -   "dbt-redshift"
+                -   "dbt-snowflake"
+                -   "dbt-spark"
+            branch:
+                description: "Choose the branch to publish from"
+                type: string
+                default: "main"
+            skip-unit-tests:
+                description: "Skip running unit tests"
+                type: boolean
+                default: false
+            skip-integration-tests:
+                description: "Skip running integration tests"
+                type: boolean
+                default: false
+    workflow_call:
+        inputs:
+            package:
+                description: "Choose the package to publish"
+                type: string
+                required: true
+            branch:
+                description: "Choose the branch to publish from"
+                type: string
+                default: "main"
+            skip-unit-tests:
+                description: "Skip running unit tests"
+                type: boolean
+                default: false
+            skip-integration-tests:
+                description: "Skip running integration tests"
+                type: boolean
+                default: false
+
+jobs:
+    unit-tests:
+        uses: ./.github/workflows/_unit-tests.yml
+        with:
+            package: ${{ inputs.package }}
+            branch: ${{ inputs.branch }}
+
+    integration-tests:
+        uses: ./.github/workflows/_integration-tests.yml
+        with:
+            packages: ${{ toJSON(inputs.package) }}
+            branch: ${{ inputs.branch }}
+        secrets: inherit
+
+    publish-internal:
+        needs: [unit-tests, integration-tests]
+        uses: ./.github/workflows/_publish-internal.yml
+        with:
+            package: ${{ inputs.package }}
+            branch: ${{ inputs.branch }}
+        secrets: inherit

--- a/.github/workflows/publish-oss.yml
+++ b/.github/workflows/publish-oss.yml
@@ -1,5 +1,5 @@
-name: "Publish"
-run-name: "Publish - ${{ inputs.package }} - ${{ inputs.deploy-to }} - ${{ github.actor }}"
+name: "Publish to OSS"
+run-name: "Publish to OSS - ${{ inputs.package }} - ${{ inputs.deploy-to }} - ${{ github.actor }}"
 
 on:
     workflow_dispatch:
@@ -25,14 +25,6 @@ on:
                 description: "Choose the branch to publish from"
                 type: string
                 default: "main"
-            pypi-internal:
-                description: "Publish Internally"
-                type: boolean
-                default: true
-            pypi-public:
-                description: "Publish to PyPI"
-                type: boolean
-                default: false
             skip-unit-tests:
                 description: "Skip running unit tests"
                 type: boolean
@@ -44,7 +36,7 @@ on:
 
 # don't publish to the same target in parallel
 concurrency:
-    group: ${{ github.workflow }}-${{ inputs.package }}-${{ inputs.deploy-to }}
+    group: Publish_OSS-${{ inputs.package }}-${{ inputs.deploy-to }}
     cancel-in-progress: true
 
 defaults:
@@ -82,25 +74,10 @@ jobs:
                 jobs: ${{ toJSON(needs) }}
                 allowed-skips: ${{ toJSON(needs) }}
 
-    publish-internal:
-        if: |
-            always() &&
-            inputs.pypi-internal == true &&
-            needs.publish-prep-checks.result == 'success' &&
-            !contains(fromJSON('["dbt-adapters", "dbt-tests-adapter", "dbt-athena-community"]'), inputs.package)
-        needs: publish-prep-checks
-        uses: ./.github/workflows/_publish-internal.yml
-        with:
-            package: ${{ inputs.package }}
-            deploy-to: ${{ inputs.deploy-to }}
-            branch: ${{ inputs.branch }}
-        secrets: inherit
-
     generate-changelog:
         needs: publish-prep-checks
         if: |
             always() &&
-            inputs.pypi-public == true &&
             needs.publish-prep-checks.result == 'success'
         uses: ./.github/workflows/_generate-changelog.yml
         with:
@@ -109,10 +86,9 @@ jobs:
             branch: ${{ inputs.branch }}
         secrets: inherit
 
-    publish-pypi:
+    publish:
         if: |
             always() &&
-            inputs.pypi-public == true &&
             needs.publish-prep-checks.result == 'success' &&
             needs.generate-changelog.result == 'success'
         needs: [publish-prep-checks, generate-changelog]

--- a/.github/workflows/publish-scheduled.yml
+++ b/.github/workflows/publish-scheduled.yml
@@ -1,0 +1,22 @@
+name: "Scheduled publishing"
+run-name: "Publish to internal - Scheduled"
+
+on:
+    schedule:
+    -   cron: "0 0 * * SUN"
+
+jobs:
+    publish:
+        strategy:
+            matrix:
+                package:
+                -   "dbt-athena"
+                -   "dbt-bigquery"
+                -   "dbt-postgres"
+                -   "dbt-redshift"
+                -   "dbt-snowflake"
+                -   "dbt-spark"
+        uses: ./.github/workflows/publish-internal.yml
+        with:
+            package: ${{ matrix.package }}
+        secrets: inherit

--- a/.github/workflows/publish-scheduled.yml
+++ b/.github/workflows/publish-scheduled.yml
@@ -16,6 +16,7 @@ jobs:
                 -   "dbt-redshift"
                 -   "dbt-snowflake"
                 -   "dbt-spark"
+            fail-fast: false
         uses: ./.github/workflows/publish-internal.yml
         with:
             package: ${{ matrix.package }}


### PR DESCRIPTION
We should release internally on a regular basis to ensure that we're always on `main` in Cloud. Automated tests will prevent us from inadvertently releasing a broken package in the event that CI checks were not sufficient.