### PR TITLE
Fix generate changelog linting

### DIFF
--- a/.github/workflows/_generate-changelog.yml
+++ b/.github/workflows/_generate-changelog.yml
@@ -144,7 +144,7 @@ jobs:
                     changie batch ${{ needs.version.outputs.base }}
                 fi
                 changie merge
-                git status
+                git add .
             working-directory: ./${{ inputs.package }}
             env:
                 CHANGIE_CORE_TEAM: ${{ needs.dbt-membership.outputs.team }}

--- a/dbt-redshift/.changes/1.9.3.md
+++ b/dbt-redshift/.changes/1.9.3.md
@@ -10,5 +10,3 @@
 - Add retry logic for retryable exceptions ([#960](https://github.com/dbt-labs/dbt-adapters/issues/960))
 - Move from setup.py to pyproject.toml and to hatch as a dev tool ([#951](https://github.com/dbt-labs/dbt-adapters/issues/951))
 - Refactor to use new batch context varaibles ([#966](https://github.com/dbt-labs/dbt-adapters/issues/966))
-
-


### PR DESCRIPTION
As it turns out, `pre-commit run --all-files` only runs on staged files, not all files in the repo as the docs [suggest](https://pre-commit.com/#pre-commit-run).