### PR TITLE
Replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc).replace(tzinfo=None)`

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fixes-20250408-104143.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20250408-104143.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: '`datetime.datetime.utcnow()` is deprecated as of Python 3.12'
+time: 2025-04-08T10:41:43.273573-06:00
+custom:
+    Author: dbeatty10
+    Issue: "980"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/token_suppliers.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/token_suppliers.py
@@ -81,7 +81,7 @@ class EntraTokenSupplier(SubjectTokenSupplier):
         """Check if the cached token is still valid."""
         if not self._token_expiry:
             return False
-        return datetime.now(timezone.utc) < (self._token_expiry - self._expiry_buffer)
+        return datetime.now(timezone.utc).replace(tzinfo=None) < (self._token_expiry - self._expiry_buffer)
 
     def _fetch_new_token(self) -> str:
         """Fetch a new token from Entra ID."""
@@ -98,7 +98,7 @@ class EntraTokenSupplier(SubjectTokenSupplier):
         # Extract expiration time from token response
         # Default to 1 hour if not specified
         expires_in = token_data.get("expires_in", 3600)
-        self._token_expiry = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+        self._token_expiry = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=expires_in)
         self._cached_token = token_data["access_token"]
 
         return token_data["access_token"]

--- a/dbt-bigquery/src/dbt/adapters/bigquery/token_suppliers.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/token_suppliers.py
@@ -81,7 +81,9 @@ class EntraTokenSupplier(SubjectTokenSupplier):
         """Check if the cached token is still valid."""
         if not self._token_expiry:
             return False
-        return datetime.now(timezone.utc).replace(tzinfo=None) < (self._token_expiry - self._expiry_buffer)
+        return datetime.now(timezone.utc).replace(tzinfo=None) < (
+            self._token_expiry - self._expiry_buffer
+        )
 
     def _fetch_new_token(self) -> str:
         """Fetch a new token from Entra ID."""
@@ -98,8 +100,9 @@ class EntraTokenSupplier(SubjectTokenSupplier):
         # Extract expiration time from token response
         # Default to 1 hour if not specified
         expires_in = token_data.get("expires_in", 3600)
-        self._token_expiry = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=expires_in)
-        self._cached_token = token_data["access_token"]
+        self._token_expiry = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
+            seconds=expires_in
+        )        self._cached_token = token_data["access_token"]
 
         return token_data["access_token"]
 

--- a/dbt-bigquery/src/dbt/adapters/bigquery/token_suppliers.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/token_suppliers.py
@@ -2,7 +2,7 @@ import requests
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Dict, Optional
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from google.auth.identity_pool import SubjectTokenSupplier
 from dbt.adapters.exceptions import FailedToConnectError
 from google.auth.external_account import SupplierContext
@@ -81,7 +81,7 @@ class EntraTokenSupplier(SubjectTokenSupplier):
         """Check if the cached token is still valid."""
         if not self._token_expiry:
             return False
-        return datetime.utcnow() < (self._token_expiry - self._expiry_buffer)
+        return datetime.now(timezone.utc) < (self._token_expiry - self._expiry_buffer)
 
     def _fetch_new_token(self) -> str:
         """Fetch a new token from Entra ID."""
@@ -98,7 +98,7 @@ class EntraTokenSupplier(SubjectTokenSupplier):
         # Extract expiration time from token response
         # Default to 1 hour if not specified
         expires_in = token_data.get("expires_in", 3600)
-        self._token_expiry = datetime.utcnow() + timedelta(seconds=expires_in)
+        self._token_expiry = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
         self._cached_token = token_data["access_token"]
 
         return token_data["access_token"]

--- a/dbt-bigquery/src/dbt/adapters/bigquery/token_suppliers.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/token_suppliers.py
@@ -102,7 +102,8 @@ class EntraTokenSupplier(SubjectTokenSupplier):
         expires_in = token_data.get("expires_in", 3600)
         self._token_expiry = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
             seconds=expires_in
-        )        self._cached_token = token_data["access_token"]
+        )
+        self._cached_token = token_data["access_token"]
 
         return token_data["access_token"]
 

--- a/dbt-postgres/.changes/unreleased/Fixes-20250408-104218.yaml
+++ b/dbt-postgres/.changes/unreleased/Fixes-20250408-104218.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: '`datetime.datetime.utcnow()` is deprecated as of Python 3.12'
+time: 2025-04-08T10:42:18.937024-06:00
+custom:
+    Author: dbeatty10
+    Issue: "980"

--- a/dbt-postgres/src/dbt/adapters/postgres/impl.py
+++ b/dbt-postgres/src/dbt/adapters/postgres/impl.py
@@ -40,7 +40,7 @@ class PostgresIndexConfig(dbtClassMixin):
         # the index will only be created on every other run. See
         # https://github.com/dbt-labs/dbt-core/issues/1945#issuecomment-576714925
         # for an explanation.
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
         inputs = self.columns + [relation.render(), str(self.unique), str(self.type), now]
         string = "_".join(inputs)
         return dbt_encoding.md5(string)

--- a/dbt-postgres/src/dbt/adapters/postgres/impl.py
+++ b/dbt-postgres/src/dbt/adapters/postgres/impl.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, List, Optional, Set
 
 from dbt.adapters.base import AdapterConfig, ConstraintSupport, available
@@ -40,7 +40,7 @@ class PostgresIndexConfig(dbtClassMixin):
         # the index will only be created on every other run. See
         # https://github.com/dbt-labs/dbt-core/issues/1945#issuecomment-576714925
         # for an explanation.
-        now = datetime.utcnow().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
         inputs = self.columns + [relation.render(), str(self.unique), str(self.type), now]
         string = "_".join(inputs)
         return dbt_encoding.md5(string)

--- a/dbt-postgres/tests/functional/sources/test_source_fresher_state.py
+++ b/dbt-postgres/tests/functional/sources/test_source_fresher_state.py
@@ -27,7 +27,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
     def setUp(self, project):
         self.run_dbt_with_vars(project, ["seed"])
         pytest._id = 101
-        pytest.freshness_start_time = datetime.now(timezone.utc)
+        pytest.freshness_start_time = datetime.now(timezone.utc).replace(tzinfo=None)
         # this is the db initial value
         pytest.last_inserted_time = "2016-09-19T14:45:51+00:00"
 
@@ -38,7 +38,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
         del os.environ["DBT_ENV_CUSTOM_ENV_key"]
 
     def _set_updated_at_to(self, project, delta):
-        insert_time = datetime.now(timezone.utc) + delta
+        insert_time = datetime.now(timezone.utc).replace(tzinfo=None) + delta
         timestr = insert_time.strftime("%Y-%m-%d %H:%M:%S")
         # favorite_color,id,first_name,email,ip_address,updated_at
         insert_id = pytest._id
@@ -67,7 +67,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
     def assertBetween(self, timestr, start, end=None):
         datefmt = "%Y-%m-%dT%H:%M:%S.%fZ"
         if end is None:
-            end = datetime.now(timezone.utc)
+            end = datetime.now(timezone.utc).replace(tzinfo=None)
 
         parsed = datetime.strptime(timestr, datefmt)
 

--- a/dbt-postgres/tests/functional/sources/test_source_fresher_state.py
+++ b/dbt-postgres/tests/functional/sources/test_source_fresher_state.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import json
 import os
 import shutil
@@ -27,7 +27,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
     def setUp(self, project):
         self.run_dbt_with_vars(project, ["seed"])
         pytest._id = 101
-        pytest.freshness_start_time = datetime.utcnow()
+        pytest.freshness_start_time = datetime.now(timezone.utc)
         # this is the db initial value
         pytest.last_inserted_time = "2016-09-19T14:45:51+00:00"
 
@@ -38,7 +38,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
         del os.environ["DBT_ENV_CUSTOM_ENV_key"]
 
     def _set_updated_at_to(self, project, delta):
-        insert_time = datetime.utcnow() + delta
+        insert_time = datetime.now(timezone.utc) + delta
         timestr = insert_time.strftime("%Y-%m-%d %H:%M:%S")
         # favorite_color,id,first_name,email,ip_address,updated_at
         insert_id = pytest._id
@@ -67,7 +67,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
     def assertBetween(self, timestr, start, end=None):
         datefmt = "%Y-%m-%dT%H:%M:%S.%fZ"
         if end is None:
-            end = datetime.utcnow()
+            end = datetime.now(timezone.utc)
 
         parsed = datetime.strptime(timestr, datefmt)
 

--- a/dbt-postgres/tests/functional/sources/test_source_freshness.py
+++ b/dbt-postgres/tests/functional/sources/test_source_freshness.py
@@ -23,7 +23,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
     def setUp(self, project):
         self.run_dbt_with_vars(project, ["seed"])
         pytest._id = 101
-        pytest.freshness_start_time = datetime.now(timezone.utc)
+        pytest.freshness_start_time = datetime.now(timezone.utc).replace(tzinfo=None)
         # this is the db initial value
         pytest.last_inserted_time = "2016-09-19T14:45:51+00:00"
 
@@ -34,7 +34,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
         del os.environ["DBT_ENV_CUSTOM_ENV_key"]
 
     def _set_updated_at_to(self, project, delta):
-        insert_time = datetime.now(timezone.utc) + delta
+        insert_time = datetime.now(timezone.utc).replace(tzinfo=None) + delta
         timestr = insert_time.strftime("%Y-%m-%d %H:%M:%S")
         # favorite_color,id,first_name,email,ip_address,updated_at
         insert_id = pytest._id
@@ -63,7 +63,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
     def assertBetween(self, timestr, start, end=None):
         datefmt = "%Y-%m-%dT%H:%M:%S.%fZ"
         if end is None:
-            end = datetime.now(timezone.utc)
+            end = datetime.now(timezone.utc).replace(tzinfo=None)
 
         parsed = datetime.strptime(timestr, datefmt)
 

--- a/dbt-postgres/tests/functional/sources/test_source_freshness.py
+++ b/dbt-postgres/tests/functional/sources/test_source_freshness.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import os
 import json
 
@@ -23,7 +23,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
     def setUp(self, project):
         self.run_dbt_with_vars(project, ["seed"])
         pytest._id = 101
-        pytest.freshness_start_time = datetime.utcnow()
+        pytest.freshness_start_time = datetime.now(timezone.utc)
         # this is the db initial value
         pytest.last_inserted_time = "2016-09-19T14:45:51+00:00"
 
@@ -34,7 +34,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
         del os.environ["DBT_ENV_CUSTOM_ENV_key"]
 
     def _set_updated_at_to(self, project, delta):
-        insert_time = datetime.utcnow() + delta
+        insert_time = datetime.now(timezone.utc) + delta
         timestr = insert_time.strftime("%Y-%m-%d %H:%M:%S")
         # favorite_color,id,first_name,email,ip_address,updated_at
         insert_id = pytest._id
@@ -63,7 +63,7 @@ class SuccessfulSourceFreshnessTest(BaseSourcesTest):
     def assertBetween(self, timestr, start, end=None):
         datefmt = "%Y-%m-%dT%H:%M:%S.%fZ"
         if end is None:
-            end = datetime.utcnow()
+            end = datetime.now(timezone.utc)
 
         parsed = datetime.strptime(timestr, datefmt)
 

--- a/dbt-redshift/.changes/unreleased/Fixes-20250408-104244.yaml
+++ b/dbt-redshift/.changes/unreleased/Fixes-20250408-104244.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: '`datetime.datetime.utcnow()` is deprecated as of Python 3.12'
+time: 2025-04-08T10:42:44.623855-06:00
+custom:
+    Author: dbeatty10
+    Issue: "980"

--- a/dbt-redshift/tests/boundary/conftest.py
+++ b/dbt-redshift/tests/boundary/conftest.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 import random
 
@@ -20,7 +20,7 @@ def connection() -> redshift_connector.Connection:
 
 @pytest.fixture
 def schema_name(request) -> str:
-    runtime = datetime.utcnow() - datetime(1970, 1, 1, 0, 0, 0)
+    runtime = datetime.now(timezone.utc) - datetime(1970, 1, 1, 0, 0, 0)
     runtime_s = int(runtime.total_seconds())
     runtime_ms = runtime.microseconds
     random_int = random.randint(0, 9999)

--- a/dbt-redshift/tests/boundary/conftest.py
+++ b/dbt-redshift/tests/boundary/conftest.py
@@ -20,7 +20,7 @@ def connection() -> redshift_connector.Connection:
 
 @pytest.fixture
 def schema_name(request) -> str:
-    runtime = datetime.now(timezone.utc) - datetime(1970, 1, 1, 0, 0, 0)
+    runtime = datetime.now(timezone.utc).replace(tzinfo=None) - datetime(1970, 1, 1, 0, 0, 0)
     runtime_s = int(runtime.total_seconds())
     runtime_ms = runtime.microseconds
     random_int = random.randint(0, 9999)

--- a/dbt-snowflake/.changes/unreleased/Fixes-20250408-104306.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20250408-104306.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: '`datetime.datetime.utcnow()` is deprecated as of Python 3.12'
+time: 2025-04-08T10:43:06.584126-06:00
+custom:
+    Author: dbeatty10
+    Issue: "980"

--- a/dbt-tests-adapter/.changes/unreleased/Fixes-20250408-104326.yaml
+++ b/dbt-tests-adapter/.changes/unreleased/Fixes-20250408-104326.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: '`datetime.datetime.utcnow()` is deprecated as of Python 3.12'
+time: 2025-04-08T10:43:26.520128-06:00
+custom:
+    Author: dbeatty10
+    Issue: "980"

--- a/dbt-tests-adapter/src/dbt/tests/adapter/basic/test_docs_generate.py
+++ b/dbt-tests-adapter/src/dbt/tests/adapter/basic/test_docs_generate.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -348,7 +348,7 @@ def run_and_generate(project, args=None):
     rm_file(project.project_root, "target", "manifest.json")
     rm_file(project.project_root, "target", "run_results.json")
 
-    start_time = datetime.utcnow()
+    start_time = datetime.now(timezone.utc)
     run_args = ["docs", "generate"]
     if args:
         run_args.extend(args)

--- a/dbt-tests-adapter/src/dbt/tests/adapter/basic/test_docs_generate.py
+++ b/dbt-tests-adapter/src/dbt/tests/adapter/basic/test_docs_generate.py
@@ -348,7 +348,7 @@ def run_and_generate(project, args=None):
     rm_file(project.project_root, "target", "manifest.json")
     rm_file(project.project_root, "target", "run_results.json")
 
-    start_time = datetime.now(timezone.utc)
+    start_time = datetime.now(timezone.utc).replace(tzinfo=None)
     run_args = ["docs", "generate"]
     if args:
         run_args.extend(args)

--- a/dbt-tests-adapter/src/dbt/tests/adapter/utils/test_current_timestamp.py
+++ b/dbt-tests-adapter/src/dbt/tests/adapter/utils/test_current_timestamp.py
@@ -52,6 +52,7 @@ class BaseCurrentTimestamp:
 
         return datetime.now(timezone.utc).replace(tzinfo=None)
 
+
 class BaseCurrentTimestampAware(BaseCurrentTimestamp):
     def test_current_timestamp_type(self, current_timestamp):
         assert is_aware(current_timestamp)

--- a/dbt-tests-adapter/src/dbt/tests/adapter/utils/test_current_timestamp.py
+++ b/dbt-tests-adapter/src/dbt/tests/adapter/utils/test_current_timestamp.py
@@ -47,11 +47,10 @@ class BaseCurrentTimestamp:
         """
         Current UTC datetime with the same timezone-awareness (or naiveness) as the input.
         """
-        return (
-            datetime.now(timezone.utc)
-            if is_aware(dt)
-            else datetime.now(timezone.utc).replace(tzinfo=None)
-        )
+        if is_aware(dt):
+            return datetime.now(timezone.utc)
+
+        return datetime.now(timezone.utc).replace(tzinfo=None)
 
 class BaseCurrentTimestampAware(BaseCurrentTimestamp):
     def test_current_timestamp_type(self, current_timestamp):

--- a/dbt-tests-adapter/src/dbt/tests/adapter/utils/test_current_timestamp.py
+++ b/dbt-tests-adapter/src/dbt/tests/adapter/utils/test_current_timestamp.py
@@ -47,8 +47,11 @@ class BaseCurrentTimestamp:
         """
         Current UTC datetime with the same timezone-awareness (or naiveness) as the input.
         """
-        return datetime.now(timezone.utc) if is_aware(dt) else datetime.now(timezone.utc).replace(tzinfo=None)
-
+        return (
+            datetime.now(timezone.utc)
+            if is_aware(dt)
+            else datetime.now(timezone.utc).replace(tzinfo=None)
+        )
 
 class BaseCurrentTimestampAware(BaseCurrentTimestamp):
     def test_current_timestamp_type(self, current_timestamp):

--- a/dbt-tests-adapter/src/dbt/tests/adapter/utils/test_current_timestamp.py
+++ b/dbt-tests-adapter/src/dbt/tests/adapter/utils/test_current_timestamp.py
@@ -47,7 +47,7 @@ class BaseCurrentTimestamp:
         """
         Current UTC datetime with the same timezone-awareness (or naiveness) as the input.
         """
-        return datetime.now(timezone.utc) if is_aware(dt) else datetime.utcnow()
+        return datetime.now(timezone.utc) if is_aware(dt) else datetime.now(timezone.utc)
 
 
 class BaseCurrentTimestampAware(BaseCurrentTimestamp):

--- a/dbt-tests-adapter/src/dbt/tests/adapter/utils/test_current_timestamp.py
+++ b/dbt-tests-adapter/src/dbt/tests/adapter/utils/test_current_timestamp.py
@@ -47,7 +47,7 @@ class BaseCurrentTimestamp:
         """
         Current UTC datetime with the same timezone-awareness (or naiveness) as the input.
         """
-        return datetime.now(timezone.utc) if is_aware(dt) else datetime.now(timezone.utc)
+        return datetime.now(timezone.utc) if is_aware(dt) else datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 class BaseCurrentTimestampAware(BaseCurrentTimestamp):


### PR DESCRIPTION
resolves #980

### Problem

Output of CI tests with Python 3.12 includes content like the following:

```
  /home/runner/.local/share/hatch/env/virtual/dbt-bigquery/N0kmxlql/dbt-bigquery/lib/python3.12/site-packages/dbt_common/invocation.py:5: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    _INVOCATION_STARTED_AT = datetime.utcnow()
```

### Solution
Import `timezone` from `datetime`, and replace instances of `datetime.datetime.utcnow()` with `datetime.datetime.now(datetime.timezone.utc)`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] Tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc).