### PR TITLE
Support Snowflake Materialized Views

### DIFF
--- a/dbt-snowflake/src/dbt/include/snowflake/macros/metadata/list_relations_without_caching.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/metadata/list_relations_without_caching.sql
@@ -57,17 +57,6 @@
 show objects in {{ schema }}
     limit {{ max_results_per_iter }}
     {% if watermark is not none -%} from '{{ watermark }}' {%- endif %}
-->> 
-show views in {{ schema }}
-->>
-select
-        iff(equal_null(o."kind", 'VIEW') and v."is_materialized", 'MATERIALIZED_VIEW', "kind") as "kind",
-        o.* exclude "kind"
-from $2 as o
-left join $1 as v
-    on o."database_name" = v."database_name"
-    and o."schema_name" = v."schema_name"
-    and o."name" = v."name"
 ;
 {%- endset -%}
 


### PR DESCRIPTION
resolves #727

### Problem

Materialized Views not supported for Snowflake

### Solution

I have successfully used this solution based on dbt-labs/dbt-labs-experimental-features/pull/11 for several years.

More elegantly, this logic could be blended into the standard view materialization macro. An additional `is_materialized` attribute could be added to the [`SnowflakeRelation`](https://github.com/dbt-labs/dbt-adapters/blob/c6aae9ee5ac3f704f052e83a0f6e6e43d42b480c/dbt-snowflake/src/dbt/adapters/snowflake/relation.py#L32) class, which can be easily populated via the `SHOW VIEWS` statement.

I'm willing to work on the implementation if you are open to support this functionality.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
