### PR TITLE
Forward Unexpected Operations on Record/Replay Wrappers

### DIFF
--- a/dbt-adapters/.changes/unreleased/Under the Hood-20250411-172257.yaml
+++ b/dbt-adapters/.changes/unreleased/Under the Hood-20250411-172257.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add more robust operation forwarding to record/replay wrappers.
+time: 2025-04-11T17:22:57.173578-04:00
+custom:
+    Author: peterallenwebb
+    Issue: "990"

--- a/dbt-adapters/src/dbt/adapters/record/handle.py
+++ b/dbt-adapters/src/dbt/adapters/record/handle.py
@@ -1,7 +1,10 @@
 from typing import Any
 
-from dbt.adapters.contracts.connection import Connection
+from dbt_common.events.base_types import BaseEvent
+from dbt_common.events.functions import fire_event
+from dbt_common.events.types import RecordReplayIssue
 
+from dbt.adapters.contracts.connection import Connection
 from dbt.adapters.record.cursor.cursor import RecordReplayCursor
 
 
@@ -38,3 +41,15 @@ class RecordReplayHandle:
     @property
     def closed(self):
         return self.native_handle.closed
+
+    def _fire_event(self, evt: BaseEvent) -> None:
+        """Wraps fire_event for easier test mocking."""
+        fire_event(evt)
+
+    def __getattr__(self, name: str) -> Any:
+        self._fire_event(
+            RecordReplayIssue(
+                msg=f"Unexpected attribute '{name}' accessed on {self.__class__.__name__}"
+            )
+        )
+        return getattr(self.native_handle, name)

--- a/dbt-adapters/tests/unit/conftest.py
+++ b/dbt-adapters/tests/unit/conftest.py
@@ -1,0 +1,7 @@
+from tests.unit.fixtures import (
+    adapter,
+    adapter_default_behaviour_flags,
+    behavior_flags,
+    config,
+    flags,
+)

--- a/dbt-adapters/tests/unit/record/test_record_cursor.py
+++ b/dbt-adapters/tests/unit/record/test_record_cursor.py
@@ -1,0 +1,50 @@
+from dbt.adapters.record import RecordReplayCursor
+
+
+class MockCursor:
+    @property
+    def rowcount(self) -> int:
+        return 42
+
+    def execute(self, operation, parameters=None) -> None:
+        pass
+
+    @property
+    def unexpected_prop(self) -> bool:
+        return True
+
+    def unexpected_func(self) -> int:
+        return 1
+
+
+class MockConnection:
+    pass
+
+
+def test_record_cursor():
+    # Ensure that record/replay's cursor wrapper forwards all property accesses
+    # and function calls to the wrapped cursor, even if they were not expected.
+    # Also, verify that a RecordReplayIssue is logged if unexpected accesses or
+    # function calls happen.
+    recorded_cursor = RecordReplayCursor(MockCursor(), MockConnection())  # type: ignore
+
+    # Test that an expected property works as designed
+    assert recorded_cursor.rowcount == 42
+    # Test that an expected function call works as designed
+    recorded_cursor.execute("select 1")
+
+    events = []
+
+    # Mock event firing
+    recorded_cursor._fire_event = events.append
+
+    # Test that an unexpected property works, but fires a warning
+    assert recorded_cursor.unexpected_prop is True
+    assert len(events) == 1
+    assert events[0].__class__.__name__ == "RecordReplayIssue"
+    events.clear()
+
+    # Test that an unexpected function works, but fires a warning
+    assert recorded_cursor.unexpected_func() == 1
+    assert len(events) == 1
+    assert events[0].__class__.__name__ == "RecordReplayIssue"

--- a/dbt-adapters/tests/unit/record/test_record_handle.py
+++ b/dbt-adapters/tests/unit/record/test_record_handle.py
@@ -1,0 +1,50 @@
+from dbt.adapters.record import RecordReplayHandle
+
+
+class MockConnection:
+    pass
+
+
+class MockHandle:
+    @property
+    def closed(self) -> bool:
+        return False
+
+    def rollback(self) -> None:
+        pass
+
+    @property
+    def unexpected_prop(self) -> bool:
+        return True
+
+    def unexpected_func(self) -> int:
+        return 1
+
+
+def test_record_handle():
+    # Ensure that record/replay's handle wrapper forwards all property accesses
+    # and function calls to the wrapped cursor, even if they were not expected.
+    # Also, verify that a RecordReplayIssue is logged if unexpected accesses or
+    # function calls happen.
+    recorded_handle = RecordReplayHandle(MockHandle(), MockConnection())  # type: ignore
+
+    # Test that an expected property works as designed
+    assert recorded_handle.closed is False
+    # Test that an expected function call works as designed
+    recorded_handle.rollback()
+
+    events = []
+
+    # Mock event firing
+    recorded_handle._fire_event = events.append
+
+    # Test that an unexpected property works, but fires a warning
+    assert recorded_handle.unexpected_prop is True
+    assert len(events) == 1
+    assert events[0].__class__.__name__ == "RecordReplayIssue"
+    events.clear()
+
+    # Test that an unexpected function works, but fires a warning
+    assert recorded_handle.unexpected_func() == 1
+    assert len(events) == 1
+    assert events[0].__class__.__name__ == "RecordReplayIssue"


### PR DESCRIPTION

resolves #990 

### Problem

Unexpected operations on record/replay wrappers could cause runtime problems.

### Solution

Dynamically forward such operations, but log an event which can be monitored.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
