### PR TITLE
fix permissions

### DIFF
--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -1,13 +1,12 @@
 name: "Scheduled tests"
-run-name: "Scheduled tests ${{ github.event_name != 'schedule' && format('- {0}', github.actor) }}"
+run-name: "Scheduled tests ${{ (github.event_name != 'schedule' && format('- {0}', github.actor)) || '' }}"
 
 on:
     schedule:
     -   cron: '0 3 * * *'
     workflow_dispatch:
 
-permissions:
-    contents: read
+permissions: read-all
 
 jobs:
     verify-builds:


### PR DESCRIPTION
### Problem

Bad permissions on scheduled tests

### Solution

Give them read-all.

Test run: https://github.com/dbt-labs/dbt-adapters/actions/runs/15001882243

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
