### PR TITLE
Make supported catalog lookup case-insensitive

### DIFF
--- a/dbt-adapters/src/dbt/adapters/catalogs/_client.py
+++ b/dbt-adapters/src/dbt/adapters/catalogs/_client.py
@@ -28,7 +28,7 @@ class CatalogIntegrationClient:
 
     def __init__(self, supported_catalogs: Iterable[Type[CatalogIntegration]]):
         self.__supported_catalogs: Dict[str, Type[CatalogIntegration]] = {
-            catalog.catalog_type: catalog for catalog in supported_catalogs
+            catalog.catalog_type.casefold(): catalog for catalog in supported_catalogs
         }
         self.__catalog_integrations: Dict[str, CatalogIntegration] = {}
 
@@ -47,7 +47,7 @@ class CatalogIntegrationClient:
 
     def __catalog_integration_factory(self, catalog_type: str) -> Type[CatalogIntegration]:
         try:
-            return self.__supported_catalogs[catalog_type]
+            return self.__supported_catalogs[catalog_type.casefold()]
         except KeyError as e:
             raise DbtCatalogIntegrationNotSupportedError(
                 catalog_type, self.__supported_catalogs.keys()

--- a/dbt-adapters/src/dbt/adapters/catalogs/_exceptions.py
+++ b/dbt-adapters/src/dbt/adapters/catalogs/_exceptions.py
@@ -25,8 +25,8 @@ class DbtCatalogIntegrationNotSupportedError(DbtConfigError):
     def __init__(self, catalog_type: str, supported_catalog_types: Iterable[str]) -> None:
         self.catalog_type = catalog_type
         msg = (
-            f"Catalog type is not supported."
-            f"Received: {catalog_type}"
+            f"Catalog type is not supported.\n"
+            f"Received: {catalog_type}\n"
             f"Expected one of: {', '.join(supported_catalog_types)}"
         )
         super().__init__(msg)


### PR DESCRIPTION
### Problem

Supported catalog lookup should be case-insensitive.

### Solution

Use casefold to make casing consistent. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
