### PR TITLE
pin psycopg2-binary in hatch same as pyproject.toml

### DIFF
--- a/dbt-postgres/hatch.toml
+++ b/dbt-postgres/hatch.toml
@@ -16,6 +16,7 @@ dependencies = [
     "ddtrace==2.3.0",
     "pre-commit==3.7.0",
     "freezegun",
+    "psycopg2-binary>=2.9,<3.0",
     "pytest>=7.0,<8.0",
     "pytest-dotenv",
     "pytest-mock",
@@ -31,8 +32,8 @@ unit-tests = "python -m pytest {args:tests/unit}"
 integration-tests = "python -m pytest {args:tests/functional}"
 docker-dev = [
     "echo Does not support integration testing, only development and unit testing. See issue https://github.com/dbt-labs/dbt-postgres/issues/99",
-	"docker build -f docker/dev.Dockerfile -t dbt-postgres-dev .",
-	"docker run --rm -it --name dbt-postgres-dev -v $(pwd):/opt/code dbt-postgres-dev",
+    "docker build -f docker/dev.Dockerfile -t dbt-postgres-dev .",
+    "docker run --rm -it --name dbt-postgres-dev -v $(pwd):/opt/code dbt-postgres-dev",
 ]
 docker-prod = "docker build -f docker/Dockerfile -t dbt-postgres ."
 
@@ -42,6 +43,7 @@ dependencies = [
     "wheel",
     "twine",
     "check-wheel-contents",
+    "psycopg2-binary>=2.9,<3.0",
 ]
 [envs.build.scripts]
 check-all = [
@@ -72,6 +74,7 @@ dependencies = [
     "pytest>=7.0,<8.0",
     "pytest-mock",
     "pytest-xdist",
+    "psycopg2-binary>=2.9,<3.0",
 ]
 [envs.ci.scripts]
 unit-tests = "python -m pytest tests/unit --ddtrace"
@@ -83,6 +86,7 @@ dependencies = [
     "dbt-tests-adapter>=1.11.0,<2.0",
     "ddtrace==2.3.0",
     "freezegun",
+    "psycopg2-binary>=2.9,<3.0",
     "pytest>=7.0,<8.0",
     "pytest-mock",
     "pytest-xdist",


### PR DESCRIPTION
### Problem
The scheduled tests are trying to install psycopg2 from source instead o the binary.  We pin to the binary in pyproject.toml but not in hatch.toml.  This means our tests are running with the source install while the package is installed with the binary.  

psycopg2-binary should install as a pre-built wheel, but if a wheel is not available for your platform or Python version, pip falls back to building from source, which requires pg_config.

error
```
writing manifest file '/private/var/folders/hn/k7g0_sh57112t0xtjxcjcm5r0000gn/T/pip-pip-egg-info-30h16iju/psycopg2_binary.egg-info/SOURCES.txt'
      
      Error: pg_config executable not found.
      
      pg_config is required to build psycopg2 from source.  Please add the directory
      containing pg_config to the $PATH or specify the full executable path with the
      option:
      
          python setup.py build_ext --pg-config /path/to/pg_config build ...
      
      or with the pg_config option in 'setup.cfg'.
      
      If you prefer to avoid building psycopg2 from source, please install the PyPI
      'psycopg2-binary' package instead.
      
      For further information please check the 'doc/src/install.rst' file (also at
      <https://www.psycopg.org/docs/install.html>).
```

### Solution

Pin to the binary in the hatch.toml as well to ensure we don't install from source. 

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
