### PR TITLE
Support description updates for incremental BigQuery models

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Under the Hood-20250501-110649.yaml
+++ b/dbt-bigquery/.changes/unreleased/Under the Hood-20250501-110649.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Allow configuration of BigQuery location value when running tests
+time: 2025-05-01T11:06:49.845082+01:00
+custom:
+    Author: alexr-lh
+    Issue: "1046"

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/adapters.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/adapters.sql
@@ -101,8 +101,10 @@
   {{ return(adapter.check_schema_exists(information_schema.database, schema)) }}
 {% endmacro %}
 
-{#-- relation-level macro is not implemented. This is handled in the CTAs statement #}
 {% macro bigquery__persist_docs(relation, model, for_relation, for_columns) -%}
+  {% if for_relation and config.persist_relation_docs() and model.description %}
+    {% do alter_relation_comment(relation, model.description) %}
+  {% endif %}
   {% if for_columns and config.persist_column_docs() and model.columns %}
     {% do alter_column_comment(relation, model.columns) %}
   {% endif %}
@@ -110,6 +112,10 @@
 
 {% macro bigquery__alter_column_comment(relation, column_dict) -%}
   {% do adapter.update_columns(relation, column_dict) %}
+{% endmacro %}
+
+{% macro bigquery__alter_relation_comment(relation, description) -%}
+  {% do adapter.update_table_description(relation.database, relation.schema, relation.identifier, model.description) %}
 {% endmacro %}
 
 {% macro bigquery__alter_relation_add_columns(relation, add_columns) %}

--- a/dbt-bigquery/test.env.example
+++ b/dbt-bigquery/test.env.example
@@ -1,6 +1,8 @@
 # Note: These values will come from your BigQuery account and GCP projects.
 
 # Test Environment field definitions
+# BigQuery location to create jobs in - e.g. US, EU
+BIGQUERY_LOCATION=
 # Name of a GCP project you don't have access to query.
 BIGQUERY_TEST_NO_ACCESS_DATABASE=
 # Authentication method required to hookup to BigQuery via client library.

--- a/dbt-bigquery/tests/conftest.py
+++ b/dbt-bigquery/tests/conftest.py
@@ -31,6 +31,7 @@ def oauth_target():
         "method": "oauth",
         "threads": 4,
         "job_retries": 2,
+        "location": os.getenv("BIGQUERY_LOCATION"),
         "compute_region": os.getenv("COMPUTE_REGION") or os.getenv("DATAPROC_REGION"),
         "dataproc_cluster_name": os.getenv("DATAPROC_CLUSTER_NAME"),
         "gcs_bucket": os.getenv("GCS_BUCKET"),
@@ -48,6 +49,7 @@ def service_account_target():
         "method": "service-account-json",
         "threads": 4,
         "job_retries": 2,
+        "location": os.getenv("BIGQUERY_LOCATION"),
         "project": project_id,
         "keyfile_json": credentials,
         # following 3 for python model


### PR DESCRIPTION
resolves #585
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/# N/A

### Problem

Currently BigQuery does not update persisted table descriptions on incremental runs.

### Solution

This modifies `bigquery__persist_docs` to include relations as well. A test is added to verify that if a model's description is changed and the model subsequently run, that the table's description has been updated. 

This may want to be pushed back into dbt-adapters but that's beyond me without further guidance. As noted in [this](https://github.com/dbt-labs/dbt-bigquery/pull/1139) PR, the testing strategy is a little unclear. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
