### PR TITLE
Fix table comment setting in Iceberg tables

### DIFF
--- a/dbt-snowflake/src/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/adapters.sql
@@ -95,10 +95,12 @@
 {% macro snowflake__alter_relation_comment(relation, relation_comment) -%}
     {%- if relation.is_dynamic_table -%}
         {%- set relation_type = 'dynamic table' -%}
+    {%- elif relation.is_iceberg_format -%}
+        {%- set relation_type = 'iceberg table' -%}
     {%- else -%}
         {%- set relation_type = relation.type -%}
     {%- endif -%}
-    comment on {{ relation_type }} {{ relation.render() }} IS $${{ relation_comment | replace('$', '[$]') }}$$;
+    alter {{ relation_type }} {{ relation.render() }} set comment = $${{ relation_comment | replace('$', '[$]') }}$$;
 {% endmacro %}
 
 


### PR DESCRIPTION
resolves 770

### Problem

Persisting table comments in Iceberg tables fails as comment on ... is ... notation does not work for Iceberg tables.

### Solution

Solution
- Update `snowflake__alter_relation_comment` to set `relation_type = 'iceberg table'` when the `is_iceberg_format` is `True`.
- Change code to use `alter <relation type> ... set comment = ...` notation instead of `comment on ... is ...` notation

**Note:** This PR was migrated from the `dbt-snowflake` repo [here](https://github.com/dbt-labs/dbt-snowflake/pull/1299).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
