### PR TITLE
ADAP-1233: Wait for databricks to start up

### DIFF
--- a/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
+++ b/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
@@ -7,6 +7,7 @@ import pytest
 try:
     from pyhive import hive
     from thrift.transport.THttpClient import THttpClient
+    from thrift.Thrift import TApplicationException
 except ImportError:
     pass
 
@@ -32,23 +33,22 @@ def start_databricks_cluster(request):
     yield
 
 
-def _wait_for_databricks_cluster():
+def _wait_for_databricks_cluster() -> None:
     """
     It takes roughly 3-5 minutes for the cluster to start, to be safe we'll wait for 10 minutes
     """
-    cursor = _cursor()
+    transport_client = _transport_client()
 
     for _ in range(20):
         try:
-            cursor.execute("SELECT 1", async_=False)
-            return
-        except Exception:
+            hive.connect(thrift_transport=transport_client)
+        except TApplicationException:
             sleep(30)
 
     raise Exception("Databricks cluster did not start in time")
 
 
-def _cursor():
+def _transport_client():
     conn_url = SparkConnectionManager.SPARK_CONNECTION_URL.format(
         host=HOST,
         cluster=CLUSTER,
@@ -56,10 +56,8 @@ def _cursor():
         organization=ORGANIZATION,
     )
 
-    transport = THttpClient(conn_url)
+    transport_client = THttpClient(conn_url)
     raw_token = f"token:{TOKEN}".encode()
     token = standard_b64encode(raw_token).decode()
-    transport.setCustomHeaders({"Authorization": f"Basic {token}"})
-
-    conn = hive.connect(thrift_transport=transport)
-    return conn.cursor()
+    transport_client.setCustomHeaders({"Authorization": f"Basic {token}"})
+    return transport_client

--- a/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
+++ b/dbt-spark/tests/functional/fixtures/start_databricks_cluster.py
@@ -42,6 +42,7 @@ def _wait_for_databricks_cluster() -> None:
     for _ in range(20):
         try:
             hive.connect(thrift_transport=transport_client)
+            return
         except TApplicationException:
             sleep(30)
 


### PR DESCRIPTION
The `hive.connect` call fails when the cluster is not available. We need to move that inside the try block to catch the temporarily unavailable error. We can also remove the `select 1` sql since it' no longer needed.