### PR TITLE
ADAP-1232: Fix unit test issues

### DIFF
--- a/.github/workflows/_unit-tests.yml
+++ b/.github/workflows/_unit-tests.yml
@@ -73,5 +73,7 @@ jobs:
             with:
                 python-version: ${{ inputs.python-version }}
         -   uses: pypa/hatch@install
+        -   run: brew install unixodbc
+            if: inputs.package == 'dbt-spark' && runner.os == 'macOS'
         -   run: hatch run unit-tests
             working-directory: ./${{ inputs.package }}

--- a/dbt-athena/tests/unit/test_adapter.py
+++ b/dbt-athena/tests/unit/test_adapter.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
 from multiprocessing import get_context
+import sys
 from unittest import mock
 from unittest.mock import patch
 
@@ -1314,6 +1315,9 @@ class TestAthenaAdapter:
         assert 0 <= bucket_number < 100
         assert bucket_number == 54
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="%s (seconds from epoch) is not supported on Windows"
+    )
     def test_murmur3_hash_with_date(self):
         d = datetime.date.today()
         bucket_number = self.adapter.murmur3_hash(d, 100)

--- a/dbt-snowflake/tests/unit/test_private_keys.py
+++ b/dbt-snowflake/tests/unit/test_private_keys.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tempfile
 from typing import Generator
 
@@ -55,6 +56,7 @@ def test_private_key_from_string_pem(private_key_string, private_key):
     assert serialize(calculated_private_key) == serialize(private_key)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="permission issues on Windows")
 def test_private_key_from_file(private_key_file, private_key):
     assert os.path.exists(private_key_file)
     calculated_private_key = private_key_from_file(private_key_file, PASSPHRASE)


### PR DESCRIPTION
There are a few unit test issues that we noticed when we started scheduled testing against all platforms. This resolves those issues by skipping specific tests on specific platforms or installing required dependencies for those tests to run.