### PR TITLE
Add utility script for force cancelling workflows and allow cancellation of "always()" workflow jobs

### DIFF
--- a/.github/workflows/_integration-tests.yml
+++ b/.github/workflows/_integration-tests.yml
@@ -131,7 +131,7 @@ jobs:
         if: |
             contains(fromJSON(inputs.packages), 'dbt-bigquery') &&
             inputs.python-version == vars.DEFAULT_PYTHON_VERSION &&
-            always()
+            always() && !cancelled()
         runs-on: ${{ inputs.os }}
         # make sure these don't kick off in parallel with the non-flaky tests, which defeats the purpose of running them separately
         needs: integration-tests-bigquery
@@ -302,7 +302,7 @@ jobs:
         if: |
             contains(fromJSON(inputs.packages), 'dbt-redshift') &&
             inputs.python-version == vars.DEFAULT_PYTHON_VERSION &&
-            always()
+            always() && !cancelled()
         runs-on: ${{ inputs.os }}
         # make sure these don't kick off in parallel with the non-flaky tests, which defeats the purpose of running them separately
         needs: integration-tests-redshift

--- a/.github/workflows/_integration-tests.yml
+++ b/.github/workflows/_integration-tests.yml
@@ -127,11 +127,11 @@ jobs:
 
     integration-tests-bigquery-flaky:
         # we only run this for one python version to avoid running in parallel
-        # we need to run with "always()" so that we run after non-flaky BQ tests even when they fail
+        # we need to run with "!cancelled()" so that we run after non-flaky BQ tests even when they fail
         if: |
             contains(fromJSON(inputs.packages), 'dbt-bigquery') &&
             inputs.python-version == vars.DEFAULT_PYTHON_VERSION &&
-            always() && !cancelled()
+            !cancelled()
         runs-on: ${{ inputs.os }}
         # make sure these don't kick off in parallel with the non-flaky tests, which defeats the purpose of running them separately
         needs: integration-tests-bigquery
@@ -298,11 +298,11 @@ jobs:
 
     integration-tests-redshift-flaky:
         # we only run this for one python version to avoid running in parallel
-        # we need to run with "always()" so that we run after non-flaky RS tests even when they fail
+        # we need to run with "!cancelled()" so that we run after non-flaky RS tests even when they fail
         if: |
             contains(fromJSON(inputs.packages), 'dbt-redshift') &&
             inputs.python-version == vars.DEFAULT_PYTHON_VERSION &&
-            always() && !cancelled()
+            !cancelled()
         runs-on: ${{ inputs.os }}
         # make sure these don't kick off in parallel with the non-flaky tests, which defeats the purpose of running them separately
         needs: integration-tests-redshift

--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -62,7 +62,7 @@ jobs:
         secrets: inherit
 
     publish-internal:
-        if: always() && !failure() && !cancelled()
+        if: ${{ !failure() && !cancelled() }}
         needs: [unit-tests, integration-tests]
         uses: ./.github/workflows/_publish-internal.yml
         with:

--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -62,7 +62,7 @@ jobs:
         secrets: inherit
 
     publish-internal:
-        if: always() && !failure()
+        if: always() && !failure() && !cancelled()
         needs: [unit-tests, integration-tests]
         uses: ./.github/workflows/_publish-internal.yml
         with:

--- a/.github/workflows/publish-oss.yml
+++ b/.github/workflows/publish-oss.yml
@@ -69,7 +69,7 @@ jobs:
         secrets: inherit
 
     generate-changelog:
-        if: always() && !failure() && !cancelled()
+        if: ${{ !failure() && !cancelled() }}
         needs:
         -   work-branch
         -   bump-version  # bump-version may be a no-op, but the changelog should be generated for the latest version
@@ -81,7 +81,7 @@ jobs:
 
     unit-tests:
         if: |
-            always() && !failure() && !cancelled() &&
+            !failure() && !cancelled() &&
             inputs.skip-unit-tests == false &&
             !contains(fromJSON('["dbt-tests-adapter"]'), inputs.package)
         needs:
@@ -94,7 +94,7 @@ jobs:
 
     integration-tests:
         if: |
-            always() && !failure() && !cancelled() &&
+            !failure() && !cancelled() &&
             inputs.skip-integration-tests == false &&
             !contains(fromJSON('["dbt-adapters", "dbt-tests-adapter"]'), inputs.package)
         needs:
@@ -107,7 +107,7 @@ jobs:
         secrets: inherit
 
     publish:
-        if: always() && !failure() && !cancelled()
+        if: ${{ !failure() && !cancelled() }}
         needs:
         -   work-branch
         -   bump-version
@@ -182,7 +182,7 @@ jobs:
                 command: wget ${{ vars.PYPI_PROJECT_URL }}/dbt-athena-community/${{ steps.version.outputs.version }}
 
     clean-up:
-        if: always() && !cancelled()
+        if: ${{ !cancelled() }}
         needs:
             -   work-branch
             -   publish

--- a/.github/workflows/publish-oss.yml
+++ b/.github/workflows/publish-oss.yml
@@ -69,7 +69,7 @@ jobs:
         secrets: inherit
 
     generate-changelog:
-        if: always() && !failure()
+        if: always() && !failure() && !cancelled()
         needs:
         -   work-branch
         -   bump-version  # bump-version may be a no-op, but the changelog should be generated for the latest version
@@ -81,7 +81,7 @@ jobs:
 
     unit-tests:
         if: |
-            always() && !failure() &&
+            always() && !failure() && !cancelled() &&
             inputs.skip-unit-tests == false &&
             !contains(fromJSON('["dbt-tests-adapter"]'), inputs.package)
         needs:
@@ -94,7 +94,7 @@ jobs:
 
     integration-tests:
         if: |
-            always() && !failure() &&
+            always() && !failure() && !cancelled() &&
             inputs.skip-integration-tests == false &&
             !contains(fromJSON('["dbt-adapters", "dbt-tests-adapter"]'), inputs.package)
         needs:
@@ -107,7 +107,7 @@ jobs:
         secrets: inherit
 
     publish:
-        if: always() && !failure()
+        if: always() && !failure() && !cancelled()
         needs:
         -   work-branch
         -   bump-version
@@ -182,7 +182,7 @@ jobs:
                 command: wget ${{ vars.PYPI_PROJECT_URL }}/dbt-athena-community/${{ steps.version.outputs.version }}
 
     clean-up:
-        if: always()
+        if: always() && !cancelled()
         needs:
             -   work-branch
             -   publish

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -108,7 +108,7 @@ jobs:
     # This job does nothing and is only used for branch protection
     results:
         name: "Pull request checks"  # keep this name, branch protection references it
-        if: always()
+        if: always() && !cancelled()
         needs: [changelog-entry-check, code-quality, verify-build, unit-tests, integration-tests]
         runs-on: ${{ vars.DEFAULT_RUNNER }}
         steps:

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -108,7 +108,7 @@ jobs:
     # This job does nothing and is only used for branch protection
     results:
         name: "Pull request checks"  # keep this name, branch protection references it
-        if: always() && !cancelled()
+        if: ${{ !cancelled() }}
         needs: [changelog-entry-check, code-quality, verify-build, unit-tests, integration-tests]
         runs-on: ${{ vars.DEFAULT_RUNNER }}
         steps:

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -65,7 +65,7 @@ jobs:
         secrets: inherit
 
     notification:
-        if: always() && !cancelled()
+        if: ${{ !cancelled() }}
         needs: [verify-builds, unit-tests, integration-tests]
         runs-on: ${{ vars.DEFAULT_RUNNER }}
         steps:

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -65,7 +65,7 @@ jobs:
         secrets: inherit
 
     notification:
-        if: always()
+        if: always() && !cancelled()
         needs: [verify-builds, unit-tests, integration-tests]
         runs-on: ${{ vars.DEFAULT_RUNNER }}
         steps:
@@ -75,7 +75,7 @@ jobs:
             with:
                 jobs: ${{ toJSON(needs) }}
         -   uses: ravsamhq/notify-slack-action@v2
-            if: ${{ always() }}
+            if: always()
             with:
                 token: ${{ secrets.GITHUB_TOKEN }}
                 status: ${{ job.status }}

--- a/scripts/force-cancel-workflow.sh
+++ b/scripts/force-cancel-workflow.sh
@@ -1,0 +1,7 @@
+RUN_ID=$1   # the run to cancel (https://github.com/dbt-labs/dbt-adapters/actions/runs/<THIS-VALUE>)
+
+gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    /repos/dbt-labs/dbt-adapters/actions/runs/$RUN_ID/force-cancel


### PR DESCRIPTION
Apparently using `if: always()` in a GHA job makes that job not cancellable: https://github.com/actions/runner/issues/1846

This shows up in two ways:
- hitting "Cancel workflow" on the run page doesn't do anything
- breaching a concurrency condition doesn't cancel the prior workflow, e.g. updating a PR will wait for the prior run to finish before running the new CI

It's only possible to force cancel via the GH API. This script wraps that API call with the `run_id` as an input so we don't need to look up the syntax each time.

I also added `&& !cancelled()` to all jobs that use `if: always()` in hopes that this will cause the job to recognize pushing "Cancel workflow", and more importantly, PR updates.