### PR TITLE
[Regression] Revert incorrect dependency pin for redshift-connector to re-enable browser IDC auth method

### DIFF
--- a/dbt-redshift/.changes/unreleased/Fixes-20250312-122641.yaml
+++ b/dbt-redshift/.changes/unreleased/Fixes-20250312-122641.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix regression to re-enable browser-based IDC authentication
+time: 2025-03-12T12:26:41.493013-04:00
+custom:
+  Author: mikealfare
+  Issue: "904"

--- a/dbt-redshift/pyproject.toml
+++ b/dbt-redshift/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "dbt-postgres>=1.8,<1.10",
     # dbt-redshift depends deeply on this package. it does not follow SemVer, therefore there have been breaking changes in previous patch releases
     # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
-    "redshift-connector<2.1.1,>=2.0.913,!=2.0.914",
+    "redshift-connector>=2.1.3,<2.2",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
     "dbt-core>=1.8.0b3",
     # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core


### PR DESCRIPTION
We inadvertently downgraded this pin when migrating to the monorepo.