### PR TITLE
Add cluster_by in Snowflake dynamic table materialization config

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Features-20250830-120802.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20250830-120802.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add cluster by config in Snowflake for dynamic tables
+time: 2025-08-30T12:08:02.458481+02:00
+custom:
+    Author: nazliander
+    Issue: "706"

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
@@ -38,6 +38,7 @@
         {{ optional('initialize', dynamic_table.initialize) }}
         {{ optional('with row access policy', dynamic_table.row_access_policy, equals_char='') }}
         {{ optional('with tag', dynamic_table.table_tag, quote_char='(', equals_char='') }}
+        {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
         as (
             {{ sql }}
         )
@@ -74,6 +75,7 @@
         {{ optional('initialize', dynamic_table.initialize) }}
         {{ optional('row_access_policy', dynamic_table.row_access_policy) }}
         {{ optional('table_tag', dynamic_table.table_tag) }}
+        {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
         as (
             {{ sql }}
         )

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
@@ -51,6 +51,7 @@ create or replace dynamic table {{ relation }}
     {{ optional('initialize', dynamic_table.initialize) }}
     {{ optional('with row access policy', dynamic_table.row_access_policy, equals_char='') }}
     {{ optional('with tag', dynamic_table.table_tag, quote_char='(', equals_char='') }}
+    {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
     as (
         {{ sql }}
     )
@@ -87,6 +88,7 @@ create or replace dynamic iceberg table {{ relation }}
     {{ optional('initialize', dynamic_table.initialize) }}
     {{ optional('row_access_policy', dynamic_table.row_access_policy) }}
     {{ optional('table_tag', dynamic_table.table_tag) }}
+    {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
     as (
         {{ sql }}
     )

--- a/dbt-snowflake/tests/functional/adapter/test_cluster_by.py
+++ b/dbt-snowflake/tests/functional/adapter/test_cluster_by.py
@@ -1,0 +1,123 @@
+import pytest
+from dbt.tests.util import check_table_does_exist, run_dbt
+
+_SEED_CSV = """
+id,first_name,last_name,email,product_id
+1,Jack,Hunter,jhunter0@foo.bar,1
+2,Kathryn,Walker,kwalker1@foo.bar,1
+3,Gerald,Ryan,gryan2@foo.bar,3
+4,Jack,Hunter,jhunter1@foo.bar,4
+5,Kathryn,Walker,kwalker2@foo.bar,5
+6,Gerald,Ryan,gryan3@foo.bar,6
+""".lstrip()
+
+
+class TestClusterBy:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"seed.csv": _SEED_CSV}
+
+    @pytest.fixture(scope="class")
+    def models(self, dbt_profile_target):
+        warehouse_name = dbt_profile_target["warehouse"]
+
+        _DYNAMIC_TABLE_1_SQL = f"""
+        {{{{ config(materialized='dynamic_table', snowflake_warehouse='{warehouse_name}', target_lag='1 minute') }}}}
+        select * from {{{{ ref('seed') }}}}
+        """.lstrip()
+
+        _DYNAMIC_TABLE_2_SQL = f"""
+        {{{{ config(materialized='dynamic_table', cluster_by=['last_name'], snowflake_warehouse='{warehouse_name}', target_lag='1 minute') }}}}
+        select * from {{{{ ref('dynamic_table_1') }}}}
+        """.lstrip()
+
+        _DYNAMIC_TABLE_3_SQL = f"""
+        {{{{ config(materialized='dynamic_table', cluster_by=['last_name', 'first_name'], snowflake_warehouse='{warehouse_name}', target_lag='1 minute') }}}}
+        select
+            last_name,
+            first_name,
+            count(*) as count
+        from {{{{ ref('seed') }}}}
+        group by 1, 2
+        """.lstrip()
+
+        _DYNAMIC_TABLE_4_SQL = f"""
+        {{{{ config(materialized='dynamic_table', cluster_by=['last_name', 'product_id % 3'], snowflake_warehouse='{warehouse_name}', target_lag='1 minute') }}}}
+        select
+            last_name,
+            first_name,
+            product_id,
+            count(*) as count
+        from {{{{ ref('seed') }}}}
+        group by 1, 2, 3
+        """.lstrip()
+
+        return {
+            "dynamic_table_1.sql": _DYNAMIC_TABLE_1_SQL,
+            "dynamic_table_2.sql": _DYNAMIC_TABLE_2_SQL,
+            "dynamic_table_3.sql": _DYNAMIC_TABLE_3_SQL,
+            "dynamic_table_4.sql": _DYNAMIC_TABLE_4_SQL,
+        }
+
+    def test_snowflake_dynamic_table_cluster_by(self, project):
+
+        run_dbt(["seed"])
+
+        db_with_schema = f"{project.database}.{project.test_schema}"
+
+        check_table_does_exist(
+            project.adapter, f"{db_with_schema}.{self._available_models_in_setup()['seed_table']}"
+        )
+
+        run_dbt()
+
+        # Check that all dynamic tables exist
+        check_table_does_exist(
+            project.adapter,
+            f"{db_with_schema}.{self._available_models_in_setup()['dynamic_table_1']}",
+        )
+        check_table_does_exist(
+            project.adapter,
+            f"{db_with_schema}.{self._available_models_in_setup()['dynamic_table_2']}",
+        )
+        check_table_does_exist(
+            project.adapter,
+            f"{db_with_schema}.{self._available_models_in_setup()['dynamic_table_3']}",
+        )
+        check_table_does_exist(
+            project.adapter,
+            f"{db_with_schema}.{self._available_models_in_setup()['dynamic_table_4']}",
+        )
+
+        with project.adapter.connection_named("__test"):
+            # Check if cluster_by is applied to dynamic_table_2 (should cluster by last_name)
+            cluster_by = self._get_dynamic_table_ddl(
+                project, self._available_models_in_setup()["dynamic_table_2"]
+            )
+            assert "CLUSTER BY (LAST_NAME)" in cluster_by.upper()
+
+            # Check if cluster_by is applied to dynamic_table_3 (should cluster by last_name, first_name)
+            cluster_by = self._get_dynamic_table_ddl(
+                project, self._available_models_in_setup()["dynamic_table_3"]
+            )
+            assert "CLUSTER BY (LAST_NAME, FIRST_NAME)" in cluster_by.upper()
+
+            # Check if cluster_by is applied to dynamic_table_4 (should cluster by last_name, split_part(email, '@', 1))
+            cluster_by = self._get_dynamic_table_ddl(
+                project, self._available_models_in_setup()["dynamic_table_4"]
+            )
+            assert "CLUSTER BY (LAST_NAME, PRODUCT_ID % 3)" in cluster_by.upper()
+
+    def _get_dynamic_table_ddl(self, project, table_name: str) -> str:
+        ddl_query = f"SELECT GET_DDL('DYNAMIC_TABLE', '{project.database}.{project.test_schema}.{table_name}')"
+        ddl = project.run_sql(ddl_query, fetch="one")
+        return ddl[0]
+
+    def _available_models_in_setup(self) -> dict[str, str]:
+        return dict(
+            seed_table="SEED",
+            dynamic_table_1="DYNAMIC_TABLE_1",
+            dynamic_table_2="DYNAMIC_TABLE_2",
+            dynamic_table_3="DYNAMIC_TABLE_3",
+            dynamic_table_4="DYNAMIC_TABLE_4",
+        )


### PR DESCRIPTION
resolves #706 
docs N/A

### Problem

Clustering via the config is not a possibility with `dbt-snowflake` while using the dynamic table materializations.

People workaround using a `post-hook`, which is not intuitive and not standardized.

### Solution

Pulling the `cluster_by` parser into the dynamic table materialization.

So that we can forward the clustering options that the dbt user intends to use in the dynamic table creation command.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
