### PR TITLE
Update internal publishing to use a separate environment

### DIFF
--- a/.github/workflows/_publish-internal.yml
+++ b/.github/workflows/_publish-internal.yml
@@ -44,7 +44,7 @@ jobs:
     publish:
         runs-on: ${{ vars.DEFAULT_RUNNER }}
         environment:
-            name: "prod"
+            name: "cloud-prod"
         steps:
         -   uses: actions/checkout@v4
             with:


### PR DESCRIPTION
This environment does not require approval, which supports fully automating internal releases. We should remove the internal release secrets from the other environment when we're comfortable with this process to avoid duplicating secrets (and updating them).