### PR TITLE
ADAP-1233: Fix the databricks startup fixture

### DIFF
--- a/dbt-spark/tests/functional/conftest.py
+++ b/dbt-spark/tests/functional/conftest.py
@@ -1,4 +1,9 @@
-from fixtures import dbt_profile_target, skip_by_profile_type, start_databricks_cluster
+from tests.functional.fixtures import (
+    dbt_profile_target,
+    skip_by_profile_type,
+    start_databricks_cluster,
+)
+
 
 pytest_plugins = ["dbt.tests.fixtures.project"]
 

--- a/dbt-spark/tests/functional/conftest.py
+++ b/dbt-spark/tests/functional/conftest.py
@@ -1,27 +1,16 @@
-import time
-import pytest
+from fixtures import dbt_profile_target, skip_by_profile_type, start_databricks_cluster
+
+pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
-def _wait_for_databricks_cluster(project):
-    """
-    It takes roughly 3min for the cluster to start, to be safe we'll wait for 5min
-    """
-    for _ in range(60):
-        try:
-            project.run_sql("SELECT 1", fetch=True)
-            return
-        except Exception:
-            time.sleep(10)
-
-    raise Exception("Databricks cluster did not start in time")
+def pytest_addoption(parser):
+    parser.addoption("--profile", action="store", default="apache_spark", type=str)
 
 
-# Running this should prevent tests from needing to be retried because the Databricks cluster isn't available
-@pytest.fixture(scope="class", autouse=True)
-def start_databricks_cluster(project, request):
-    profile_type = request.config.getoption("--profile")
-
-    if "databricks" in profile_type:
-        _wait_for_databricks_cluster(project)
-
-    yield 1
+# Using @pytest.mark.skip_profile('apache_spark') uses the 'skip_by_profile_type'
+# autouse fixture below
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "skip_profile(profile): skip test for the given profile",
+    )

--- a/dbt-spark/tests/functional/fixtures/__init__.py
+++ b/dbt-spark/tests/functional/fixtures/__init__.py
@@ -1,0 +1,2 @@
+from profiles import dbt_profile_target, skip_by_profile_type
+from start_databricks_cluster import start_databricks_cluster

--- a/dbt-spark/tests/functional/fixtures/__init__.py
+++ b/dbt-spark/tests/functional/fixtures/__init__.py
@@ -1,2 +1,2 @@
-from profiles import dbt_profile_target, skip_by_profile_type
-from start_databricks_cluster import start_databricks_cluster
+from tests.functional.fixtures.profiles import dbt_profile_target, skip_by_profile_type
+from tests.functional.fixtures.start_databricks_cluster import start_databricks_cluster

--- a/dbt-spark/tests/functional/fixtures/profiles.py
+++ b/dbt-spark/tests/functional/fixtures/profiles.py
@@ -1,40 +1,35 @@
-import pytest
 import os
 
-pytest_plugins = ["dbt.tests.fixtures.project"]
-
-
-def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="apache_spark", type=str)
-
-
-# Using @pytest.mark.skip_profile('apache_spark') uses the 'skip_by_profile_type'
-# autouse fixture below
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers",
-        "skip_profile(profile): skip test for the given profile",
-    )
+import pytest
 
 
 @pytest.fixture(scope="session")
 def dbt_profile_target(request):
+
+    creds = {
+        "databricks_cluster": databricks_cluster_target,
+        "databricks_sql_endpoint": databricks_sql_endpoint_target,
+        "apache_spark": apache_spark_target,
+        "databricks_http_cluster": databricks_http_cluster_target,
+        "spark_session": spark_session_target,
+        "spark_http_odbc": spark_http_odbc_target,
+    }
+
+    profile = request.config.getoption("--profile")
+
+    try:
+        return creds[profile]()
+    except KeyError:
+        raise ValueError(f"Invalid profile type '{profile}'")
+
+
+@pytest.fixture(autouse=True)
+def skip_by_profile_type(request):
     profile_type = request.config.getoption("--profile")
-    if profile_type == "databricks_cluster":
-        target = databricks_cluster_target()
-    elif profile_type == "databricks_sql_endpoint":
-        target = databricks_sql_endpoint_target()
-    elif profile_type == "apache_spark":
-        target = apache_spark_target()
-    elif profile_type == "databricks_http_cluster":
-        target = databricks_http_cluster_target()
-    elif profile_type == "spark_session":
-        target = spark_session_target()
-    elif profile_type == "spark_http_odbc":
-        target = spark_http_odbc_target()
-    else:
-        raise ValueError(f"Invalid profile type '{profile_type}'")
-    return target
+    if request.node.get_closest_marker("skip_profile"):
+        for skip_profile_type in request.node.get_closest_marker("skip_profile").args:
+            if skip_profile_type == profile_type:
+                pytest.skip(f"skipped on '{profile_type}' profile")
 
 
 def apache_spark_target():
@@ -89,6 +84,7 @@ def databricks_http_cluster_target():
         "token": os.getenv("DBT_DATABRICKS_TOKEN"),
         "method": "http",
         "port": 443,
+        "organization": "0",
         "connect_retries": 3,
         "connect_timeout": 5,
         "retry_all": False,
@@ -116,12 +112,3 @@ def spark_http_odbc_target():
         "connect_timeout": 5,
         "retry_all": True,
     }
-
-
-@pytest.fixture(autouse=True)
-def skip_by_profile_type(request):
-    profile_type = request.config.getoption("--profile")
-    if request.node.get_closest_marker("skip_profile"):
-        for skip_profile_type in request.node.get_closest_marker("skip_profile").args:
-            if skip_profile_type == profile_type:
-                pytest.skip(f"skipped on '{profile_type}' profile")

--- a/dbt-spark/tests/functional/fixtures/profiles.py
+++ b/dbt-spark/tests/functional/fixtures/profiles.py
@@ -7,12 +7,12 @@ import pytest
 def dbt_profile_target(request):
 
     creds = {
-        "databricks_cluster": databricks_cluster_target,
-        "databricks_sql_endpoint": databricks_sql_endpoint_target,
         "apache_spark": apache_spark_target,
-        "databricks_http_cluster": databricks_http_cluster_target,
-        "spark_session": spark_session_target,
         "spark_http_odbc": spark_http_odbc_target,
+        "spark_session": spark_session_target,
+        "databricks_cluster": databricks_cluster_target,
+        "databricks_http_cluster": databricks_http_cluster_target,
+        "databricks_sql_endpoint": databricks_sql_endpoint_target,
     }
 
     profile = request.config.getoption("--profile")
@@ -84,7 +84,6 @@ def databricks_http_cluster_target():
         "token": os.getenv("DBT_DATABRICKS_TOKEN"),
         "method": "http",
         "port": 443,
-        "organization": "0",
         "connect_retries": 3,
         "connect_timeout": 5,
         "retry_all": False,

--- a/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
+++ b/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
@@ -11,7 +11,7 @@ except ImportError:
 
 from dbt.adapters.spark.connections import SparkConnectionManager
 
-from .profiles import databricks_http_cluster_target
+from tests.functional.fixtures.profiles import databricks_http_cluster_target
 
 
 # Running this should prevent tests from needing to be retried because the Databricks cluster isn't available

--- a/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
+++ b/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
@@ -38,12 +38,12 @@ def _wait_for_databricks_cluster():
     """
     cursor = _cursor()
 
-    for _ in range(60):
+    for _ in range(20):
         try:
             cursor.execute("SELECT 1", async_=False)
             return
         except Exception:
-            sleep(10)
+            sleep(30)
 
     raise Exception("Databricks cluster did not start in time")
 

--- a/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
+++ b/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
@@ -1,0 +1,61 @@
+import base64
+import time
+
+import pytest
+
+try:
+    from pyhive import hive
+    from thrift.transport import THttpClient
+except ImportError:
+    pass
+
+from dbt.adapters.spark.connections import SparkConnectionManager
+
+from .profiles import databricks_http_cluster_target
+
+
+# Running this should prevent tests from needing to be retried because the Databricks cluster isn't available
+@pytest.fixture(scope="session", autouse=True)
+def start_databricks_cluster(request):
+
+    profile = request.config.getoption("--profile")
+
+    if profile == "databricks_http_cluster":
+        _wait_for_databricks_cluster()
+
+    yield
+
+
+def _wait_for_databricks_cluster():
+    """
+    It takes roughly 3-5 minutes for the cluster to start, to be safe we'll wait for 10 minutes
+    """
+    cursor = _cursor()
+
+    for _ in range(60):
+        try:
+            cursor.execute("SELECT 1", async_=False)
+            return
+        except Exception:
+            time.sleep(10)
+
+    raise Exception("Databricks cluster did not start in time")
+
+
+def _cursor():
+    creds = databricks_http_cluster_target()
+
+    conn_url = SparkConnectionManager.SPARK_CONNECTION_URL.format(
+        host=creds.host,
+        port=creds.port,
+        organization=creds.organization,
+        cluster=creds.cluster,
+    )
+
+    transport = THttpClient.THttpClient(conn_url)
+    raw_token = f"token:{creds.token}".encode()
+    token = base64.standard_b64encode(raw_token).decode()
+    transport.setCustomHeaders({"Authorization": f"Basic {token}"})
+
+    conn = hive.connect(thrift_transport=transport)
+    return conn.cursor()

--- a/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
+++ b/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
@@ -13,7 +13,7 @@ except ImportError:
 from dbt.adapters.spark.connections import SparkConnectionManager
 
 
-HOST = getenv("DBT_DATABRICKS_HOST_NAME")
+HOST = "https://" + getenv("DBT_DATABRICKS_HOST_NAME")
 CLUSTER = getenv("DBT_DATABRICKS_CLUSTER_NAME")
 TOKEN = getenv("DBT_DATABRICKS_TOKEN")
 PORT = 443

--- a/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
+++ b/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
@@ -46,14 +46,14 @@ def _cursor():
     creds = databricks_http_cluster_target()
 
     conn_url = SparkConnectionManager.SPARK_CONNECTION_URL.format(
-        host=creds.host,
-        port=creds.port,
-        organization=creds.organization,
-        cluster=creds.cluster,
+        host=creds["host"],
+        port=creds["port"],
+        organization=creds["organization"],
+        cluster=creds["cluster"],
     )
 
     transport = THttpClient.THttpClient(conn_url)
-    raw_token = f"token:{creds.token}".encode()
+    raw_token = f"token:{creds['token']}".encode()
     token = base64.standard_b64encode(raw_token).decode()
     transport.setCustomHeaders({"Authorization": f"Basic {token}"})
 


### PR DESCRIPTION
We need to ensure the databricks cluster is ready before running tests. The current method requires the `project` fixture, which makes a call to create a test schema. This call would also need to wait, so we cannot rely on the `project` fixture.

Instead, we will vendor some of the connection functionality and use non-dbt methods to call the cluster directly.

While doing this work, I moved some fixtures around to make them a bit more organized as well as scope them appropriately. Specifically, I moved all of the profile fixtures to the functional tests level so they don't run as part of unit tests. I also put these fixtures in a separate module to remove noise from co-locating them with the databricks start-up fixture.

I added an `__init__.py` file in the functional tests directory to assist with test discovery. Omitting this creates the potential for name collisions, which we traditionally handle by prefixing additional quantifiers everywhere.