### PR TITLE
Fix the python model empty/sample mode fix to not break when the ref macro has been overridden

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20250327-140935.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20250327-140935.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix the python model empty/sample mode fix to not break when the ref macro has
+  been overridden
+time: 2025-03-27T14:09:35.463143-05:00
+custom:
+  Author: QMalcolm
+  Issue: "953"

--- a/dbt-adapters/src/dbt/include/global_project/macros/python_model/python.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/python_model/python.sql
@@ -11,7 +11,17 @@
     {%- set ref_dict = {} -%}
     {%- for _ref in model.refs -%}
         {% set _ref_args = [_ref.get('package'), _ref['name']] if _ref.get('package') else [_ref['name'],] %}
-        {%- set resolved = ref(*_ref_args, v=_ref.get('version')).render() -%}
+        {%- set resolved = ref(*_ref_args, v=_ref.get('version')) -%}
+
+        {#
+            We want to get the string of the returned relation in order to skip sample/empty mode rendering logic.
+            However, people override the default ref macro, and often return a string instead of a relation. Thus,
+            to make sure we dont blow things up, we have ot ensure the resolved relation is not already a string.
+        #}
+        {%- if resolved is not string -%}
+            {%- set resolved = resolved.render() -%}
+        {%- endif -%}
+
         {%- if _ref.get('version') -%}
             {% do _ref_args.extend(["v" ~ _ref['version']]) %}
         {%- endif -%}

--- a/dbt-adapters/src/dbt/include/global_project/macros/python_model/python.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/python_model/python.sql
@@ -14,11 +14,12 @@
         {%- set resolved = ref(*_ref_args, v=_ref.get('version')) -%}
 
         {#
-            We want to get the string of the returned relation in order to skip sample/empty mode rendering logic.
-            However, people override the default ref macro, and often return a string instead of a relation. Thus,
-            to make sure we dont blow things up, we have ot ensure the resolved relation is not already a string.
+            We want to get the string of the returned relation by calling .render() in order to skip sample/empty
+            mode rendering logic. However, people override the default ref macro, and often return a string instead
+            of a relation (like the ref macro does by default). Thus, to make sure we dont blow things up, we have
+            to ensure the resolved relation has a .render() method.
         #}
-        {%- if resolved is not string -%}
+        {%- if resolved.render is defined and resolved.render is callable -%}
             {%- set resolved = resolved.render() -%}
         {%- endif -%}
 


### PR DESCRIPTION
resolves #953
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

### Problem

We broke python models for people who had overridden the `ref` macro to return a string.

### Solution

Only call `render()` on the resolved `ref()` if the thing returned from `ref()` isn't a `string`.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
