### PR TITLE
SRE-1546: Setting CI Visibility key to Main DD Account

### DIFF
--- a/.github/workflows/_integration-tests.yml
+++ b/.github/workflows/_integration-tests.yml
@@ -53,7 +53,7 @@ permissions:
 env:
     DBT_INVOCATION_ENV: ${{ vars.DBT_INVOCATION_ENV }}
     DD_CIVISIBILITY_AGENTLESS_ENABLED: ${{ vars.DD_CIVISIBILITY_AGENTLESS_ENABLED }}
-    DD_API_KEY: ${{ secrets.DD_API_KEY }}
+    DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}
     DD_SITE: ${{ vars.DD_SITE }}
     DD_ENV: ${{ vars.DD_ENV }}
     DD_SERVICE: ${{ github.event.repository.name }}  # this can change per run because of forks


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
Datadog staging has been migrated over to the Main Datadog account. A new and standardized API key for CI Visibility in Datadog has been created in PR: https://github.com/dbt-labs/terraform-datadog/pull/1782

We will need to cutover from the staging account to the main Datadog account.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
This PR updates the secret that contains the Main account generated Datadog API key.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
