### PR TITLE
update error check to account for both types of logging

### DIFF
--- a/dbt-redshift/tests/functional/adapter/test_exception_handling.py
+++ b/dbt-redshift/tests/functional/adapter/test_exception_handling.py
@@ -98,4 +98,4 @@ class TestRetryAll:
 
     def test_running_bad_model_retries(self, project):
         result, log = run_dbt_and_capture(["run", "--log-level=debug"], expect_pass=False)
-        assert "adapter: Got a retryable error" in log
+        assert "Got a retryable error" in log


### PR DESCRIPTION
The logging is slightly different depending on whether it's JSON format or text format. The original test may pass locally because that's text(?) format whereas CI uses JSON (or the other way around).