### PR TITLE
bq sf/set lower bound on base adapter

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Dependencies-20250609-135552.yaml
+++ b/dbt-bigquery/.changes/unreleased/Dependencies-20250609-135552.yaml
@@ -1,5 +1,5 @@
 kind: Dependencies
-body: set a lower bound for dbt-adapters version in dbt-bigquery
+body: update the lower bound for dbt-adapters version in dbt-bigquery to >=1.16
 time: 2025-06-09T13:55:52.414339-07:00
 custom:
   Author: colin-rogers-dbt

--- a/dbt-bigquery/.changes/unreleased/Dependencies-20250609-135552.yaml
+++ b/dbt-bigquery/.changes/unreleased/Dependencies-20250609-135552.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: set a lower bound for dbt-adapters version in dbt-bigquery
+time: 2025-06-09T13:55:52.414339-07:00
+custom:
+  Author: colin-rogers-dbt
+  PR: "1148"

--- a/dbt-bigquery/pyproject.toml
+++ b/dbt-bigquery/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "dbt-common>=1.10,<2.0",
-    "dbt-adapters>=1.7,<2.0",
+    "dbt-adapters>=1.16,<2.0",
     # 3.20 introduced pyarrow>=3.0 under the `pandas` extra
     "google-cloud-bigquery[pandas]>=3.0,<4.0",
     "google-cloud-storage>=2.4,<3.2",

--- a/dbt-snowflake/.changes/unreleased/Dependencies-20250609-135623.yaml
+++ b/dbt-snowflake/.changes/unreleased/Dependencies-20250609-135623.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: set a lower bound for dbt-adapters version in dbt-snowflake
+time: 2025-06-09T13:56:23.849857-07:00
+custom:
+  Author: colin-rogers-dbt
+  PR: "1148"

--- a/dbt-snowflake/.changes/unreleased/Dependencies-20250609-135623.yaml
+++ b/dbt-snowflake/.changes/unreleased/Dependencies-20250609-135623.yaml
@@ -1,5 +1,5 @@
 kind: Dependencies
-body: set a lower bound for dbt-adapters version in dbt-snowflake
+body: update the lower bound for dbt-adapters version in dbt-snowflake to >=1.16
 time: 2025-06-09T13:56:23.849857-07:00
 custom:
   Author: colin-rogers-dbt

--- a/dbt-snowflake/pyproject.toml
+++ b/dbt-snowflake/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "dbt-common>=1.10,<2.0",
-    "dbt-adapters>=1.14.3,<2.0",
+    "dbt-adapters>=1.16,<2.0",
     # lower bound pin due to CVE-2025-24794
     "snowflake-connector-python[secure-local-storage]>=3.13.1,<4.0.0",
     "certifi<2025.4.26",


### PR DESCRIPTION
- set a lower bound for dbt-adapters version in dbt-bigquery and dbt-snowflake

resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
