### PR TITLE
Replace certifi upper version constraint with inequality

### DIFF
--- a/dbt-snowflake/pyproject.toml
+++ b/dbt-snowflake/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "dbt-adapters>=1.10.4,<2.0",
     # lower bound pin due to CVE-2025-24794
     "snowflake-connector-python[secure-local-storage]>=3.13.1,<4.0.0",
-    "certifi<2025.4.26",
+    "certifi!=2025.4.26",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
     "dbt-core>=1.8.0",
     # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core


### PR DESCRIPTION
resolves #1036, improving on #1027

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

It's pretty important to keep CAs up-to-date, so this definitely isn't sustainable. People may pin the current version of `dbt-snowflake` without noticing the `certifi` upper-bound, and as a result they will eventually end up with connection issues and/or not recognizing revoked certificates.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Replace `<` with `!=` to block only the problematic version and not future versions.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
