### PR TITLE
fix(bigquery): BigFrames notebook execution when using a service account with `oauth` 

### DIFF
--- a/dbt-bigquery/src/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/python_submissions.py
@@ -47,6 +47,8 @@ _DEFAULT_BIGFRAMES_TIMEOUT = 60 * 60
 # Time interval in seconds between successive polling attempts to check the
 # notebook job's status in BigFrames mode.
 _COLAB_POLL_INTERVAL = 30
+# Suffix used by all service accounts.
+_SERVICE_ACCOUNT_SUFFIX = "iam.gserviceaccount.com"
 
 
 class _BigQueryPythonHelper(PythonJobHelper):
@@ -332,7 +334,12 @@ class BigFramesHelper(_BigQueryPythonHelper):
                     url="https://www.googleapis.com/oauth2/v2/userinfo",
                     headers={"Authorization": f"Bearer {self._GoogleCredentials.token}"},
                 )
-                notebook_execution_job.execution_user = json.loads(response.data).get("email")
+                email = json.loads(response.data).get("email")
+
+                if email and email.endswith(_SERVICE_ACCOUNT_SUFFIX):
+                    notebook_execution_job.service_account = email
+                else:
+                    notebook_execution_job.execution_user = email
         else:
             raise ValueError(
                 f"Unsupported credential method in BigFrames: '{self._connection_method}'"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/python_submissions.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/python_submissions.py
@@ -47,7 +47,7 @@ _DEFAULT_BIGFRAMES_TIMEOUT = 60 * 60
 # Time interval in seconds between successive polling attempts to check the
 # notebook job's status in BigFrames mode.
 _COLAB_POLL_INTERVAL = 30
-# Suffix used by all service accounts.
+# Suffix used by service accounts.
 _SERVICE_ACCOUNT_SUFFIX = "iam.gserviceaccount.com"
 
 


### PR DESCRIPTION
resolves #1231
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com (N/A)

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

Executing a BigFrames notebook when using a service account and `oauth` fails, as the current implementation assumes that it will always be a personal account. 

### Solution

Check the email account returned by `oauth` and check if it is a service account (i.e. if it ends with `iam.gserviceaccount.com`). If it is a service account, we set `notebook_execution_job.service_account` instead of `notebook_execution_job.execution_user`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
