### PR TITLE
mac + python 3.9 test fix

### DIFF
--- a/.github/workflows/_integration-tests.yml
+++ b/.github/workflows/_integration-tests.yml
@@ -209,7 +209,13 @@ jobs:
         -   uses: actions/setup-python@v5
             with:
                 python-version: ${{ inputs.python-version }}
-        -   run: echo "HATCH_PYTHON=${{ inputs.python-version }}" >> $GITHUB_ENV
+        -   run: |
+                echo "HATCH_PYTHON=${{ inputs.python-version }}" >> $GITHUB_ENV
+                echo "PIP_ONLY_BINARY=psycopg2-binary" >> $GITHUB_ENV
+        # mac + 3.9 requires postgresql to be installed manually so that the psycopg2-binary wheel can be found
+        -   if: inputs.python-version == '3.9' && inputs.os == 'macos-14'
+            run: |
+                brew install postgresql
         -   run: psql -f ./scripts/setup_test_database.sql
             env:
                 PGHOST: ${{ vars.POSTGRES_TEST_HOST }}

--- a/.github/workflows/_unit-tests.yml
+++ b/.github/workflows/_unit-tests.yml
@@ -81,7 +81,14 @@ jobs:
         -   uses: actions/setup-python@v5
             with:
                 python-version: ${{ inputs.python-version }}
-        -   run: echo "HATCH_PYTHON=${{ inputs.python-version }}" >> $GITHUB_ENV
+        -   run: |
+                echo "HATCH_PYTHON=${{ inputs.python-version }}" >> $GITHUB_ENV
+                echo "PIP_ONLY_BINARY=psycopg2-binary" >> $GITHUB_ENV
+        # mac + 3.9 requires postgresql to be installed manually so that the psycopg2-binary wheel can be found
+        -   name: "psycopg2-binary check"
+            if: inputs.python-version == '3.9' && inputs.os == 'macos-14'
+            run: |
+                brew install postgresql
         -   uses: pypa/hatch@install
         -   run: brew install unixodbc
             if: inputs.package == 'dbt-spark' && runner.os == 'macOS'

--- a/.github/workflows/_verify-build.yml
+++ b/.github/workflows/_verify-build.yml
@@ -73,7 +73,14 @@ jobs:
         -   uses: actions/setup-python@v5
             with:
                 python-version: ${{ inputs.python-version }}
-        -   run: echo "HATCH_PYTHON=${{ inputs.python-version }}" >> $GITHUB_ENV
+        -   run: |
+                echo "HATCH_PYTHON=${{ inputs.python-version }}" >> $GITHUB_ENV
+                echo "PIP_ONLY_BINARY=psycopg2-binary" >> $GITHUB_ENV
+        # mac + 3.9 requires postgresql to be installed manually so that the psycopg2-binary wheel can be found
+        -   name: "psycopg2-binary check"
+            if: inputs.python-version == '3.9' && inputs.os == 'macos-14'
+            run: |
+                brew install postgresql
         -   uses: pypa/hatch@install
         -   run: hatch build && hatch run build:check-all
             working-directory: ./${{ inputs.package }}

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -1,5 +1,5 @@
 name: "Scheduled tests"
-run-name: "Scheduled tests - ${{ github.actor }}"
+run-name: "Scheduled tests ${{ github.event_name != 'schedule' && format('- {0}', github.actor) }}"
 
 on:
     schedule:
@@ -26,8 +26,8 @@ jobs:
                 python-version: ${{ fromJSON(vars.SUPPORTED_PYTHON_VERSIONS) }}
         with:
             package: ${{ matrix.package }}
-            branch: ${{ github.event.pull_request.head.ref }}
-            repository: ${{ github.event.pull_request.head.repo.full_name }}
+            branch: ${{ github.ref }}
+            repository: ${{ github.repository }}
             os: ${{ matrix.os }}
             python-version: ${{ matrix.python-version }}
 
@@ -49,8 +49,8 @@ jobs:
                 python-version: ${{ fromJSON(vars.SUPPORTED_PYTHON_VERSIONS) }}
         with:
             package: ${{ matrix.package }}
-            branch: ${{ github.event.pull_request.head.ref }}
-            repository: ${{ github.event.pull_request.head.repo.full_name }}
+            branch: ${{ github.ref }}
+            repository: ${{ github.repository }}
             os: ${{ matrix.os }}
             python-version: ${{ matrix.python-version }}
             hatch-env: "ci"
@@ -59,8 +59,8 @@ jobs:
         uses: ./.github/workflows/_integration-tests.yml
         with:
             packages: ${{ toJSON('[dbt-athena, dbt-bigquery, dbt-postgres, dbt-redshift, dbt-snowflake, dbt-spark]') }}
-            branch: ${{ github.event.pull_request.head.ref }}
-            repository: ${{ github.event.pull_request.head.repo.full_name }}
+            branch: ${{ github.ref }}
+            repository: ${{ github.repository }}
             os: ${{ vars.DEFAULT_RUNNER }}
             python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}
             hatch-env: "ci"

--- a/dbt-postgres/hatch.toml
+++ b/dbt-postgres/hatch.toml
@@ -16,7 +16,6 @@ dependencies = [
     "ddtrace==2.3.0",
     "pre-commit==3.7.0",
     "freezegun",
-    "psycopg2-binary>=2.9,<3.0",
     "pytest>=7.0,<8.0",
     "pytest-dotenv",
     "pytest-mock",
@@ -74,7 +73,6 @@ dependencies = [
     "pytest>=7.0,<8.0",
     "pytest-mock",
     "pytest-xdist",
-    "psycopg2-binary>=2.9,<3.0",
 ]
 [envs.ci.scripts]
 unit-tests = "python -m pytest tests/unit --ddtrace"
@@ -86,7 +84,6 @@ dependencies = [
     "dbt-tests-adapter>=1.11.0,<2.0",
     "ddtrace==2.3.0",
     "freezegun",
-    "psycopg2-binary>=2.9,<3.0",
     "pytest>=7.0,<8.0",
     "pytest-mock",
     "pytest-xdist",


### PR DESCRIPTION

### Problem

macos doesn't have postgresql installed when using python 3.9.  

### Solution

Force install it for that combo.

Test run: https://github.com/dbt-labs/dbt-adapters/actions/runs/14929565819

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
