### PR TITLE
Support description updates for incremental BigQuery models

### DIFF
--- a/dbt-bigquery/src/dbt/include/bigquery/macros/adapters.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/adapters.sql
@@ -101,8 +101,10 @@
   {{ return(adapter.check_schema_exists(information_schema.database, schema)) }}
 {% endmacro %}
 
-{#-- relation-level macro is not implemented. This is handled in the CTAs statement #}
 {% macro bigquery__persist_docs(relation, model, for_relation, for_columns) -%}
+  {% if for_relation and config.persist_relation_docs() and model.description %}
+    {% do alter_relation_comment(relation, model.description) %}
+  {% endif %}
   {% if for_columns and config.persist_column_docs() and model.columns %}
     {% do alter_column_comment(relation, model.columns) %}
   {% endif %}
@@ -110,6 +112,10 @@
 
 {% macro bigquery__alter_column_comment(relation, column_dict) -%}
   {% do adapter.update_columns(relation, column_dict) %}
+{% endmacro %}
+
+{% macro bigquery__alter_relation_comment(relation, description) -%}
+  {% do adapter.update_table_description(relation.database, relation.schema, relation.identifier, model.description) %}
 {% endmacro %}
 
 {% macro bigquery__alter_relation_add_columns(relation, add_columns) %}


### PR DESCRIPTION
resolves #585
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

### Problem

Currently BigQuery does not update persisted table descriptions on incremental runs.

### Solution

This modifies bigquery__persist_docs to include relations as well. A test is added to verify that if a model's description is changed and the model subsequently run, that the table's description has been updated.

This may want to be pushed back into dbt-adapters but that's beyond me without further guidance. As noted in this PR, the testing strategy is a little unclear.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
