### PR TITLE
Create indexes on the intermediate relation before the swap

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20250402-130204.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20250402-130204.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Create indexes on the intermediate relation before the swap
+time: 2025-04-02T13:02:04.442441-06:00
+custom:
+    Author: dbeatty10 etx121
+    Issue: "966"

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/table.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/table.sql
@@ -31,6 +31,8 @@
     {{ get_create_table_as_sql(False, intermediate_relation, sql) }}
   {%- endcall %}
 
+  {% do create_indexes(intermediate_relation) %}
+
   -- cleanup
   {% if existing_relation is not none %}
      /* Do the equivalent of rename_if_exists. 'existing_relation' could have been dropped
@@ -42,8 +44,6 @@
   {% endif %}
 
   {{ adapter.rename_relation(intermediate_relation, target_relation) }}
-
-  {% do create_indexes(target_relation) %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 


### PR DESCRIPTION
resolves #966

Everything below is as reported and described by @etx121:

### Problem

Postgres tables with indexes are experiencing downtime during `dbt build`, etc while the indexes are be built. During this downtime, business users can not access the table (although [dbt is designed to still be accessible](https://docs.getdbt.com/faqs/Models/run-downtime) during this time).

The order of operations currently is:

1. Build the model into an intermediate table location
1. Rename the target table to back it up
1. Rename the intermediate table into the target name
1. **Create the indexes**
1. Drop the backup table

### Solution

Move the step that builds the indexes up two steps earlier, like this:

1. Build the model into an intermediate table location
1. **Create the indexes**
1. Rename the target table to back it up
1. Rename the intermediate table into the target name
1. Drop the backup table

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in ~development and it appears to resolve the stated issue~ CI and passed all the checks
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
