### PR TITLE
[Bug] Apply cluster key to tables after table creation during a ctas statement

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20250507-135848.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20250507-135848.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Apply cluster keys via a separate ALTER statement after creating a table via
+  a CTAS statement.
+time: 2025-05-07T13:58:48.771492-04:00
+custom:
+  Author: mikealfare
+  Issue: "1071"

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
@@ -87,7 +87,6 @@ create or replace {{ transient }}table {{ relation }}
     {%- if contract_config.enforced %}
     {{ get_table_columns_and_constraints() }}
     {%- endif %}
-    {{ optional('cluster by', catalog_relation.cluster_by, '(', '') }}
     {% if copy_grants -%} copy grants {%- endif %}
     as (
         {%- if catalog_relation.cluster_by is not none -%}
@@ -144,7 +143,6 @@ create or replace iceberg table {{ relation }}
     {%- if contract_config.enforced %}
     {{ get_table_columns_and_constraints() }}
     {%- endif %}
-    {{ optional('cluster by', catalog_relation.cluster_by, '(', '') }}
     {{ optional('external_volume', catalog_relation.external_volume, "'") }}
     catalog = 'SNOWFLAKE'  -- required, and always SNOWFLAKE for built-in Iceberg tables
     base_location = '{{ catalog_relation.base_location }}'


### PR DESCRIPTION
### Problem

Some users are seeing issues when creating table materializations with a cluster by key. Per Snowflake docs, this should be done afterwards via an alter statement.

### Solution

Remove the cluster by clause from the CTAS statement and run it as a separate alter statement afterwards.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
