### PR TITLE
Remove type-checking dependencies from build requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,4 @@ repos:
         -   types-python-dateutil
         -   types-pytz
         -   types-requests
+        -   boto3-stubs[athena,glue,lakeformation,sts]

--- a/dbt-athena/pyproject.toml
+++ b/dbt-athena/pyproject.toml
@@ -32,7 +32,6 @@ dependencies=[
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
     "dbt-core>=1.8.0",
     "boto3>=1.28",
-    "boto3-stubs[athena,glue,lakeformation,sts]>=1.28",
     "mmh3>=4.0.1,<4.2.0",
     "pyathena>=2.25,<4.0",
     "pydantic>=1.10,<3.0",


### PR DESCRIPTION
Type stubs should be listed in `.pre-commit-config.yaml`, not in build requirements.