### PR TITLE
[Redshift] Properly quote column names in DDL for add and drop

### DIFF
--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
@@ -308,7 +308,7 @@
 
     {% for column in add_columns %}
       {% set sql -%}
-          alter {{ relation.type }} {{ relation }} add column {{ column.name }} {{ column.data_type }}
+          alter {{ relation.type }} {{ relation }} add column {{ adapter.quote(column.name) }} {{ column.data_type }}
       {% endset %}
       {% do run_query(sql) %}
     {% endfor %}
@@ -319,7 +319,7 @@
 
     {% for column in remove_columns %}
       {% set sql -%}
-          alter {{ relation.type }} {{ relation }} drop column {{ column.name }}
+          alter {{ relation.type }} {{ relation }} drop column {{ adapter.quote(column.name) }}
       {% endset %}
       {% do run_query(sql) %}
     {% endfor %}


### PR DESCRIPTION
resolves #841 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#N/A

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

dbt run fails on incremental models if a column in a table that is not in the model's column list has a name that begins with a question mark

### Solution

This PR uses `adapter.quote` to properly quote column names in add column and drop column statements. 

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
