### PR TITLE
Allow configuring the format of EventTimeFilter

### DIFF
--- a/dbt-adapters/.changes/unreleased/Features-20250308-190612.yaml
+++ b/dbt-adapters/.changes/unreleased/Features-20250308-190612.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Allow configuring the format of EventTimeFilter
+time: 2025-03-08T19:06:12.577376+09:00
+custom:
+    Author: logicoffee
+    Issue: "11331"

--- a/dbt-adapters/src/dbt/adapters/base/relation.py
+++ b/dbt-adapters/src/dbt/adapters/base/relation.py
@@ -41,8 +41,21 @@ SerializableIterable = Union[Tuple, FrozenSet]
 @dataclass
 class EventTimeFilter(FakeAPIObject):
     field_name: str
+    filter_format: str = "%Y-%m-%d %H:%M:%S%z"
     start: Optional[datetime] = None
     end: Optional[datetime] = None
+
+    @property
+    def start_time_formatted(self) -> Optional[str]:
+        if self.start is None:
+            return None
+        return self.start.strftime(self.filter_format)
+
+    @property
+    def end_time_formatted(self) -> Optional[str]:
+        if self.end is None:
+            return None
+        return self.end.strftime(self.filter_format)
 
 
 @dataclass(frozen=True, eq=False, repr=False)
@@ -256,12 +269,14 @@ class BaseRelation(FakeAPIObject, Hashable):
         Returns "" if start and end are both None
         """
         filter = ""
-        if event_time_filter.start and event_time_filter.end:
-            filter = f"{event_time_filter.field_name} >= '{event_time_filter.start}' and {event_time_filter.field_name} < '{event_time_filter.end}'"
-        elif event_time_filter.start:
-            filter = f"{event_time_filter.field_name} >= '{event_time_filter.start}'"
-        elif event_time_filter.end:
-            filter = f"{event_time_filter.field_name} < '{event_time_filter.end}'"
+        if event_time_filter.start_time_formatted and event_time_filter.end_time_formatted:
+            filter = f"{event_time_filter.field_name} >= '{event_time_filter.start_time_formatted}' and {event_time_filter.field_name} < '{event_time_filter.end_time_formatted}'"
+        elif event_time_filter.start_time_formatted:
+            filter = (
+                f"{event_time_filter.field_name} >= '{event_time_filter.start_time_formatted}'"
+            )
+        elif event_time_filter.end_time_formatted:
+            filter = f"{event_time_filter.field_name} < '{event_time_filter.end_time_formatted}'"
 
         return filter
 

--- a/dbt-adapters/src/dbt/adapters/base/relation.py
+++ b/dbt-adapters/src/dbt/adapters/base/relation.py
@@ -41,7 +41,7 @@ SerializableIterable = Union[Tuple, FrozenSet]
 @dataclass
 class EventTimeFilter(FakeAPIObject):
     field_name: str
-    filter_format: str = "%Y-%m-%d %H:%M:%S%z"
+    filter_format: Optional[str] = None
     start: Optional[datetime] = None
     end: Optional[datetime] = None
 
@@ -49,12 +49,16 @@ class EventTimeFilter(FakeAPIObject):
     def start_time_formatted(self) -> Optional[str]:
         if self.start is None:
             return None
+        if self.filter_format is None:
+            return str(self.start)
         return self.start.strftime(self.filter_format)
 
     @property
     def end_time_formatted(self) -> Optional[str]:
         if self.end is None:
             return None
+        if self.filter_format is None:
+            return str(self.end)
         return self.end.strftime(self.filter_format)
 
 

--- a/dbt-adapters/tests/unit/test_relation.py
+++ b/dbt-adapters/tests/unit/test_relation.py
@@ -103,6 +103,15 @@ def test_render_limited(limit, require_alias, expected_result):
             """(select * from "test_database"."test_schema"."test_identifier" where column >= '2020-01-01 00:00:00')""",
         ),
         (
+            EventTimeFilter(
+                field_name="column",
+                start=datetime(year=2020, month=1, day=1),
+                filter_format="%Y-%m-%d",
+            ),
+            False,
+            """(select * from "test_database"."test_schema"."test_identifier" where column >= '2020-01-01')""",
+        ),
+        (
             EventTimeFilter(field_name="column", start=datetime(year=2020, month=1, day=1)),
             True,
             """(select * from "test_database"."test_schema"."test_identifier" where column >= '2020-01-01 00:00:00') _dbt_et_filter_subq_test_identifier""",
@@ -115,11 +124,30 @@ def test_render_limited(limit, require_alias, expected_result):
         (
             EventTimeFilter(
                 field_name="column",
+                end=datetime(year=2020, month=1, day=1),
+                filter_format="%Y-%m-%d",
+            ),
+            False,
+            """(select * from "test_database"."test_schema"."test_identifier" where column < '2020-01-01')""",
+        ),
+        (
+            EventTimeFilter(
+                field_name="column",
                 start=datetime(year=2020, month=1, day=1),
                 end=datetime(year=2020, month=1, day=2),
             ),
             False,
             """(select * from "test_database"."test_schema"."test_identifier" where column >= '2020-01-01 00:00:00' and column < '2020-01-02 00:00:00')""",
+        ),
+        (
+            EventTimeFilter(
+                field_name="column",
+                start=datetime(year=2020, month=1, day=1),
+                end=datetime(year=2020, month=1, day=2),
+                filter_format="%Y-%m-%d",
+            ),
+            False,
+            """(select * from "test_database"."test_schema"."test_identifier" where column >= '2020-01-01' and column < '2020-01-02')""",
         ),
     ],
 )

--- a/dbt-bigquery/src/dbt/adapters/bigquery/relation.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/relation.py
@@ -8,7 +8,6 @@ from dbt.adapters.base.relation import (
     BaseRelation,
     ComponentName,
     InformationSchema,
-    EventTimeFilter,
 )
 from dbt.adapters.contracts.relation import RelationConfig, RelationType
 from dbt.adapters.relation_configs import RelationConfigChangeAction
@@ -120,24 +119,6 @@ class BigQueryRelation(BaseRelation):
 
     def information_schema(self, identifier: Optional[str] = None) -> "BigQueryInformationSchema":
         return BigQueryInformationSchema.from_relation(self, identifier)
-
-    def _render_event_time_filtered(self, event_time_filter: EventTimeFilter) -> str:
-        """
-        Returns "" if start and end are both None
-        """
-        filter = ""
-        if event_time_filter.start and event_time_filter.end:
-            filter = f"cast({event_time_filter.field_name} as timestamp) >= '{event_time_filter.start}' and cast({event_time_filter.field_name} as timestamp) < '{event_time_filter.end}'"
-        elif event_time_filter.start:
-            filter = (
-                f"cast({event_time_filter.field_name} as timestamp) >= '{event_time_filter.start}'"
-            )
-        elif event_time_filter.end:
-            filter = (
-                f"cast({event_time_filter.field_name} as timestamp) < '{event_time_filter.end}'"
-            )
-
-        return filter
 
 
 @dataclass(frozen=True, eq=False, repr=False)


### PR DESCRIPTION
ref: https://github.com/dbt-labs/dbt-core/issues/11331
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Currently, EventTimeFilter is formatted as `YYYY-MM-DD HH:MM:SS+00:00`. However this format is not suitable for the following cases:

- referencing tables where event_time isn't of type timestamp (especially in BigQuery).
  - For BigQuery, it's addressed by https://github.com/dbt-labs/dbt-bigquery/pull/1422.
  - But casting event_time to timestamp causes a full scan.
  - When event_time is of type date, it's preferable to filter referenced tables using `event_time > 'YYYY-MM-DD'` 
- referencing sharded tables (especially in BigQuery).
  - Daily sharded tables are usually have a suffix like 'YYYYMMDD'.
  - It's better to filter referenced tables using `_table_suffix > 'YYYY-MM-DD'`.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Added format configuration to EventTimeFilter.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
