### PR TITLE
Feature/dbt snowflake/connection_name parameter support

### DIFF
--- a/dbt-snowflake/tests/functional/auth_tests/test_connection_name.py
+++ b/dbt-snowflake/tests/functional/auth_tests/test_connection_name.py
@@ -1,0 +1,51 @@
+"""
+Create a connections.toml file at ~/.snowflake/connections.toml
+or you can specify a different folder using env variable SNOWFLAKE_HOME.
+
+The file should have an entry similar to the following
+with your credentials. Any type of authentication can be used.
+
+[default]
+user = "test_user"
+warehouse = "test_warehouse"
+database = "test_database"
+schema = "test_schema"
+role = "test_role"
+password = "test_password"
+authenticator = "snowflake"
+
+You can name you connection something other than "default" by also setting
+the SNOWFLAKE_DEFAULT_CONNECTION_NAME environment variable.
+
+On Linux and Mac OS you will need to set the following
+permissions on your connections.toml or you will receive an error.
+
+chown $USER ~/.snowflake/connections.toml
+chmod 0600 ~/.snowflake/connections.toml
+
+"""
+
+import os
+
+from dbt.tests.util import run_dbt
+import pytest
+
+
+class TestConnectionName:
+    @pytest.fixture(scope="class", autouse=True)
+    def dbt_profile_target(self):
+        return {
+            "type": "snowflake",
+            "threads": 4,
+            "account": os.getenv("SNOWFLAKE_TEST_ACCOUNT"),
+            "database": os.getenv("SNOWFLAKE_TEST_DATABASE"),
+            "warehouse": os.getenv("SNOWFLAKE_TEST_WAREHOUSE"),
+            "connection_name": os.getenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME", "default"),
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_model.sql": "select 1 as id"}
+
+    def test_connection(self, project):
+        run_dbt()


### PR DESCRIPTION
resolves #684

### Problem

Snowflake now supports a `connection_name` parameter and a `connections.toml` file with connection parameters. dbt does not currently support this feature. One of the advantages of the `connections.toml` is that it can leverage new snowflake features as they are introduced without requiring any direct changes in dbt. 

[Additional information on this parameter and the connections.toml file are available in the Snowflake documentation.](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#connecting-using-the-connections-toml-file)

Essentially, by adding the `connection_name` parameter, dbt can avoid having to promptly implement most new parameters in the future.  This change is also far less invasive and much easier to test than attempting to support all the individual authentication parameters supported by the Snowflake Python Connector. Testers won't need to test every individual parameter, just that dbt is able to pass the `connection_name` parameter to the Snowflake driver and that the driver is able to pick up parameters from the connections.toml that are not specified in the profile.yml. Those parameters can be as simple as a Snowflake password or the parameters for key pair authentication.

WIthout this change, features such as the `token_file_path` parameter cannot be used with dbt. That feature is important to Snowflake customers who wish to deploy dbt in a Snowpark Container and is the original reason I opened the issue. More importantly though, Snowflake frequently adds new parameters. You can see the current list, which is far longer than dbt supports, in the [Snowflake connection.py script](https://github.com/snowflakedb/snowflake-connector-python/blob/main/src/snowflake/connector/connection.py#L324), on lines 325-381.

### Solution

The only changes necessary are in the dbt-snowflake `connections.py` script. In three places, we just add the `connection_name` parameter the same as any other parameter. Then, I also updated the `__post_init__` method to not perform as many checks on the authentication parameters when the `connection_name` is specified. This allows us to skip entering passwords or key pair details in dbt when we will instead put these settings in the connections.toml.

### Testing
I have provided a `test_connection_name.py` unit test in the PR. I have tested a number of different parameters with my connections.toml and they are all picked up. I believe it is sufficient to test that dbt can pick up a simple parameter like `password`. Beyond that, the Snowflake developers will be responsible to test all the possible values for the connections.toml.

#### These are the instructions to test the feature, adapted from unit test script:

- Create a `connections.toml` file at `~/.snowflake/connections.toml` or you can specify a different folder using env variable `SNOWFLAKE_HOME`. You don't have to reference this location in dbt because the Snowflake driver will pick up this environment variable.

- The file should have an entry similar to the following with your credentials. Any type of authentication can be used.
```toml
[default]
user = "test_user"
warehouse = "test_warehouse"
database = "test_database"
schema = "test_schema"
role = "test_role"
password = "test_password"
authenticator = "snowflake"
```

- On Linux and Mac OS you will need to set the following permissions on your connections.toml or you will receive an error.
```bash
chown $USER ~/.snowflake/connections.toml
chmod 0600 ~/.snowflake/connections.toml
```
- Specify your `connection_name` parameter in your `profiles.yml` config
- Take out settings like `password`, `private_key_path`, or `private_key_passphrase` from your `profiles.yml` config
- Test executing `dbt debug` and it will use the the credentials you added to the `connections.toml` to connect to Snowflake. As expected, you will not see these credentials in the output of `dbt debug` but you will see the value of the `connection_name` parameter.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
