### PR TITLE
[DRAFT] add docker releases to relevant adapter releases

### DIFF
--- a/.github/workflows/_publish-docker.yml
+++ b/.github/workflows/_publish-docker.yml
@@ -1,0 +1,48 @@
+name: "Publish Docker"
+
+on:
+    workflow_call:
+        inputs:
+            package:
+                description: "Choose the package to publish"
+                type: string
+                required: true
+            version:
+                description: "Choose the version to publish"
+                type: string
+                required: true
+            dry-run:
+                description: "Dry Run"
+                type: boolean
+                default: false
+    workflow_dispatch:
+        inputs:
+            package:
+                description: "Choose the package to publish"
+                type: choice
+                options:
+                    -   "dbt-bigquery"
+                    -   "dbt-postgres"
+                    -   "dbt-redshift"
+                    -   "dbt-snowflake"
+                    -   "dbt-spark"
+            version:
+                description: "Choose the version to publish"
+                type: string
+                required: true
+            dry-run:
+                description: "Dry Run"
+                type: boolean
+                default: false
+
+permissions:
+    packages: write
+
+jobs:
+    publish-docker:
+        uses: dbt-labs/dbt-release/.github/workflows/release-docker.yml@main
+        with:
+            package: ${{ inputs.package }}
+            version_number: ${{ inputs.version }}
+            dockerfile: ${{ inputs.package }}/docker/Dockerfile
+            test_run: ${{ inputs.dry-run }}

--- a/.github/workflows/publish-oss.yml
+++ b/.github/workflows/publish-oss.yml
@@ -128,6 +128,8 @@ jobs:
             # this permission is required for trusted publishing
             # see https://github.com/marketplace/actions/pypi-publish
             id-token: write
+        outputs:
+            version: ${{ steps.version.outputs.version }}
         steps:
 
         # merge changes before publishing to prod because we lock trusted publishing to main
@@ -186,6 +188,18 @@ jobs:
                 retry_wait_seconds: 10
                 max_attempts: 15  # 5 minutes: (10s timeout + 10s delay) * 15 attempts
                 command: wget ${{ vars.PYPI_PROJECT_URL }}/dbt-athena-community/${{ steps.version.outputs.version }}
+
+    publish-docker:
+        if: ${{ inputs.package != 'dbt-athena' && inputs.package != 'dbt-tests-adapter' && inputs.package != 'dbt-adapters' }}
+        needs:
+            -   publish
+        permissions:
+            packages: write
+        uses: ./.github/workflows/_publish-docker.yml
+        with:
+            package: ${{ inputs.package }}
+            version: ${{ needs.publish.outputs.version }}
+            dry-run: ${{ inputs.deploy-to == 'test' && true || false }}
 
     clean-up:
         if: ${{ !cancelled() }}

--- a/dbt-bigquery/docker/Dockerfile
+++ b/dbt-bigquery/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     build-essential=12.9 \
     ca-certificates=20210119 \
     git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.18-0+deb11u1 \
+    libpq-dev=13.21-0+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \
@@ -34,4 +34,4 @@ HEALTHCHECK CMD dbt --version || exit 1
 WORKDIR /usr/app/dbt/
 ENTRYPOINT ["dbt"]
 
-RUN python -m pip install --no-cache-dir "dbt-bigquery @ git+https://github.com/dbt-labs/dbt-bigquery@${commit_ref}"
+RUN python -m pip install --no-cache-dir "dbt-bigquery @ git+https://github.com/dbt-labs/dbt-adapters/dbt-bigquery@${commit_ref}"

--- a/dbt-postgres/docker/Dockerfile
+++ b/dbt-postgres/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     build-essential=12.9 \
     ca-certificates=20210119 \
     git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.18-0+deb11u1 \
+    libpq-dev=13.21-0+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \
@@ -34,4 +34,4 @@ HEALTHCHECK CMD dbt --version || exit 1
 WORKDIR /usr/app/dbt/
 ENTRYPOINT ["dbt"]
 
-RUN python -m pip install --no-cache-dir "dbt-postgres @ git+https://github.com/dbt-labs/dbt-postgres@${commit_ref}"
+RUN python -m pip install --no-cache-dir "dbt-postgres @ git+https://github.com/dbt-labs/dbt-adapters/dbt-postgres@${commit_ref}"

--- a/dbt-redshift/docker/Dockerfile
+++ b/dbt-redshift/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     build-essential=12.9 \
     ca-certificates=20210119 \
     git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.18-0+deb11u1 \
+    libpq-dev=13.21-0+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \
@@ -34,4 +34,4 @@ HEALTHCHECK CMD dbt --version || exit 1
 WORKDIR /usr/app/dbt/
 ENTRYPOINT ["dbt"]
 
-RUN python -m pip install --no-cache-dir "dbt-redshift @ git+https://github.com/dbt-labs/dbt-redshift@${commit_ref}"
+RUN python -m pip install --no-cache-dir "dbt-redshift @ git+https://github.com/dbt-labs/dbt-adapters/dbt-redshift@${commit_ref}"

--- a/dbt-snowflake/docker/Dockerfile
+++ b/dbt-snowflake/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     build-essential=12.9 \
     ca-certificates=20210119 \
     git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.18-0+deb11u1 \
+    libpq-dev=13.21-0+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
     software-properties-common=0.96.20.2-2.1 \
@@ -34,4 +34,4 @@ HEALTHCHECK CMD dbt --version || exit 1
 WORKDIR /usr/app/dbt/
 ENTRYPOINT ["dbt"]
 
-RUN python -m pip install --no-cache-dir "dbt-snowflake @ git+https://github.com/dbt-labs/dbt-snowflake@${commit_ref}"
+RUN python -m pip install --no-cache-dir "dbt-snowflake @ git+https://github.com/dbt-labs/dbt-adapters/dbt-snowflake@${commit_ref}"

--- a/dbt-spark/docker/Dockerfile
+++ b/dbt-spark/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     ca-certificates=20210119 \
     gcc=4:10.2.1-1 \
     git=1:2.30.2-1+deb11u2 \
-    libpq-dev=13.18-0+deb11u1 \
+    libpq-dev=13.21-0+deb11u1 \
     libsasl2-dev=2.1.27+dfsg-2.1+deb11u1 \
     make=4.3-4.1 \
     openssh-client=1:8.4p1-5+deb11u3 \
@@ -39,4 +39,4 @@ HEALTHCHECK CMD dbt --version || exit 1
 WORKDIR /usr/app/dbt/
 ENTRYPOINT ["dbt"]
 
-RUN python -m pip install --no-cache-dir "dbt-spark[${extras}] @ git+https://github.com/dbt-labs/dbt-spark@${commit_ref}"
+RUN python -m pip install --no-cache-dir "dbt-spark[${extras}] @ git+https://github.com/dbt-labs/dbt-adapters/dbt-spark@${commit_ref}"


### PR DESCRIPTION
resolves #672 

### Problem

Docker releases have fallen behind.  They've also historically be published under dbt-core instead of their own package.

### Solution

We've already done work to separate the adapter docker images.  Now we need to finish it out for adapters.

Left to do:
Currently we don't tag commits as releases in dbt-adapters since a single commit could correspond to various adapter releases (dbt-snowflake 1.9.2 could be the same commit as dbt-bigquery 1.9.7 since it's a monorepo).  The existing docker release depends on that version tag.  
    - [ ] Determine is there's a reason we don't tag in a deterministic way (`dbt-snowflake-v1.10.0`) and start doing it if we can
    - [ ] If we can't start tagging pull out the central docker process and rewrite it to support the architecture we need to use



### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
