### PR TITLE
Add row access policy and table_tag config for snowflake

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Features-20250312-151053.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20250312-151053.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add row_access_policy and table_tag config for Snowflake models
+time: 2025-03-12T15:10:53.501206+01:00
+custom:
+  Author: b-per
+  Issue: "697"

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
@@ -12,6 +12,8 @@
     {%- set cluster_by_keys = config.get('cluster_by', default=none) -%}
     {%- set enable_automatic_clustering = config.get('automatic_clustering', default=false) -%}
     {%- set copy_grants = config.get('copy_grants', default=false) -%}
+    {%- set row_access_policy = config.get('row_access_policy', default=none) -%}
+    {%- set table_tag = config.get('table_tag', default=none) -%}
 
     {%- if cluster_by_keys is not none and cluster_by_keys is string -%}
       {%- set cluster_by_keys = [cluster_by_keys] -%}
@@ -40,7 +42,10 @@
           {{ get_table_columns_and_constraints() }}
           {% set compiled_code = get_select_subquery(compiled_code) %}
         {% endif %}
-        {% if copy_grants and not temporary -%} copy grants {%- endif %} as
+        {% if copy_grants and not temporary -%} copy grants {%- endif %}
+        {% if row_access_policy -%} with row access policy {{ row_access_policy }} {%- endif %}
+        {% if table_tag -%} with tag ({{ table_tag }}) {%- endif %}
+        as
         (
           {%- if cluster_by_string is not none -%}
             select * from (

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/view/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/view/create.sql
@@ -1,6 +1,8 @@
 {% macro snowflake__create_view_as_with_temp_flag(relation, sql, is_temporary=False) -%}
   {%- set secure = config.get('secure', default=false) -%}
   {%- set copy_grants = config.get('copy_grants', default=false) -%}
+  {%- set row_access_policy = config.get('row_access_policy', default=none) -%}
+  {%- set table_tag = config.get('table_tag', default=none) -%}
   {%- set sql_header = config.get('sql_header', none) -%}
 
   {{ sql_header if sql_header is not none }}
@@ -19,7 +21,10 @@
   {%- if contract_config.enforced -%}
     {{ get_assert_columns_equivalent(sql) }}
   {%- endif %}
-  {% if copy_grants -%} copy grants {%- endif %} as (
+  {% if copy_grants -%} copy grants {%- endif %}
+  {% if row_access_policy -%} with row access policy {{ row_access_policy }} {%- endif %}
+  {% if table_tag -%} with tag ({{ table_tag }}) {%- endif %}
+  as (
     {{ sql }}
   );
 {% endmacro %}

--- a/dbt-snowflake/tests/functional/extra_config/test_extra_config.py
+++ b/dbt-snowflake/tests/functional/extra_config/test_extra_config.py
@@ -1,0 +1,172 @@
+import pytest
+import re
+
+from dbt.tests.util import run_dbt
+
+
+def get_cleanded_model_ddl_from_file(file_name: str) -> str:
+    with open(f"target/run/test/models/{file_name}", "r") as ddl_file:
+        return re.sub(r"\s+", " ", ddl_file.read())
+
+
+_MODELS_TABLE_ROW_ACCESS_POLICY = """
+{{ config(
+    materialized='table',
+    row_access_policy='row_access_policy_name on (id)',
+) }}
+
+select 1 as id
+"""
+_DDL_MODELS_TABLE_ROW_ACCESS_POLICY = (
+    """.table_row_access_policy with row access policy row_access_policy_name on (id) as"""
+)
+
+_MODELS_TABLE_TAG = """
+{{ config(
+    materialized='table',
+    table_tag="tag_name = 'tag_value'",
+) }}
+
+select 1 as id
+"""
+_DDL_MODELS_TABLE_TAG = """.table_tag with tag (tag_name = 'tag_value')"""
+
+_MODELS_TABLE_TAG_AND_ROW_ACCESS_POLICY = """
+{{ config(
+    materialized='table',
+    table_tag="tag_name = 'tag_value'",
+    row_access_policy='row_access_policy_name on (id)',
+) }}
+
+select 1 as id
+"""
+_DDL_MODELS_TABLE_TAG_AND_ROW_ACCESS_POLICY = """.table_tag_and_row_access_policy with row access policy row_access_policy_name on (id) with tag (tag_name = 'tag_value') as"""
+
+# View model templates
+_MODELS_VIEW_ROW_ACCESS_POLICY = """
+{{ config(
+    materialized='view',
+    row_access_policy='row_access_policy_name on (id)',
+) }}
+
+select 1 as id
+"""
+_DDL_MODELS_VIEW_ROW_ACCESS_POLICY = (
+    """.view_row_access_policy with row access policy row_access_policy_name on (id) as"""
+)
+
+_MODELS_VIEW_TAG = """
+{{ config(
+    materialized='view',
+    table_tag="tag_name = 'tag_value'",
+) }}
+
+select 1 as id
+"""
+_DDL_MODELS_VIEW_TAG = """.view_tag with tag (tag_name = 'tag_value')"""
+
+_MODELS_VIEW_TAG_AND_ROW_ACCESS_POLICY = """
+{{ config(
+    materialized='view',
+    table_tag="tag_name = 'tag_value'",
+    row_access_policy='row_access_policy_name on (id)',
+) }}
+
+select 1 as id
+"""
+_DDL_MODELS_VIEW_TAG_AND_ROW_ACCESS_POLICY = """.view_tag_and_row_access_policy with row access policy row_access_policy_name on (id) with tag (tag_name = 'tag_value') as"""
+
+# Incremental model templates
+_MODELS_INCREMENTAL_ROW_ACCESS_POLICY = """
+{{ config(
+    materialized='incremental',
+    row_access_policy='row_access_policy_name on (id)',
+) }}
+
+select 1 as id
+"""
+_DDL_MODELS_INCREMENTAL_ROW_ACCESS_POLICY = (
+    """.incremental_row_access_policy with row access policy row_access_policy_name on (id) as"""
+)
+
+_MODELS_INCREMENTAL_TAG = """
+{{ config(
+    materialized='incremental',
+    table_tag="tag_name = 'tag_value'",
+) }}
+
+select 1 as id
+"""
+_DDL_MODELS_INCREMENTAL_TAG = """.incremental_tag with tag (tag_name = 'tag_value')"""
+
+_MODELS_INCREMENTAL_TAG_AND_ROW_ACCESS_POLICY = """
+{{ config(
+    materialized='incremental',
+    table_tag="tag_name = 'tag_value'",
+    row_access_policy='row_access_policy_name on (id)',
+) }}
+
+select 1 as id
+"""
+_DDL_MODELS_INCREMENTAL_TAG_AND_ROW_ACCESS_POLICY = """.incremental_tag_and_row_access_policy with row access policy row_access_policy_name on (id) with tag (tag_name = 'tag_value') as"""
+
+
+class TestExtraConfig:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            # Table models
+            "table_row_access_policy.sql": _MODELS_TABLE_ROW_ACCESS_POLICY,
+            "table_tag.sql": _MODELS_TABLE_TAG,
+            "table_tag_and_row_access_policy.sql": _MODELS_TABLE_TAG_AND_ROW_ACCESS_POLICY,
+            # View models
+            "view_row_access_policy.sql": _MODELS_VIEW_ROW_ACCESS_POLICY,
+            "view_tag.sql": _MODELS_VIEW_TAG,
+            "view_tag_and_row_access_policy.sql": _MODELS_VIEW_TAG_AND_ROW_ACCESS_POLICY,
+            # Incremental models
+            "incremental_row_access_policy.sql": _MODELS_INCREMENTAL_ROW_ACCESS_POLICY,
+            "incremental_tag.sql": _MODELS_INCREMENTAL_TAG,
+            "incremental_tag_and_row_access_policy.sql": _MODELS_INCREMENTAL_TAG_AND_ROW_ACCESS_POLICY,
+        }
+
+    def test_extra_config_table(self, project):
+        # depending on the Snowflake edition tags and row access policies are supported so we check the DDL sent
+        results = run_dbt(["run", "--select", "table_*"], expect_pass=None)
+        assert len(results) == 3
+
+        assert _DDL_MODELS_TABLE_ROW_ACCESS_POLICY in get_cleanded_model_ddl_from_file(
+            "table_row_access_policy.sql"
+        )
+        assert _DDL_MODELS_TABLE_TAG in get_cleanded_model_ddl_from_file("table_tag.sql")
+        assert _DDL_MODELS_TABLE_TAG_AND_ROW_ACCESS_POLICY in get_cleanded_model_ddl_from_file(
+            "table_tag_and_row_access_policy.sql"
+        )
+
+    def test_extra_config_view(self, project):
+        # Test view models with row access policy and tags
+        results = run_dbt(["run", "--select", "view_*"], expect_pass=None)
+        assert len(results) == 3
+
+        assert _DDL_MODELS_VIEW_ROW_ACCESS_POLICY in get_cleanded_model_ddl_from_file(
+            "view_row_access_policy.sql"
+        )
+        assert _DDL_MODELS_VIEW_TAG in get_cleanded_model_ddl_from_file("view_tag.sql")
+        assert _DDL_MODELS_VIEW_TAG_AND_ROW_ACCESS_POLICY in get_cleanded_model_ddl_from_file(
+            "view_tag_and_row_access_policy.sql"
+        )
+
+    def test_extra_config_incremental(self, project):
+        # Test incremental models with row access policy and tags
+        results = run_dbt(["run", "--select", "incremental_*"], expect_pass=None)
+        assert len(results) == 3
+
+        assert _DDL_MODELS_INCREMENTAL_ROW_ACCESS_POLICY in get_cleanded_model_ddl_from_file(
+            "incremental_row_access_policy.sql"
+        )
+        assert _DDL_MODELS_INCREMENTAL_TAG in get_cleanded_model_ddl_from_file(
+            "incremental_tag.sql"
+        )
+        assert (
+            _DDL_MODELS_INCREMENTAL_TAG_AND_ROW_ACCESS_POLICY
+            in get_cleanded_model_ddl_from_file("incremental_tag_and_row_access_policy.sql")
+        )


### PR DESCRIPTION
resolves #697

If approved, I am happy to add docs for it as well.

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
Today, it is not possible to set table tags or row access policies as part of CTAS statements. We can do it with post-hooks but there is a delay between the moment the object is created and the moment the tag or policy gets assigned, making potentially the object not available for some time.

Having those parameters as config allows making it part of the transaction.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
Add 2 new parameters for Snowflake tables/views/incremental models:

- `row_access_policy`
- `table_tag`


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
