### PR TITLE
Add sample mode support for dbt-athena

### DIFF
--- a/dbt-athena/.changes/unreleased/Features-20250312-134105.yaml
+++ b/dbt-athena/.changes/unreleased/Features-20250312-134105.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add support for sample mode
+time: 2025-03-12T13:41:05.922071-05:00
+custom:
+  Author: QMalcolm
+  Issue: "907"

--- a/dbt-athena/tests/functional/adapter/test_sample_mode.py
+++ b/dbt-athena/tests/functional/adapter/test_sample_mode.py
@@ -1,0 +1,44 @@
+import datetime
+import os
+from unittest import mock
+import pytest
+
+from dbt.tests.adapter.sample_mode.test_sample_mode import (
+    BaseSampleModeTest,
+)
+from dbt.tests.util import run_dbt
+
+now = datetime.datetime.now()
+twelve_hours_ago = now - datetime.timedelta(hours=12)
+two_days_ago = now - datetime.timedelta(days=2)
+
+_input_model_sql = f"""
+{{{{ config(materialized='table', event_time='event_time') }}}}
+select 1 as id, cast('{two_days_ago.strftime('%Y-%m-%d %H:%M:%S-0')}' as timestamp) as event_time
+UNION ALL
+select 2 as id, cast('{twelve_hours_ago.strftime('%Y-%m-%d %H:%M:%S-0')}' as timestamp) as event_time
+UNION ALL
+select 3 as id, cast('{now.strftime('%Y-%m-%d %H:%M:%S-0')}' as timestamp) as event_time
+"""
+
+
+class TestAthenaSampleMode(BaseSampleModeTest):
+    @pytest.fixture(scope="class")
+    def input_model_sql(self) -> str:
+        return _input_model_sql
+
+    @mock.patch.dict(os.environ, {"DBT_EXPERIMENTAL_SAMPLE_MODE": "True"})
+    def test_sample_mode(self, project) -> None:
+        _ = run_dbt(["run"])
+        self.assert_row_count(
+            project=project,
+            relation_name="model_that_samples_input_sql",
+            expected_row_count=3,
+        )
+
+        _ = run_dbt(["run", "--sample=1 day"])
+        self.assert_row_count(
+            project=project,
+            relation_name="model_that_samples_input_sql",
+            expected_row_count=2,
+        )


### PR DESCRIPTION
resolves #907 

### Problem

`--sample` didn't work for dbt-athena

### Solution

Override `_render_event_time_filtered` for the `AthenaRelation` class to be an athena specific implementation. Of note, this also will help for implementing microbatch for dbt-athena, which is not done yet.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
