### PR TITLE
Limit rows in data tests failures using a cross-database macro

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20250430-142018.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20250430-142018.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Limit rows using cross-database macro
+time: 2025-04-30T14:20:18.578658-06:00
+custom:
+    Author: dbeatty10
+    Issue: "1041"

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/tests/helpers.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/tests/helpers.sql
@@ -8,8 +8,7 @@
       {{ fail_calc }} {{ warn_if }} as should_warn,
       {{ fail_calc }} {{ error_if }} as should_error
     from (
-      {{ main_sql }}
-      {{ "limit " ~ limit if limit != none }}
+      {{ get_limit_subquery_sql(main_sql, limit) }}
     ) dbt_internal_test
 {%- endmacro %}
 


### PR DESCRIPTION
resolves #1041

### Problem

@colin-rogers-dbt made a great point here: https://github.com/dbt-labs/dbt-adapters/pull/376#discussion_r2069255527

It applies to this code as well:

https://github.com/dbt-labs/dbt-adapters/blob/6255adf01aa4e3004d0267047c02813ee10d6b5e/dbt-adapters/src/dbt/include/global_project/macros/materializations/tests/helpers.sql#L12

### Solution

Make the default implementation be as cross-database "safe" as possible.

Update `default__get_test_sql` to use [`get_limit_subquery_sql`](https://github.com/dbt-labs/dbt-adapters/blob/6255adf01aa4e3004d0267047c02813ee10d6b5e/dbt-adapters/src/dbt/include/global_project/macros/adapters/show.sql#L21) (ideally renamed to `get_limit_sql` as proposed in https://github.com/dbt-labs/dbt-adapters/issues/1038).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX