### PR TITLE
Keep limit in get_test_sql

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20250501-150241.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20250501-150241.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Keep limit in get_test_sql
+time: 2025-05-01T15:02:41.175961+01:00
+custom:
+    Author: aranke
+    Issue: ' '

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/tests/test.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/tests/test.sql
@@ -56,7 +56,7 @@
 
   {% call statement('main', fetch_result=True) -%}
 
-    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if)}}
+    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit)}}
 
   {%- endcall %}
 

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/tests/test.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/tests/test.sql
@@ -56,7 +56,7 @@
 
   {% call statement('main', fetch_result=True) -%}
 
-    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit)}}
+    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit=none)}}
 
   {%- endcall %}
 


### PR DESCRIPTION
resolves failing dbt-core runs: https://github.com/dbt-labs/dbt-core/actions/runs/14774226697/job/41479499471

### Problem

dbt-core tests were failing

### Solution

Add limit back to `get_test_sql` that was removed in #376.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
