### PR TITLE
Raise deprecation warning for dbt-athena-community

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,6 @@ repos:
         -   --namespace-packages
         -   --ignore-missing-imports
         -   --warn-redundant-casts
-        -   --warn-unused-ignores
         -   --pretty
         -   --show-error-codes
         additional_dependencies:

--- a/dbt-athena-community/src/dbt/adapters/athena_community/__init__.py
+++ b/dbt-athena-community/src/dbt/adapters/athena_community/__init__.py
@@ -1,1 +1,7 @@
 # this is a shell package that allows us to publish dbt-athena as dbt-athena-community
+import warnings
+
+warnings.warn(
+    "dbt-athena-community will be deprecated in favor of dbt-athena following version 1.9.x. To continue using new features, please run `pip install dbt-athena` instead.",
+    DeprecationWarning,
+)

--- a/dbt-athena-community/src/dbt/adapters/athena_community/__init__.py
+++ b/dbt-athena-community/src/dbt/adapters/athena_community/__init__.py
@@ -1,7 +1,1 @@
 # this is a shell package that allows us to publish dbt-athena as dbt-athena-community
-import warnings
-
-warnings.warn(
-    "dbt-athena-community will be deprecated in favor of dbt-athena following version 1.9.x. To continue using new features, please run `pip install dbt-athena` instead.",
-    DeprecationWarning,
-)

--- a/dbt-athena/.changes/unreleased/Under the Hood-20250305-184206.yaml
+++ b/dbt-athena/.changes/unreleased/Under the Hood-20250305-184206.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Issue a warning to dbt-athena-community users to migrate to dbt-athena
+time: 2025-03-05T18:42:06.109752-05:00
+custom:
+  Author: mikealfare
+  Issue: "879"

--- a/dbt-athena/src/dbt/adapters/athena/__init__.py
+++ b/dbt-athena/src/dbt/adapters/athena/__init__.py
@@ -15,3 +15,19 @@ __all__ = [
     "AthenaAdapter",
     "Plugin",
 ]
+
+
+# check to see if this package was imported indirectly via dbt-athena-community
+try:
+    # if this is successful, raise a warning to point users to use this package directly
+    import dbt.adapters.athena_community
+    import warnings
+
+    warnings.warn(
+        "dbt-athena-community will be deprecated in favor of dbt-athena following version 1.9.x. To continue using new features, please run `pip install dbt-athena` instead.",
+        DeprecationWarning,
+    )
+
+except ImportError:
+    # if the import was unsuccessful, dbt-athena was installed directly, which is the desired state
+    pass


### PR DESCRIPTION
We are pulling support for the backwards compatibility associated with `dbt-athena-community` after the `1.9` support cycle. Users will need to install `dbt-athena` directly for `1.10` and beyond. This will raise a warning if users are installing `dbt-athena` via `dbt-athena-community`.