### PR TITLE
ADAP-1235: Fix test_persist_docs missing column test

### DIFF
--- a/dbt-spark/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/dbt-spark/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -168,4 +168,3 @@ class TestPersistDocsMissingColumn:
                 "Missing field name in table" in res[0].message,
             ]
         )
-        assert "name `name` cannot be resolve" in res[0].message

--- a/dbt-spark/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/dbt-spark/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -162,5 +162,8 @@ class TestPersistDocsMissingColumn:
         """
         run_dbt(["seed"])
         res = run_dbt(["run"], expect_pass=False)
-        assert any("[UNRESOLVED_COLUMN.WITH_SUGGESTION]" in res[0].message, "Missing field name in table" in res[0].message)
+        assert any(
+            "[UNRESOLVED_COLUMN.WITH_SUGGESTION]" in res[0].message,
+            "Missing field name in table" in res[0].message,
+        )
         assert "name `name` cannot be resolve" in res[0].message

--- a/dbt-spark/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/dbt-spark/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -150,7 +150,17 @@ class TestPersistDocsMissingColumn:
         return {"schema.yml": _PROPERTIES__MODELS}
 
     def test_missing_column(self, project):
-        """spark will use our schema to verify all columns exist rather than fail silently"""
+        """
+        spark will use our schema to verify all columns exist rather than fail silently
+
+        "resolve" vs "resolved" is intentional; example error message:
+            ('42000', '[42000] [Simba][Hardy] (80) Syntax or semantic analysis error thrown in server while executing query.
+            Error message from server:
+                org.apache.hive.service.cli.HiveSQLException: Error running query: [UNRESOLVED_COLUMN.WITH_SUGGESTION]
+                org.apache.spark.sql.AnalysisException: [UNRESOLVED_COLUMN.WITH_SUGGESTION] A column, variable, or function parameter with name `name` cannot be resolve (80) (SQLExecDirectW)'
+            )
+        """
         run_dbt(["seed"])
         res = run_dbt(["run"], expect_pass=False)
-        assert "Missing field name in table" in res[0].message
+        assert "[UNRESOLVED_COLUMN.WITH_SUGGESTION]" in res[0].message
+        assert "name `name` cannot be resolve" in res[0].message

--- a/dbt-spark/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/dbt-spark/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -162,5 +162,5 @@ class TestPersistDocsMissingColumn:
         """
         run_dbt(["seed"])
         res = run_dbt(["run"], expect_pass=False)
-        assert "[UNRESOLVED_COLUMN.WITH_SUGGESTION]" in res[0].message
+        assert any("[UNRESOLVED_COLUMN.WITH_SUGGESTION]" in res[0].message, "Missing field name in table" in res[0].message)
         assert "name `name` cannot be resolve" in res[0].message

--- a/dbt-spark/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/dbt-spark/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -163,7 +163,9 @@ class TestPersistDocsMissingColumn:
         run_dbt(["seed"])
         res = run_dbt(["run"], expect_pass=False)
         assert any(
-            "[UNRESOLVED_COLUMN.WITH_SUGGESTION]" in res[0].message,
-            "Missing field name in table" in res[0].message,
+            [
+                "[UNRESOLVED_COLUMN.WITH_SUGGESTION]" in res[0].message,
+                "Missing field name in table" in res[0].message,
+            ]
         )
         assert "name `name` cannot be resolve" in res[0].message


### PR DESCRIPTION
We are looking for a specific string in the exception that Spark throws. It looks like that description has changed but the exception is the same. This just updates what we expect.