### PR TITLE
Create indexes on the target/intermediate/temp relation before the swap

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20250402-160530.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20250402-160530.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Create indexes on the intermediate relation before the swap for incremental models
+time: 2025-04-02T16:05:30.892493-06:00
+custom:
+    Author: dbeatty10 etx121
+    Issue: "966"


### PR DESCRIPTION
resolves #966

### Problem

Postgres `incremental` models with indexes are experiencing downtime during `dbt build`, etc while the indexes are being built. During this downtime, business users can not access the table (although [dbt is designed to still be accessible](https://docs.getdbt.com/faqs/Models/run-downtime) during this time).

### Solution

Same thing as https://github.com/dbt-labs/dbt-adapters/pull/968, but for `incremental` materialization.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
