### PR TITLE
Pin `certifi` to avoid issue with certificate authority update

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20250426-231149.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20250426-231149.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Pin certifi library to address regression in version 2025.4.26
+time: 2025-04-26T23:11:49.127849-04:00
+custom:
+  Author: mikealfare
+  Issue: "1027"

--- a/dbt-snowflake/pyproject.toml
+++ b/dbt-snowflake/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "dbt-adapters>=1.10.4,<2.0",
     # lower bound pin due to CVE-2025-24794
     "snowflake-connector-python[secure-local-storage]>=3.13.1,<4.0.0",
+    "certifi<2025.4.26",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
     "dbt-core>=1.8.0",
     # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core


### PR DESCRIPTION
There was a recent update to `certifi`, a dependency of `snowflake-connector-python`, that affects authentication and raises the following error:

```
snowflake.connector.errors.OperationalError: 254007: The certificate is revoked or could not be validated: hostname={server}.s3.us-west-2.amazonaws.com
```

This was introduced in release `2025.4.26`. Scheduled tests demonstrate this failure ([example](https://github.com/dbt-labs/dbt-adapters/actions/runs/14677134399/job/41204298954)). Pinning `certifi` resolves this issue.