### PR TITLE
Propagate copy_grants for Snowflake py_write_table

### DIFF
--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
@@ -185,6 +185,7 @@ alter iceberg table {{ relation }} resume recluster;
 {% macro py_write_table(compiled_code, target_relation) %}
 
 {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
+{%- set copy_grants = config.get('copy_grants', default=false) -%}
 
 {% if catalog_relation.is_transient %}
     {%- set table_type='transient' -%}
@@ -205,7 +206,7 @@ def materialize(session, df, target_relation):
             # session.write_pandas does not have overwrite function
             df = session.createDataFrame(df)
     {% set target_relation_name = resolve_model_name(target_relation) %}
-    df.write.mode("overwrite").save_as_table('{{ target_relation_name }}', table_type='{{table_type}}')
+    df.write.mode("overwrite").save_as_table('{{ target_relation_name }}', table_type='{{table_type}}', copy_grants={{copy_grants}})
 
 
 def main(session):


### PR DESCRIPTION
resolves #1249

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

`copy_grants` is ignored in Snowflake's `py_write_table` macro. As a result, `table` materialization drops all table grants when a model runs.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Include `copy_grants` in `py_write_table` macro `df.write()` call.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
