### PR TITLE
add permissions for workflows

### DIFF
--- a/.github/workflows/_publish-internal.yml
+++ b/.github/workflows/_publish-internal.yml
@@ -41,6 +41,10 @@ defaults:
 env:
   TEMP_PROFILE_NAME: "temp_aws_profile"
 
+permissions:
+    contents: read
+    id-token: write
+
 jobs:
     publish:
         runs-on: ${{ vars.DEFAULT_RUNNER }}

--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -1,6 +1,10 @@
 name: "Publish internal"
 run-name: "Publish internal - ${{ github.actor }} - package:${{ inputs.package }} branch:${{ inputs.branch }} skip-unit-tests:${{ inputs.skip-unit-tests }} skip-integration-tests:${{ inputs.skip-integration-tests }}"
 
+permissions:
+    id-token: write
+    contents: read
+
 on:
     workflow_dispatch:
         inputs:

--- a/.github/workflows/publish-oss.yml
+++ b/.github/workflows/publish-oss.yml
@@ -42,6 +42,10 @@ concurrency:
     group: Publish_OSS-${{ inputs.package }}-${{ inputs.deploy-to }}
     cancel-in-progress: true
 
+permissions:
+    contents: write
+    id-token: write
+
 jobs:
     work-branch:
         runs-on: ${{ vars.DEFAULT_RUNNER }}

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -10,6 +10,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.number }}
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
     affected-packages:
         runs-on: ubuntu-latest
@@ -47,6 +50,9 @@ jobs:
     changelog-entry-check:
         uses: ./.github/workflows/_changelog-entry-check.yml
         needs: affected-packages
+        permissions:
+            contents: read
+            pull-requests: write
         if: ${{ toJSON(fromJSON(needs.affected-packages.outputs.changelog-entry-check)) != '[]' }}
         strategy:
             fail-fast: false
@@ -97,6 +103,9 @@ jobs:
     integration-tests:
         uses: ./.github/workflows/_integration-tests.yml
         needs: affected-packages
+        permissions:
+            id-token: write
+            contents: read
         if: ${{ toJSON(fromJSON(needs.affected-packages.outputs.integration-tests)) != '[]' }}
         with:
             packages: ${{ needs.affected-packages.outputs.integration-tests }}

--- a/.github/workflows/scheduled-publishing.yml
+++ b/.github/workflows/scheduled-publishing.yml
@@ -5,6 +5,10 @@ on:
     schedule:
     -   cron: "0 0 * * SUN"
 
+permissions:
+    id-token: write
+    contents: read
+
 jobs:
     publish:
         strategy:

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -6,6 +6,9 @@ on:
     -   cron: '0 3 * * *'
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     verify-builds:
         uses: ./.github/workflows/_verify-build.yml
@@ -57,6 +60,9 @@ jobs:
 
     integration-tests:
         uses: ./.github/workflows/_integration-tests.yml
+        permissions:
+            contents: read
+            id-token: write
         with:
             packages: ${{ toJSON('[dbt-athena, dbt-bigquery, dbt-postgres, dbt-redshift, dbt-snowflake, dbt-spark]') }}
             branch: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
### Problem

All workflows should have permissions defined.

### Solution

this adds least permissions and ensure we pass through contents: read when setting extra permissions at a job level.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
