### PR TITLE
port over PR.

### DIFF
--- a/dbt-spark/.changes/unreleased/Fixes-20250228-073629.yaml
+++ b/dbt-spark/.changes/unreleased/Fixes-20250228-073629.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Stop adding aliases to render_limited output for --empty
+time: 2025-02-28T07:36:29.779607-08:00
+custom:
+    Author: anaghshineh versusfacit
+    Issue: "474"

--- a/dbt-spark/src/dbt/adapters/spark/relation.py
+++ b/dbt-spark/src/dbt/adapters/spark/relation.py
@@ -35,6 +35,7 @@ class SparkRelation(BaseRelation):
     is_iceberg: Optional[bool] = None
     # TODO: make this a dict everywhere
     information: Optional[str] = None
+    require_alias: bool = False
 
     def __post_init__(self) -> None:
         if self.database != self.schema and self.database:

--- a/dbt-spark/tests/functional/adapter/empty/test_empty.py
+++ b/dbt-spark/tests/functional/adapter/empty/test_empty.py
@@ -1,4 +1,4 @@
-from dbt.tests.adapter.empty.test_empty import BaseTestEmpty
+from dbt.tests.adapter.empty.test_empty import BaseTestEmpty, BaseTestEmptyInlineSourceRef
 
 
 class TestSparkEmpty(BaseTestEmpty):

--- a/dbt-spark/tests/functional/adapter/empty/test_empty.py
+++ b/dbt-spark/tests/functional/adapter/empty/test_empty.py
@@ -3,3 +3,7 @@ from dbt.tests.adapter.empty.test_empty import BaseTestEmpty
 
 class TestSparkEmpty(BaseTestEmpty):
     pass
+
+
+class TestSparkEmptyInlineSourceRef(BaseTestEmptyInlineSourceRef):
+    pass


### PR DESCRIPTION
I researched this and things do look solid. I made sure as well this won't break anyone. I can't think of a case where this change of behavior will since I don't know who will be using the render limited _dbt specific aliases

resolves #474 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

More an oversight than anything. Subqueries in Spark don't require subqueries.

### Solution

So, let's turn them off for render limited. That way `--empty` works.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
