### PR TITLE
Fix dev and ci to install all requirements during pre-installation to ensure transients dependencies are also installed from main

### DIFF
--- a/dbt-athena-community/hatch.toml
+++ b/dbt-athena-community/hatch.toml
@@ -4,6 +4,8 @@ sources = ["src"]
 
 [envs.default]
 pre-install-commands = [
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pip install -e ../dbt-adapters",
     "pip install -e ../dbt-tests-adapter",
     "pip install -e ../dbt-athena",
@@ -54,6 +56,8 @@ check-sdist = [
 
 [envs.ci]
 pre-install-commands = [
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pip install -e ../dbt-adapters",
     "pip install -e ../dbt-tests-adapter",
     "pip install -e ../dbt-athena",

--- a/dbt-athena/hatch.toml
+++ b/dbt-athena/hatch.toml
@@ -7,12 +7,12 @@ sources = ["src"]
 
 [envs.default]
 pre-install-commands = [
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pip install -e ../dbt-adapters",
     "pip install -e ../dbt-tests-adapter",
 ]
 dependencies = [
-    "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",
     "moto~=5.0.13",
     "pre-commit==3.7.0",
@@ -56,12 +56,12 @@ check-sdist = [
 
 [envs.ci]
 pre-install-commands = [
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pip install -e ../dbt-adapters",
     "pip install -e ../dbt-tests-adapter",
 ]
 dependencies = [
-    "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",
     "moto~=5.0.13",
     "pyparsing~=3.1.4",

--- a/dbt-bigquery/hatch.toml
+++ b/dbt-bigquery/hatch.toml
@@ -7,12 +7,12 @@ sources = ["src"]
 
 [envs.default]
 pre-install-commands = [
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pip install -e ../dbt-adapters",
     "pip install -e ../dbt-tests-adapter",
 ]
 dependencies = [
-    "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",
     "ipdb~=0.13.13",
     "pre-commit==3.7.0",
@@ -67,12 +67,12 @@ docker-prod = "docker build -f docker/Dockerfile -t dbt-bigquery ."
 
 [envs.ci]
 pre-install-commands = [
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pip install -e ../dbt-adapters",
     "pip install -e ../dbt-tests-adapter",
 ]
 dependencies = [
-    "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",
     "flaky",
     "freezegun",

--- a/dbt-postgres/hatch.toml
+++ b/dbt-postgres/hatch.toml
@@ -7,12 +7,12 @@ sources = ["src"]
 
 [envs.default]
 pre-install-commands = [
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pip install -e ../dbt-adapters",
     "pip install -e ../dbt-tests-adapter",
 ]
 dependencies = [
-    "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",
     "pre-commit==3.7.0",
     "freezegun",
@@ -62,12 +62,12 @@ check-sdist = [
 
 [envs.ci]
 pre-install-commands = [
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pip install -e ../dbt-adapters",
     "pip install -e ../dbt-tests-adapter",
 ]
 dependencies = [
-    "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",
     "freezegun",
     "pytest>=7.0,<8.0",

--- a/dbt-redshift/hatch.toml
+++ b/dbt-redshift/hatch.toml
@@ -7,13 +7,13 @@ sources = ["src"]
 
 [envs.default]
 pre-install-commands = [
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pip install -e ../dbt-adapters",
     "pip install -e ../dbt-tests-adapter",
     "pip install -e ../dbt-postgres",
 ]
 dependencies = [
-    "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",
     "freezegun",
     "ipdb~=0.13.13",
@@ -67,13 +67,13 @@ docker-prod = "docker build -f docker/Dockerfile -t dbt-redshift ."
 
 [envs.ci]
 pre-install-commands = [
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pip install -e ../dbt-adapters",
     "pip install -e ../dbt-tests-adapter",
     "pip install -e ../dbt-postgres",
 ]
 dependencies = [
-    "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",
     "flaky",
     "freezegun",

--- a/dbt-snowflake/hatch.toml
+++ b/dbt-snowflake/hatch.toml
@@ -7,12 +7,12 @@ sources = ["src"]
 
 [envs.default]
 pre-install-commands = [
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pip install -e ../dbt-adapters",
     "pip install -e ../dbt-tests-adapter",
 ]
 dependencies = [
-    "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",
     "ipdb~=0.13.13",
     "pre-commit~=3.7.0",
@@ -64,12 +64,12 @@ docker-prod = "docker build -f docker/Dockerfile -t dbt-snowflake ."
 
 [envs.ci]
 pre-install-commands = [
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pip install -e ../dbt-adapters",
     "pip install -e ../dbt-tests-adapter",
 ]
 dependencies = [
-    "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "ddtrace==2.3.0",
     "pytest>=7.0,<8.0",
     "pytest-csv~=3.0",

--- a/dbt-tests-adapter/hatch.toml
+++ b/dbt-tests-adapter/hatch.toml
@@ -7,11 +7,11 @@ sources = ["src"]
 
 [envs.default]
 pre-install-commands = [
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pip install -e ../dbt-adapters",
 ]
 dependencies = [
-    "dbt_common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pre-commit==3.7.0",
     "pytest>=7.0,<8.0"
 ]


### PR DESCRIPTION
We bumped `dbt-common` to 2.0 and then updated the pin in dependent packages to the next major version. However, we have not published that pin to PyPI yet for `dbt-core`. This breaks when trying to install a package where `dbt-core` is a transient dependency (`dbt-tests-adapter`) and when also installing `dbt-common` (all packages). We should ensure that we're installing all dbt- packages from `main` for dev and ci; this issue made it evident that we were not. While we later install these dependencies as part of the normal dependencies from main, different transient dependencies may have been installed when using PyPI in the pre-installation.