### PR TITLE
Allow configuration of BigQuery location value when running tests

### DIFF
--- a/dbt-bigquery/test.env.example
+++ b/dbt-bigquery/test.env.example
@@ -1,6 +1,8 @@
 # Note: These values will come from your BigQuery account and GCP projects.
 
 # Test Environment field definitions
+# BigQuery location to create jobs in - e.g. US, EU
+BIGQUERY_LOCATION=
 # Name of a GCP project you don't have access to query.
 BIGQUERY_TEST_NO_ACCESS_DATABASE=
 # Authentication method required to hookup to BigQuery via client library.

--- a/dbt-bigquery/tests/conftest.py
+++ b/dbt-bigquery/tests/conftest.py
@@ -31,6 +31,7 @@ def oauth_target():
         "method": "oauth",
         "threads": 4,
         "job_retries": 2,
+        "location": os.getenv("BIGQUERY_LOCATION"),
         "compute_region": os.getenv("COMPUTE_REGION") or os.getenv("DATAPROC_REGION"),
         "dataproc_cluster_name": os.getenv("DATAPROC_CLUSTER_NAME"),
         "gcs_bucket": os.getenv("GCS_BUCKET"),
@@ -48,6 +49,7 @@ def service_account_target():
         "method": "service-account-json",
         "threads": 4,
         "job_retries": 2,
+        "location": os.getenv("BIGQUERY_LOCATION"),
         "project": project_id,
         "keyfile_json": credentials,
         # following 3 for python model


### PR DESCRIPTION
resolves #1046
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#N/A

### Problem
Currently it is not possible to run tests against different regions than the default (US). This prevents users from contributing that are unable to create jobs in that region.

### Solution
This PR adds a new variable to the test environment that is used in the testing profiles to set the location for jobs to be created in. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
