### PR TITLE
Always run `dbt-spark` integration tests on `py3.10` 

### DIFF
--- a/.github/workflows/_integration-tests.yml
+++ b/.github/workflows/_integration-tests.yml
@@ -378,7 +378,9 @@ jobs:
         -   uses: actions/setup-python@v5
             with:
                 python-version: ${{ inputs.python-version }}
-        -   run: echo "HATCH_PYTHON=${{ inputs.python-version }}" >> $GITHUB_ENV
+        # TODO: update 3.10 to ${{ inputs.python-version }} once we update default python to >=3.10
+        # the version of dagger-io that we use does not support py3.9
+        -   run: echo "HATCH_PYTHON=3.10" >> $GITHUB_ENV
         -   uses: pypa/hatch@install
         -   run: hatch run pip install -r dagger/requirements.txt
         -   run: hatch run ${{ inputs.hatch-env }}:integration-tests --profile ${{ matrix.profile }}

--- a/.github/workflows/_integration-tests.yml
+++ b/.github/workflows/_integration-tests.yml
@@ -382,5 +382,4 @@ jobs:
         # the version of dagger-io that we use does not support py3.9
         -   run: echo "HATCH_PYTHON=3.10" >> $GITHUB_ENV
         -   uses: pypa/hatch@install
-        -   run: hatch run pip install -r dagger/requirements.txt
         -   run: hatch run ${{ inputs.hatch-env }}:integration-tests --profile ${{ matrix.profile }}

--- a/dbt-spark/hatch.toml
+++ b/dbt-spark/hatch.toml
@@ -78,7 +78,10 @@ features=["all"]
 
 [envs.ci.scripts]
 unit-tests = "python -m pytest tests/unit --ddtrace"
-integration-tests = "python dagger/run_dbt_spark_tests.py {args:--profile apache_spark}"
+integration-tests = [
+    "pip install -r dagger/requirements.txt",
+    "python dagger/run_dbt_spark_tests.py {args:--profile apache_spark}",
+]
 
 [envs.cd]
 pre-install-commands = []
@@ -95,4 +98,7 @@ features=["all"]
 
 [envs.cd.scripts]
 unit-tests = "python -m pytest tests/unit --ddtrace"
-integration-tests = "python dagger/run_dbt_spark_tests.py {args:--profile apache_spark}"
+integration-tests = [
+    "pip install -r dagger/requirements.txt",
+    "python dagger/run_dbt_spark_tests.py {args:--profile apache_spark}",
+]


### PR DESCRIPTION
`dagger-io` does not support `py3.9`, which is our current default python version. Once `py3.9` hits end of life later this year, we can update our default version and revert this patch.

We were previously running these tests on `py3.12` unknowingly. See #1016 to see how we addressed this (setting `HATCH_PYTHON`).