### PR TITLE
Issue a warning for dbt-athena-community users to point them towards dbt-athena

### DIFF
--- a/dbt-athena-community/src/dbt/adapters/athena_community/__init__.py
+++ b/dbt-athena-community/src/dbt/adapters/athena_community/__init__.py
@@ -1,1 +1,7 @@
 # this is a shell package that allows us to publish dbt-athena as dbt-athena-community
+import warnings
+
+warnings.warn(
+    "dbt-athena-community will be deprecated in favor of dbt-athena following version 1.9.x. To continue using new features, please run `pip install dbt-athena` instead.",
+    DeprecationWarning,
+)

--- a/dbt-athena/.changes/unreleased/Under the Hood-20250305-184206.yaml
+++ b/dbt-athena/.changes/unreleased/Under the Hood-20250305-184206.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Issue a warning to dbt-athena-community users to migrate to dbt-athena
+time: 2025-03-05T18:42:06.109752-05:00
+custom:
+  Author: mikealfare
+  Issue: "879"


### PR DESCRIPTION
We will no longer support `dbt-athena-community` post-1.9.x. This package will continue to be supported under `dbt-athena`; it was migrated in the 1.8.x series.