### PR TITLE
Add query comments to system queries

### DIFF
--- a/dbt-bigquery/src/dbt/adapters/bigquery/connections.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/connections.py
@@ -274,6 +274,28 @@ class BigQueryConnectionManager(BaseConnectionManager):
                 limit=limit,
             )
 
+    def raw_execute_with_comment(
+        self,
+        sql: str,
+        use_legacy_sql: bool = False,
+        limit: Optional[int] = None,
+        dry_run: bool = False,
+    ):
+        """
+        A lightweight wrapper over raw_execute that prepends the dbt query comment.
+
+        This exists as a "third way" between raw_execute (fully manual, no preprocessing)
+        and execute (postprocessing and formatting). This is useful when you need query
+        auditing but no Adapter Response.
+        """
+        sql = self._add_query_comment(sql)
+        return self.raw_execute(
+            sql,
+            use_legacy_sql=use_legacy_sql,
+            limit=limit,
+            dry_run=dry_run,
+        )
+
     def execute(
         self, sql, auto_begin=False, fetch=None, limit: Optional[int] = None
     ) -> Tuple[BigQueryAdapterResponse, "agate.Table"]:

--- a/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
@@ -435,7 +435,7 @@ class BigQueryAdapter(BaseAdapter):
         :param str sql: The sql to execute.
         :return: List[BigQueryColumn]
         """
-        _, iterator = self.connections.raw_execute(sql)
+        _, iterator = self.connections.raw_execute_with_comment(sql)
         columns = [self.Column.create_from_field(field) for field in iterator.schema]
         flattened_columns = []
         for column in columns:
@@ -447,7 +447,7 @@ class BigQueryAdapter(BaseAdapter):
         try:
             conn = self.connections.get_thread_connection()
             client = conn.handle
-            query_job, iterator = self.connections.raw_execute(select_sql)
+            query_job, iterator = self.connections.raw_execute_with_comment(select_sql)
             query_table = client.get_table(query_job.destination)
             return self._get_dbt_columns_from_bq_table(query_table)
 

--- a/dbt-bigquery/tests/functional/test_incremental_materialization.py
+++ b/dbt-bigquery/tests/functional/test_incremental_materialization.py
@@ -1,9 +1,14 @@
+import json
 import pytest
-from dbt.tests.util import run_dbt
+import re
+from dbt.tests.util import run_dbt, run_dbt_and_capture
 
 # This is a short term hack, we need to go back
 # and make adapter implementations of:
 # https://github.com/dbt-labs/dbt-core/pull/6330
+
+
+_COMMENT_RE = re.compile(r'/\*\s*{[^}]*"dbt_version"\s*:\s*"[^"]+"[^}]*}\s*\*/')
 
 _INCREMENTAL_MODEL = """
 {{
@@ -14,16 +19,41 @@ _INCREMENTAL_MODEL = """
 
 {% if not is_incremental() %}
 
-    select 10 as id, cast('2020-01-01 01:00:00' as datetime) as date_hour union all
-    select 30 as id, cast('2020-01-01 02:00:00' as datetime) as date_hour
+    select
+        10 as id, cast('2020-01-01 01:00:00' as datetime) as date_hour
+    union all select
+        30 as id, cast('2020-01-01 02:00:00' as datetime) as date_hour
 
 {% else %}
 
-    select 20 as id, cast('2020-01-01 01:00:00' as datetime) as date_hour union all
-    select 40 as id, cast('2020-01-01 02:00:00' as datetime) as date_hour
+    select
+        20 as id, cast('2020-01-01 01:00:00' as datetime) as date_hour
+    union all select
+        40 as id, cast('2020-01-01 02:00:00' as datetime) as date_hour
 
 {% endif %}
--- Test Comment To Prevent Reccurence of https://github.com/dbt-labs/dbt-core/issues/6485
+-- Test Comment To Prevent Recurrence of
+--     https://github.com/dbt-labs/dbt-core/issues/6485
+"""
+
+INCREMENTAL_MODEL_COPY_PARTITIONS = """
+{{
+  config(
+      materialized='incremental',
+      incremental_strategy='insert_overwrite',
+      partition_by={
+          'field': '_partition',
+          'granularity': 'day',
+          'data_type': 'timestamp',
+          'time_ingestion_partitioning': True,
+          'copy_partitions': True,
+      },
+      on_schema_change='append_new_columns'
+  )
+}}
+SELECT
+  timestamp_trunc(current_timestamp(), day) AS _partition,
+  'some value'                               AS col1
 """
 
 
@@ -39,3 +69,49 @@ class TestIncrementalModel(BaseIncrementalModelConfig):
         assert len(results) == 1
         results = run_dbt(["run"])
         assert len(results) == 1
+
+
+class TestAllQueriesHaveDbtComment:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_incremental_model.sql": INCREMENTAL_MODEL_COPY_PARTITIONS}
+
+    def _extract_executed_sql(self, raw_logs: str) -> list[str]:
+        """
+        Return every SQL script that dbt 1.4+ actually sent to BigQuery.
+
+        In JSON logs each statement is logged by an event whose `data`
+        payload is a dict containing a key `"sql"`.
+        """
+        scripts: list[str] = []
+        for line in raw_logs.splitlines():
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            data = parsed.get("data")
+            if isinstance(data, dict) and "sql" in data:
+                sql = str(data["sql"]).strip()
+                if sql:
+                    scripts.append(sql)
+        return scripts
+
+    def _has_structured_comment(self, sql: str) -> bool:
+        """True iff the first non-blank line is the structured dbt comment."""
+        first_line = sql.lstrip().splitlines()[0]
+        return bool(_COMMENT_RE.fullmatch(first_line))
+
+    def test_every_query_has_comment(self, project):
+        run_dbt(["run"])
+        _, raw_logs = run_dbt_and_capture(["--debug", "--log-format=json", "run"])
+
+        executed_sqls = self._extract_executed_sql(raw_logs)
+        assert executed_sqls, "No SQL was captured from the dbt logs"
+
+        missing = [sql for sql in executed_sqls if not self._has_structured_comment(sql)]
+
+        assert not missing, (
+            f"{len(missing)} queries are missing structured dbt comments.\n\n"
+            + "\n\n---\n\n".join(missing)
+        )


### PR DESCRIPTION
resolves #1090 

## Problem
Wowee, wowee, this one took me a fair bit of effort to find a case to reproduce it. But we stuck the landing 🏂 

* The BigQuery adapter still had a few helper paths (`get_column_schema_from_query`,  
  `get_columns_in_select_sql`, and the `copy_partitions` flow they trigger) that called
  `raw_execute()` directly.  
* `raw_execute()` bypasses dbt’s query-comment injection, so those statements
  (e.g. the final `COPY … TO …` job produced when `copy_partitions=True`) reached
  BigQuery without the structured  
  `/* {"app": "dbt", "dbt_version": …, "node_id": …} */` header.  
* Existing tests only looked at statements beginning with `CREATE | MERGE | DROP`,
  so the leak went undetected.

## Solution
* Introduced **`raw_execute_with_comment()`**, a thin wrapper that prepends
  `add_query_comment()` to every SQL string before delegating to `raw_execute()`.
* Re-routed all helper calls that previously used `raw_execute()` to use the new
  wrapper instead:
* Added a regression test that used the edge case of `copy_partitions=True` to test this behavior
* I used TDD to verify this test is actually functioning

Result: **every query the BigQuery adapter sends—data-load scripts *and*
metadata helpers—now carries the structured dbt query comment.**

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
