### PR TITLE
fixed issue with double quotes hardcoded for column

### DIFF
--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/snapshots/helpers.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/snapshots/helpers.sql
@@ -8,7 +8,7 @@
 {% macro default__create_columns(relation, columns) %}
   {% for column in columns %}
     {% call statement() %}
-      alter table {{ relation.render() }} add column "{{ column.name }}" {{ column.data_type }};
+      alter table {{ relation.render() }} add column {{ adapter.quote(column.name) }} {{ column.data_type }};
     {% endcall %}
   {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
resolves #1118

### Problem

Currently, if you create a snapshot, add a new column to the source table, then update the snapshot, it uses a hard coded double quote to quote the new column name.

### Solution

It should instead rely on the adapter-specific quoting method.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX


Not gonna lie, I don't use hatch and I really don't feel like figuring all that crap out just to do a one line PR. If someone else wants to take it over for me, go for it. 