### PR TITLE
add customer to RELATION_TYPE_MAP

### DIFF
--- a/dbt-athena/src/dbt/adapters/athena/relation.py
+++ b/dbt-athena/src/dbt/adapters/athena/relation.py
@@ -115,6 +115,7 @@ RELATION_TYPE_MAP = {
     "view": TableType.VIEW,
     "cte": TableType.CTE,
     "materializedview": TableType.MATERIALIZED_VIEW,
+    "customer": TableType.TABLE
 }
 
 


### PR DESCRIPTION
Adds support for S3Tables customer table type https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-tables.html

resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

dbt codegen will not generate source for an unrecognized table type "customer". This table type is associated with managed S3 table buckets.

### Solution

This changes the RELATION_TYPE_MAP to add support for the "customer" table type.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
