### PR TITLE
add read all permission to PR CI

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -10,8 +10,7 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.number }}
     cancel-in-progress: true
 
-permissions:
-    contents: read
+permissions: read-all
 
 jobs:
     affected-packages:


### PR DESCRIPTION
### Problem

Getting the error:

```
[Invalid workflow file: .github/workflows/pull-request-checks.yml#L72](https://github.com/dbt-labs/dbt-adapters/actions/runs/14933133750/workflow)
The workflow is not valid. .github/workflows/pull-request-checks.yml (Line: 72, Col: 5): Error calling workflow 'dbt-labs/dbt-adapters/.github/workflows/_verify-build.yml@cb5deaa0dea0bf84d156f6819d1111d93aa3dbd3'. The workflow is requesting 'actions: read, attestations: read, checks: read, deployments: read, discussions: read, issues: read, packages: read, pages: read, pull-requests: read, repository-projects: read, statuses: read, security-events: read, id-token: read, models: read', but is only allowed 'actions: none, a[...]
```

### Solution

Allow full reading.

We will need to force merge this past branch requirements since this workflow triggers off pull_request_target which is what's on main now.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
