### PR TITLE
Revert repo versions to allow for proper version bump

### DIFF
--- a/.github/workflows/publish-oss.yml
+++ b/.github/workflows/publish-oss.yml
@@ -146,5 +146,5 @@ jobs:
         with:
             package: ${{ inputs.package }}
             branch: ${{ inputs.branch }}
-            version: "patch,dev"  # dbt-core checks for semver, which does not support post releases
+            version: "patch,alpha"  # dbt-core checks for semver, which does not support post releases
         secrets: inherit

--- a/.github/workflows/publish-oss.yml
+++ b/.github/workflows/publish-oss.yml
@@ -139,12 +139,3 @@ jobs:
                 retry_wait_seconds: 10
                 max_attempts: 15  # 5 minutes: (10s timeout + 10s delay) * 15 attempts
                 command: wget ${{ vars.PYPI_PROJECT_URL }}/dbt-athena-community/${{ steps.version.outputs.version }}
-
-    bump-version-post:
-        needs: publish
-        uses: ./.github/workflows/_bump-version.yml
-        with:
-            package: ${{ inputs.package }}
-            branch: ${{ inputs.branch }}
-            version: "patch,alpha"  # dbt-core checks for semver, which does not support post releases
-        secrets: inherit

--- a/.github/workflows/publish-oss.yml
+++ b/.github/workflows/publish-oss.yml
@@ -146,5 +146,5 @@ jobs:
         with:
             package: ${{ inputs.package }}
             branch: ${{ inputs.branch }}
-            version: "post"
+            version: "patch,dev"  # dbt-core checks for semver, which does not support post releases
         secrets: inherit

--- a/.github/workflows/publish-oss.yml
+++ b/.github/workflows/publish-oss.yml
@@ -139,3 +139,12 @@ jobs:
                 retry_wait_seconds: 10
                 max_attempts: 15  # 5 minutes: (10s timeout + 10s delay) * 15 attempts
                 command: wget ${{ vars.PYPI_PROJECT_URL }}/dbt-athena-community/${{ steps.version.outputs.version }}
+
+    bump-version-post:
+        needs: publish
+        uses: ./.github/workflows/_bump-version.yml
+        with:
+            package: ${{ inputs.package }}
+            branch: ${{ inputs.branch }}
+            version: "post"
+        secrets: inherit

--- a/dbt-adapters/src/dbt/adapters/__about__.py
+++ b/dbt-adapters/src/dbt/adapters/__about__.py
@@ -1,1 +1,1 @@
-version = "1.14.1"
+version = "1.14.1.post0"

--- a/dbt-adapters/src/dbt/adapters/__about__.py
+++ b/dbt-adapters/src/dbt/adapters/__about__.py
@@ -1,1 +1,1 @@
-version = "1.14.1.post0"
+version = "1.14.2.dev0"

--- a/dbt-adapters/src/dbt/adapters/__about__.py
+++ b/dbt-adapters/src/dbt/adapters/__about__.py
@@ -1,1 +1,1 @@
-version = "1.14.2.dev0"
+version = "1.14.2a0"

--- a/dbt-athena-community/pyproject.toml
+++ b/dbt-athena-community/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 # these versions should always match and they both should match the local version of dbt-athena
-dependencies = ["dbt-athena==1.9.1.post0"]
-version = "1.9.1.post0"
+dependencies = ["dbt-athena==1.9.2.dev0"]
+version = "1.9.2.dev0"
 [project.urls]
 Homepage = "https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-athena"
 Documentation = "https://docs.getdbt.com"

--- a/dbt-athena-community/pyproject.toml
+++ b/dbt-athena-community/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 # these versions should always match and they both should match the local version of dbt-athena
-dependencies = ["dbt-athena==1.9.1"]
-version = "1.9.1"
+dependencies = ["dbt-athena==1.9.1.post0"]
+version = "1.9.1.post0"
 [project.urls]
 Homepage = "https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-athena"
 Documentation = "https://docs.getdbt.com"

--- a/dbt-athena-community/pyproject.toml
+++ b/dbt-athena-community/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 # these versions should always match and they both should match the local version of dbt-athena
-dependencies = ["dbt-athena==1.9.2.dev0"]
-version = "1.9.2.dev0"
+dependencies = ["dbt-athena==1.9.2a0"]
+version = "1.9.2a0"
 [project.urls]
 Homepage = "https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-athena"
 Documentation = "https://docs.getdbt.com"

--- a/dbt-athena/src/dbt/adapters/athena/__version__.py
+++ b/dbt-athena/src/dbt/adapters/athena/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.1"
+version = "1.9.1.post0"

--- a/dbt-athena/src/dbt/adapters/athena/__version__.py
+++ b/dbt-athena/src/dbt/adapters/athena/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.2.dev0"
+version = "1.9.2a0"

--- a/dbt-athena/src/dbt/adapters/athena/__version__.py
+++ b/dbt-athena/src/dbt/adapters/athena/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.1.post0"
+version = "1.9.2.dev0"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/__version__.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.2.dev0"
+version = "1.9.2a0"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/__version__.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.1.post0"
+version = "1.9.2.dev0"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/__version__.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/__version__.py
@@ -1,1 +1,1 @@
-version = "1.10.0a1"
+version = "1.9.1.post0"

--- a/dbt-postgres/src/dbt/adapters/postgres/__version__.py
+++ b/dbt-postgres/src/dbt/adapters/postgres/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.0.post0"
+version = "1.9.1.dev0"

--- a/dbt-postgres/src/dbt/adapters/postgres/__version__.py
+++ b/dbt-postgres/src/dbt/adapters/postgres/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.0"
+version = "1.9.0.post0"

--- a/dbt-postgres/src/dbt/adapters/postgres/__version__.py
+++ b/dbt-postgres/src/dbt/adapters/postgres/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.1.dev0"
+version = "1.9.1a0"

--- a/dbt-redshift/src/dbt/adapters/redshift/__version__.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.0.post0"
+version = "1.9.1.dev0"

--- a/dbt-redshift/src/dbt/adapters/redshift/__version__.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/__version__.py
@@ -1,1 +1,1 @@
-version = "1.10.0a1"
+version = "1.9.0.post0"

--- a/dbt-redshift/src/dbt/adapters/redshift/__version__.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.1.dev0"
+version = "1.9.1a0"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/__version__.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.2.dev0"
+version = "1.9.2a0"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/__version__.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.1.post0"
+version = "1.9.2.dev0"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/__version__.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/__version__.py
@@ -1,1 +1,1 @@
-version = "1.10.0a1"
+version = "1.9.1.post0"

--- a/dbt-spark/src/dbt/adapters/spark/__version__.py
+++ b/dbt-spark/src/dbt/adapters/spark/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.2.dev0"
+version = "1.9.2a0"

--- a/dbt-spark/src/dbt/adapters/spark/__version__.py
+++ b/dbt-spark/src/dbt/adapters/spark/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.1.post0"
+version = "1.9.2.dev0"

--- a/dbt-spark/src/dbt/adapters/spark/__version__.py
+++ b/dbt-spark/src/dbt/adapters/spark/__version__.py
@@ -1,1 +1,1 @@
-version = "1.10.0a1"
+version = "1.9.1.post0"

--- a/dbt-tests-adapter/src/dbt/tests/__about__.py
+++ b/dbt-tests-adapter/src/dbt/tests/__about__.py
@@ -1,1 +1,1 @@
-version = "1.11.1.dev0"
+version = "1.11.1a0"

--- a/dbt-tests-adapter/src/dbt/tests/__about__.py
+++ b/dbt-tests-adapter/src/dbt/tests/__about__.py
@@ -1,1 +1,1 @@
-version = "1.11.0.post0"
+version = "1.11.1.dev0"

--- a/dbt-tests-adapter/src/dbt/tests/__about__.py
+++ b/dbt-tests-adapter/src/dbt/tests/__about__.py
@@ -1,1 +1,1 @@
-version = "1.11.0"
+version = "1.11.0.post0"


### PR DESCRIPTION
We pushed all of the versions up to `1.10.0a1` after the last OSS release. However, we are patching some of those versions now, and would need to roll back the version to use the standard version bump process. Instead of going from `1.9.2`, for example, to `1.10.0a1`, we should have gone to `1.9.2a0`. This would have allowed us to choose whether the next release was a patch or a minor instead of being locked into minor.