### PR TITLE
[ADAP-803] Bugfix: Set is_iceberg to true when information contains table_type=ICEBERG

### DIFF
--- a/dbt-spark/src/dbt/adapters/spark/impl.py
+++ b/dbt-spark/src/dbt/adapters/spark/impl.py
@@ -214,7 +214,9 @@ class SparkAdapter(SQLAdapter):
             )
             is_delta: bool = "Provider: delta" in information
             is_hudi: bool = "Provider: hudi" in information
-            is_iceberg: bool = "Provider: iceberg" in information
+            is_iceberg: bool = (
+                "Provider: iceberg" in information or "table_type=ICEBERG" in information
+            )
 
             relation: BaseRelation = self.Relation.create(
                 schema=_schema,


### PR DESCRIPTION
resolves [ADAP-803]
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

N/A

### Problem

Existing Iceberg tables are not recognized when using a Hive metastore:

The existing table '' is in another format than 'delta' or 'iceberg' or 'hudi'

### Solution

Check the output of the database scan for "table_type=ICEBERG" in addition to "Provider: iceberg" since we get "Provider: hive" for Iceberg tables registered in a Hive metastore

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
