### PR TITLE
Bump `libpq-dev`

### DIFF
--- a/dbt-bigquery/docker/Dockerfile
+++ b/dbt-bigquery/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     build-essential=12.9 \
     ca-certificates=20210119 \
     git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.18-0+deb11u1 \
+    libpq-dev=13.20-0+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \

--- a/dbt-postgres/docker/Dockerfile
+++ b/dbt-postgres/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     build-essential=12.9 \
     ca-certificates=20210119 \
     git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.18-0+deb11u1 \
+    libpq-dev=13.20-0+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \

--- a/dbt-redshift/docker/Dockerfile
+++ b/dbt-redshift/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     build-essential=12.9 \
     ca-certificates=20210119 \
     git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.18-0+deb11u1 \
+    libpq-dev=13.20-0+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \

--- a/dbt-snowflake/docker/Dockerfile
+++ b/dbt-snowflake/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     build-essential=12.9 \
     ca-certificates=20210119 \
     git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.18-0+deb11u1 \
+    libpq-dev=13.20-0+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \

--- a/dbt-spark/docker/Dockerfile
+++ b/dbt-spark/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     ca-certificates=20210119 \
     gcc=4:10.2.1-1 \
     git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.18-0+deb11u1 \
+    libpq-dev=13.20-0+deb11u1 \
     libsasl2-dev=2.1.27+dfsg-2.1+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-adapters/issues/1060

### Problem

User reported broken packages for `dbt-core==1.9.4` when trying to build Dockerimage on arm64.

### Solution

Adopt this change for each Dockerfile for each adapter: https://github.com/dbt-labs/dbt-core/pull/11373

> [!NOTE]  
> I didn't test if this actually works or not.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
