### PR TITLE
Drop target table before cloning

### DIFF
--- a/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/clone.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/clone.sql
@@ -3,7 +3,8 @@
 {% endmacro %}
 
 {% macro bigquery__create_or_replace_clone(this_relation, defer_relation) %}
+    drop table if exists {{ this_relation }};
     create or replace
       table {{ this_relation }}
-      clone {{ defer_relation }}
+      clone {{ defer_relation }};
 {% endmacro %}


### PR DESCRIPTION
resolves #1077 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
BQ requires actual dropping of the table before cloning (`create or replace ...` is not sufficient) if the partition spec changes.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
