### PR TITLE
fix: `as DBT_INTERNAL_DEST` generates raises an error on Redshift

### DIFF
--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/merge.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/merge.sql
@@ -67,7 +67,7 @@
 
         {%- set unique_key_str = unique_key|join(', ') -%}
 
-        delete from {{ target }} as DBT_INTERNAL_DEST
+        delete from {{ target }}
         where ({{ unique_key_str }}) in (
             select distinct {{ unique_key_str }}
             from {{ source }} as DBT_INTERNAL_SOURCE


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
Redshift doesn't allow `AS [aliase]` in delete query; in addition, having AS in the DELETE is unnecessary as there is no reference to the table. 

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
