### PR TITLE
Rename `get_limit_subquery_sql` to `get_limit_sql`

### DIFF
--- a/dbt-adapters/.changes/unreleased/Features-20250430-135848.yaml
+++ b/dbt-adapters/.changes/unreleased/Features-20250430-135848.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Rename `get_limit_subquery_sql` to `get_limit_sql`
+time: 2025-04-30T13:58:48.249786-06:00
+custom:
+    Author: dbeatty10
+    Issue: "1038"

--- a/dbt-adapters/src/dbt/include/global_project/macros/adapters/show.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/adapters/show.sql
@@ -7,7 +7,7 @@
   {%- if sql_header is not none -%}
   {{ sql_header }}
   {%- endif %}
-  {{ get_limit_subquery_sql(compiled_code, limit) }}
+  {{ get_limit_sql(compiled_code, limit) }}
 {% endmacro %}
 
 {#
@@ -15,6 +15,13 @@
     to the calling macro.
 #}
 {%- macro get_limit_subquery_sql(sql, limit) -%}
+  {{ adapter.dispatch('get_limit_sql', 'dbt')(sql, limit) }}
+{%- endmacro -%}
+
+{#
+    Renamed from `get_limit_subquery_sql`.
+#}
+{%- macro get_limit_sql(sql, limit) -%}
   {{ adapter.dispatch('get_limit_sql', 'dbt')(sql, limit) }}
 {%- endmacro -%}
 


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-adapters/issues/1038

### Problem

When the `get_limit_subquery_sql` macro was first introduced, the name of the macro included an implementation detail -- it was implemented with a subquery, and the name included that detail.

But the macro was reimplemented in https://github.com/dbt-labs/dbt-adapters/pull/249 and it stopped using a subquery, so there's a mismatch between the macro name and the default implementation.

Now, there are other uses for the logic in this macro (like https://github.com/dbt-labs/dbt-adapters/pull/376), and using it as-is feels misleading.

### Solution

Relax the name of the macro so it doesn't imply using a subquery. Also retain a definition with the old name for backwards compatibility.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
