### PR TITLE
Add semantic view as materialization

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Features-20250903-133304.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20250903-133304.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add Snowflake Semantic View as materialization
+time: 2025-09-03T13:33:04.958749-07:00
+custom:
+    Author: sfc-gh-yutliu
+    Issue: "1260"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
@@ -43,6 +43,7 @@ class SnowflakeRelation(BaseRelation):
                 SnowflakeRelationType.Table,  # type: ignore
                 SnowflakeRelationType.View,  # type: ignore
                 SnowflakeRelationType.DynamicTable,  # type: ignore
+                SnowflakeRelationType.SemanticView,  # type: ignore
             }
         )
     )
@@ -53,6 +54,7 @@ class SnowflakeRelation(BaseRelation):
                 SnowflakeRelationType.DynamicTable,  # type: ignore
                 SnowflakeRelationType.Table,  # type: ignore
                 SnowflakeRelationType.View,  # type: ignore
+                SnowflakeRelationType.SemanticView,  # type: ignore
             }
         )
     )
@@ -68,6 +70,10 @@ class SnowflakeRelation(BaseRelation):
     @property
     def is_iceberg_format(self) -> bool:
         return self.table_format == constants.ICEBERG_TABLE_FORMAT
+
+    @property
+    def is_semantic_view(self) -> bool:
+        return self.type == SnowflakeRelationType.SemanticView
 
     @classproperty
     def DynamicTable(cls) -> str:

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/policies.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/policies.py
@@ -10,6 +10,7 @@ class SnowflakeRelationType(StrEnum):
     CTE = "cte"
     External = "external"
     DynamicTable = "dynamic_table"
+    SemanticView = "semantic_view"
 
 
 class SnowflakeIncludePolicy(Policy):

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/adapters.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/adapters.sql
@@ -95,6 +95,8 @@
 {% macro snowflake__alter_relation_comment(relation, relation_comment) -%}
     {%- if relation.is_dynamic_table -%}
         {%- set relation_type = 'dynamic table' -%}
+    {% elif relation.is_semantic_view -%}
+        {%- set relation_type = 'semantic view' -%}
     {%- else -%}
         {%- set relation_type = relation.type -%}
     {%- endif -%}
@@ -111,6 +113,8 @@
     {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute="name") | list %}
     {% if relation.is_dynamic_table -%}
         {% set relation_type = "table" %}
+    {% elif relation.is_semantic_view -%}
+        {%- set relation_type = "semantic view" -%}
     {% else -%}
         {% set relation_type = relation.type %}
     {% endif %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/semantic_view.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/semantic_view.sql
@@ -1,0 +1,15 @@
+{% materialization semantic_view, adapter='snowflake' -%}
+
+    {% set original_query_tag = set_query_tag() %}
+    {% set to_return = snowflake__create_or_replace_semantic_view() %}
+
+    {% set target_relation = this.incorporate(type='semantic_view') %}
+
+    -- COMMENT ON SEMANTIC VIEW support
+    {% do persist_docs(target_relation, model, for_columns=false) %}
+
+    {% do unset_query_tag(original_query_tag) %}
+
+    {% do return(to_return) %}
+
+{%- endmaterialization %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/create.sql
@@ -3,6 +3,9 @@
     {% if relation.is_dynamic_table %}
         {{ snowflake__get_create_dynamic_table_as_sql(relation, sql) }}
 
+    {% elif relation.is_semantic_view %}
+            {{ snowflake__get_create_semantic_view_sql(relation, sql) }}
+
     {% else %}
         {{ default__get_create_sql(relation, sql) }}
 

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/create.sql
@@ -1,0 +1,54 @@
+{% macro snowflake__get_create_semantic_view_sql(relation, sql) -%}
+{#-
+--  Produce DDL that creates a semantic view
+--
+--  Args:
+--  - relation: Union[SnowflakeRelation, str]
+--      - SnowflakeRelation - required for relation.render()
+--      - str - is already the rendered relation name
+--  - sql: str - the code defining the model
+--  Returns:
+--      A valid DDL statement which will result in a new semantic view.
+-#}
+
+  create or replace semantic view {{ relation }}
+  {{ sql }}
+
+{%- endmacro %}
+
+
+{% macro snowflake__create_or_replace_semantic_view() %}
+  {%- set identifier = model['alias'] -%}
+
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+  {%- set exists_as_view = (old_relation is not none and old_relation.is_semantic_view) -%}
+  {%- set copy_grants = config.get('copy_grants', default=false) -%}
+
+  {%- set target_relation = api.Relation.create(
+      identifier=identifier, schema=schema, database=database,
+      type='semantic_view') -%}
+  {% set grant_config = config.get('grants') %}
+
+  {%- if copy_grants -%}
+    {#- Normalize SQL and append COPY GRANTS if not already present (case-insensitive) -#}
+    {%- set _sql_norm = sql | trim -%}
+    {%- set _sql_norm = _sql_norm[:-1] if _sql_norm[-1:] == ';' else _sql_norm -%}
+    {%- set _sql_norm = _sql_norm | trim -%}
+    {%- set _ends = (_sql_norm | lower)[-11:] -%}
+    {%- if _ends != 'copy grants' -%}
+      {%- set sql = sql ~ '\nCOPY GRANTS' -%}
+    {%- endif -%}
+  {%- endif -%}
+
+  {{ run_hooks(pre_hooks) }}
+
+  -- build model
+  {% call statement('main') -%}
+    {{ snowflake__get_create_semantic_view_sql(target_relation, sql) }}
+  {%- endcall %}
+
+  {{ run_hooks(post_hooks) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{% endmacro %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/drop.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/drop.sql
@@ -1,0 +1,3 @@
+{% macro snowflake__get_drop_semantic_view_sql(relation) %}
+    drop semantic view if exists {{ relation }}
+{% endmacro %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/rename.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/semantic_view/rename.sql
@@ -1,0 +1,10 @@
+{%- macro snowflake__get_semantic_view_rename_sql(relation, new_name) -%}
+    /*
+    Rename or move a semantic view to the new name.
+    Args:
+        relation: SnowflakeRelation - relation to be renamed
+        new_name: Union[str, SnowflakeRelation] - new name for `relation`
+    Returns: templated string
+    */
+    alter semantic view if exists {{ relation }} rename to {{ new_name }}
+{%- endmacro -%}

--- a/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
+++ b/dbt-snowflake/tests/functional/semantic_view/test_semantic_view_basic.py
@@ -1,0 +1,268 @@
+import pytest
+
+from dbt.tests.util import run_dbt, run_dbt_and_capture
+
+_SEED__DATA = """id,value\n1,100\n2,200\n3,300\n"""
+
+_MODEL__BASE_TABLE_SQL = """
+{{ config(materialized='table') }}
+select * from {{ ref('my_seed') }}
+"""
+
+_MODEL__SEMANTIC_VIEW_SQL = """
+{{ config(materialized='semantic_view') }}
+TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_table2') }})
+DIMENSIONS(t1.count as value, t2.volume as value)
+METRICS(t1.total_rows AS SUM(t1.count), t2.max_volume as max(t2.volume))
+COMMENT='test semantic view'
+"""
+
+_MODEL__TABLE_REFER_SEMANTIC_VIEW_SQL = """
+{{ config(materialized='table') }}
+select * from semantic_view({{ ref('my_semantic_view') }} metrics total_rows)
+"""
+
+_MODEL__TABLE_REFER_RAW_SEMANTIC_VIEW_SQL = """
+{{ config(materialized='table') }}
+select * from semantic_view({{ source('seed_sources', 'raw_semantic_view') }} metrics total_rows)
+"""
+
+_MODEL__SEMANTIC_VIEW_WITH_COPY_SQL = """
+{{ config(materialized='semantic_view') }}
+TABLES(t1 AS {{ ref('base_table') }})
+DIMENSIONS(t1.count as value)
+METRICS(t1.total_rows AS SUM(t1.value))
+COMMENT='test semantic view explicit copy grants'
+COPY GRANTS
+"""
+
+_MODEL__SEMANTIC_VIEW_WITHOUT_COPY_SQL = """
+{{ config(materialized='semantic_view') }}
+TABLES(t1 AS {{ ref('base_table') }})
+DIMENSIONS(t1.count as value)
+METRICS(t1.total_rows AS SUM(t1.value))
+COMMENT='test semantic view yaml copy grants'
+"""
+
+_MODEL__SEMANTIC_VIEW_WITH_EXTENSION_SQL = """
+{{ config(materialized='semantic_view') }}
+TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_table2') }})
+DIMENSIONS(t1.count as value, t2.volume as value)
+METRICS(t1.total_rows AS SUM(t1.count), t2.max_volume as max(t2.volume))
+with extension (CA = '{"verified_queries":[{"name":"hi", "question": "hello"}]')
+"""
+
+_SCHEMA_YML = """
+version: 2
+models:
+  - name: my_semantic_view
+    description: "Semantic view description for persist_docs"
+  - name: my_semantic_view_without_copy
+    config:
+      copy_grants: true
+  - name: my_semantic_view_with_copy
+"""
+
+_SOURCES_YML = """
+version: 2
+sources:
+  - name: seed_sources
+    schema: "{{ target.schema }}"
+    tables:
+      - name: raw_semantic_view
+      - name: base_table2
+"""
+
+
+class TestSemanticViewBasic:
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": _SEED__DATA}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        return {
+            "base_table.sql": _MODEL__BASE_TABLE_SQL,
+            "my_semantic_view.sql": _MODEL__SEMANTIC_VIEW_SQL,
+            "my_semantic_view_with_copy.sql": _MODEL__SEMANTIC_VIEW_WITH_COPY_SQL,
+            "my_semantic_view_without_copy.sql": _MODEL__SEMANTIC_VIEW_WITHOUT_COPY_SQL,
+            "table_refer_to_semantic_view.sql": _MODEL__TABLE_REFER_SEMANTIC_VIEW_SQL,
+            "table_refer_to_raw_semantic_view.sql": _MODEL__TABLE_REFER_RAW_SEMANTIC_VIEW_SQL,
+            "table_with_ca_extension.sql": _MODEL__SEMANTIC_VIEW_WITH_EXTENSION_SQL,
+            "sources.yml": _SOURCES_YML,
+            "schema.yml": _SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "test": {
+                    "+persist_docs": {
+                        "relation": True,
+                    }
+                }
+            }
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run", "--select", "base_table"])
+
+        database = project.database
+        schema = project.test_schema
+
+        # Create a physical source table with different values than base_table
+        project.run_sql(
+            f"""
+            create or replace table {database}.{schema}.base_table2 as
+            select id, value + 1000 as value from {database}.{schema}.base_table
+        """
+        )
+
+        project.run_sql(
+            f"""
+            create or replace semantic view raw_semantic_view
+            tables(t1 as {database}.{schema}.base_table)
+            dimensions(t1.count as value)
+            metrics(t1.total_rows as sum(t1.value))
+        """
+        )
+
+    def test_create_semantic_view(self, project):
+        database = project.database
+        schema = project.test_schema
+
+        qualified = f"{database}.{schema}.my_semantic_view"
+
+        # Create the semantic view and assert DDL in logs
+        _, logs = run_dbt_and_capture(["--debug", "run", "--select", "my_semantic_view.sql"])
+        assert f"create or replace semantic view {qualified}" in logs.lower()
+
+        # Verify existence via SHOW SEMANTIC VIEWS (preferred for semantic views)
+        exists_sql = (
+            f"show semantic views like 'MY_SEMANTIC_VIEW' in schema " f"{database}.{schema}"
+        )
+        rows = project.run_sql(exists_sql, fetch="all")
+        assert rows and len(rows) >= 1, "semantic view not found via SHOW SEMANTIC VIEWS"
+
+        # verify the select-star result of the table which refer to the semantic view and the semantic view are the same
+        table_select_star_sql = f"select sum(value) from {database}.{schema}.BASE_TABLE"
+        table_select_result = project.run_sql(table_select_star_sql, fetch="all")
+        semantic_view_select_star_sql = f"select * from semantic_view({database}.{schema}.MY_SEMANTIC_VIEW metrics total_rows);"
+        semantic_view_select_result = project.run_sql(semantic_view_select_star_sql, fetch="all")
+        assert table_select_result[0][0] == semantic_view_select_result[0][0]
+
+    def test_table_refer_to_semantic_view(self, project):
+        database = project.database
+        schema = project.test_schema
+
+        qualified = f"{database}.{schema}.table_refer_to_semantic_view"
+
+        # Create the semantic view and assert DDL in logs
+        _, logs = run_dbt_and_capture(
+            ["--debug", "run", "--select", "+table_refer_to_semantic_view.sql"]
+        )
+        assert f"create or replace transient table {qualified}" in logs.lower()
+
+        # verify the select-star result of the table which refer to the semantic view and the semantic view are the same
+        table_select_star_sql = f"select * from {database}.{schema}.TABLE_REFER_TO_SEMANTIC_VIEW"
+        table_select_result = project.run_sql(table_select_star_sql, fetch="all")
+        semantic_view_select_star_sql = f"select * from semantic_view({database}.{schema}.MY_SEMANTIC_VIEW metrics total_rows);"
+        semantic_view_select_result = project.run_sql(semantic_view_select_star_sql, fetch="all")
+        assert table_select_result[0][0] == semantic_view_select_result[0][0]
+
+    def test_table_refer_to_raw_semantic_view(self, project):
+        database = project.database
+        schema = project.test_schema
+
+        qualified = f"{database}.{schema}.table_refer_to_raw_semantic_view"
+
+        # Create the semantic view and assert DDL in logs
+        _, logs = run_dbt_and_capture(
+            [
+                "--debug",
+                "run",
+                "--select",
+                "+table_refer_to_raw_semantic_view.sql",
+            ]
+        )
+        assert f"create or replace transient table {qualified}" in logs.lower()
+        # verify the select-star result of the table which refer to the semantic view and the semantic view are the same
+        table_select_star_sql = (
+            f"select * from {database}.{schema}.table_refer_to_raw_semantic_view"
+        )
+        table_select_result = project.run_sql(table_select_star_sql, fetch="all")
+        semantic_view_select_star_sql = f"select * from semantic_view({database}.{schema}.raw_semantic_view metrics total_rows);"
+        semantic_view_select_result = project.run_sql(semantic_view_select_star_sql, fetch="all")
+        assert table_select_result[0][0] == semantic_view_select_result[0][0]
+
+    def test_semantic_view_comment(self, project):
+        database = project.database
+        schema = project.test_schema
+
+        qualified = f"{database}.{schema}.my_semantic_view"
+
+        # Create the semantic view and assert DDL in logs
+        _, logs = run_dbt_and_capture(["--debug", "run", "--select", "my_semantic_view.sql"])
+        assert f"comment on semantic view {qualified}" in logs.lower()
+        # Verify existence via SHOW SEMANTIC VIEWS (preferred for semantic views)
+        exists_sql = (
+            f"show semantic views like 'MY_SEMANTIC_VIEW' in schema " f"{database}.{schema}"
+        )
+        rows = project.run_sql(exists_sql, fetch="all")
+        assert "semantic view description for persist_docs" in rows[0][4].lower()
+
+    def test_semantic_view_copy_grants_logic(self, project):
+        database = project.database
+        schema = project.test_schema
+
+        # Case 1: SQL already ends with COPY GRANTS -> should not rely on yaml, appears in DDL
+        qualified_with = f"{database}.{schema}.my_semantic_view_with_copy"
+        _, logs_with = run_dbt_and_capture(
+            ["--debug", "run", "--select", "my_semantic_view_with_copy.sql"]
+        )
+        assert f"create or replace semantic view {qualified_with}" in logs_with.lower()
+        assert "copy grants" in logs_with.lower()
+
+        # Case 2: SQL does not end with COPY GRANTS but YAML sets copy_grants: true -> appended
+        qualified_without = f"{database}.{schema}.my_semantic_view_without_copy"
+        _, logs_without = run_dbt_and_capture(
+            ["--debug", "run", "--select", "my_semantic_view_without_copy.sql"]
+        )
+        assert f"create or replace semantic view {qualified_without}" in logs_without.lower()
+        assert "copy grants" in logs_without.lower()
+
+        # Case 3: SQL does not end with COPY GRANTS and YAML does not set copy_grants: true -> no copy grants
+        qualified_without_sql_or_yaml = f"{database}.{schema}.my_semantic_view"
+        _, logs_without_sql_or_yaml = run_dbt_and_capture(
+            ["--debug", "run", "--select", "my_semantic_view.sql"]
+        )
+        assert (
+            f"create or replace semantic view {qualified_without_sql_or_yaml}"
+            in logs_without.lower()
+        )
+        assert "copy grants" not in logs_without_sql_or_yaml.lower()
+
+    def test_semantic_view_with_ca_extension(self, project):
+        database = project.database
+        schema = project.test_schema
+
+        qualified = f"{database}.{schema}.table_with_ca_extension"
+
+        # Create the semantic view and assert DDL in logs
+        _, logs = run_dbt_and_capture(
+            ["--debug", "run", "--select", "table_with_ca_extension.sql"]
+        )
+        assert f"create or replace semantic view {qualified}" in logs.lower()
+
+        desc_semantic_view_sql = f"describe semantic view {qualified}"
+        desc_remantic_view_res = project.run_sql(desc_semantic_view_sql, fetch="all")
+        for row in desc_remantic_view_res:
+            if row[0].lower() == "extension":
+                assert row[1].lower() == "ca"
+                assert row[4].lower() == '{"verified_queries":[{"name":"hi", "question": "hello"}]'
+                break
+        else:
+            assert False, "Extension not found"

--- a/dbt-snowflake/tests/unit/test_alter_relation_comment_macro.py
+++ b/dbt-snowflake/tests/unit/test_alter_relation_comment_macro.py
@@ -43,6 +43,7 @@ class TestSnowflakeAlterRelationCommentMacro(unittest.TestCase):
         relation_type="table",
         is_dynamic_table=False,
         is_iceberg_format=False,
+        is_semantic_view=False,
         database="test_db",
         schema="test_schema",
         identifier="test_table",
@@ -52,6 +53,7 @@ class TestSnowflakeAlterRelationCommentMacro(unittest.TestCase):
         mock_relation.type = relation_type
         mock_relation.is_dynamic_table = is_dynamic_table
         mock_relation.is_iceberg_format = is_iceberg_format
+        mock_relation.is_semantic_view = is_semantic_view
         mock_relation.render.return_value = f"{database}.{schema}.{identifier}"
         return mock_relation
 

--- a/dbt-snowflake/tests/unit/test_renamed_relations.py
+++ b/dbt-snowflake/tests/unit/test_renamed_relations.py
@@ -14,5 +14,6 @@ def test_renameable_relation():
             SnowflakeRelationType.Table,
             SnowflakeRelationType.View,
             SnowflakeRelationType.DynamicTable,
+            SnowflakeRelationType.SemanticView,
         }
     )


### PR DESCRIPTION
resolves #1260 
dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
dbt-snowflake did not support the new Snowflake "semantic view" relation type, so dbt users could not create or manage semantic views as first-class dbt resources or materializations. There was no materialization, build support, or test coverage for semantic views.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

[Snowflake Semantic Views in DBT](https://docs.google.com/document/d/1F-JGHM6CSGD4Di34eHWeI822EzUMtZAcg4nsDJnBZdQ/edit?usp=sharing)

This pr adds support for "semantic view" as a new materialization in the dbt-snowflake adapter. It introduces the necessary logic, macros, SQL generation, and tests to enable creating, dropping, and renaming semantic views in Snowflake via dbt.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Test
1. `tests/functional/semantic_view/test_semantic_view_basic.py` passed
    - `test_create_semantic_view`: semantic view model refers to raw table (use `source(<raw_table>)`) and table model (use `ref(<table_model>)`).
    - `test_table_refer_to_semantic_view`: table model refers to a semantic view model (use `ref(<semantic_view_model>)`).
    - `test_table_refer_to_raw_semantic_view`: table model refers to raw semantic view (use source(<semantic_view>))
    - `test_semantic_view_comment`: test description is recorded by `comment on semantic view` command.
    - `test_semantic_view_copy_grants_logic`: test copy grants configuration is properly handled.
    - `test_semantic_view_with_ca_extension`: test Cortex Analyst Extension query is properly handled in DBT.

```
(dbt_venv) ➜  dbt-snowflake git:(semantic-view/issue-1260) ✗ hatch run unit-tests tests/functional/semantic_view/test_semantic_view_basic.py                                                  
========================================================================================== test session starts ==========================================================================================
platform darwin -- Python 3.11.6, pytest-7.4.4, pluggy-1.6.0 -- /Users/yutliu/dbt-adapter-snowflake/dbt-adapters/dbt-snowflake/.hatch/dbt-snowflake/bin/python
cachedir: .pytest_cache
rootdir: /Users/yutliu/dbt-adapter-snowflake/dbt-adapters/dbt-snowflake
configfile: pyproject.toml
plugins: ddtrace-2.3.0, csv-3.0.0, logbook-1.2.0, xdist-3.8.0, dotenv-0.5.2
16 workers [6 items]      
scheduling tests via LoadScheduling

tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_create_semantic_view 
tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_table_refer_to_raw_semantic_view 
tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_table_refer_to_semantic_view 
tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_semantic_view_with_ca_extension 
tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_semantic_view_copy_grants_logic 
tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_semantic_view_comment 
[gw3] [ 16%] PASSED tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_semantic_view_comment 
[gw1] [ 33%] PASSED tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_table_refer_to_semantic_view 
[gw0] [ 50%] PASSED tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_create_semantic_view 
[gw2] [ 66%] PASSED tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_table_refer_to_raw_semantic_view 
[gw4] [ 83%] PASSED tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_semantic_view_copy_grants_logic 
[gw5] [100%] PASSED tests/functional/semantic_view/test_semantic_view_basic.py::TestSemanticViewBasic::test_semantic_view_with_ca_extension 

=========================================================================================== warnings summary ============================================================================================
.hatch/dbt-snowflake/lib/python3.11/site-packages/dbt/cli/options.py:6: 17 warnings
  /Users/yutliu/dbt-adapter-snowflake/dbt-adapters/dbt-snowflake/.hatch/dbt-snowflake/lib/python3.11/site-packages/dbt/cli/options.py:6: DeprecationWarning: 'parser.OptionParser' is deprecated and will be removed in Click 9.0. The old parser is available in 'optparse'.
    from click.parser import OptionParser, ParsingState

.hatch/dbt-snowflake/lib/python3.11/site-packages/dbt/cli/options.py:6: 17 warnings
  /Users/yutliu/dbt-adapter-snowflake/dbt-adapters/dbt-snowflake/.hatch/dbt-snowflake/lib/python3.11/site-packages/dbt/cli/options.py:6: DeprecationWarning: 'parser.ParsingState' is deprecated and will be removed in Click 9.0. The old parser is available in 'optparse'.
    from click.parser import OptionParser, ParsingState

tests/functional/semantic_view/test_semantic_view_basic.py: 40 warnings
  /Users/yutliu/dbt-adapter-snowflake/dbt-adapters/dbt-snowflake/.hatch/dbt-snowflake/lib/python3.11/site-packages/snowflake/connector/__init__.py:54: DeprecationWarning: The 'insecure_mode' connection property is deprecated. Please use 'disable_ocsp_checks' instead
    return SnowflakeConnection(**kwargs)

tests/functional/semantic_view/test_semantic_view_basic.py: 60 warnings
  /Users/yutliu/dbt-adapter-snowflake/dbt-adapters/dbt-snowflake/.hatch/dbt-snowflake/lib/python3.11/site-packages/snowflake/connector/vendored/urllib3/contrib/pyopenssl.py:434: DeprecationWarning: Attempting to mutate a Context after a Connection was created. In the future, this will raise an exception
    self._ctx.set_options(value)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================== 6 passed, 374 warnings in 50.01s ====================================================================================
(dbt_venv) ➜  dbt-snowflake git:(semantic-view/issue-1260) ✗ 
```

2. Unit test passed:
```
(dbt_venv) ➜  dbt-snowflake git:(semantic-view/issue-1260) ✗ hatch run unit-tests                                                           
========================================================================================== test session starts ==========================================================================================
platform darwin -- Python 3.11.6, pytest-7.4.4, pluggy-1.6.0 -- /Users/yutliu/dbt-adapter-snowflake/dbt-adapters/dbt-snowflake/.hatch/dbt-snowflake/bin/python
cachedir: .pytest_cache
rootdir: /Users/yutliu/dbt-adapter-snowflake/dbt-adapters/dbt-snowflake
configfile: pyproject.toml
plugins: ddtrace-2.3.0, csv-3.0.0, logbook-1.2.0, xdist-3.8.0, dotenv-0.5.2
16 workers [94 items]     
scheduling tests via LoadScheduling

tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_special_characters 
tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_iceberg_dynamic_precedence 
tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_iceberg_table_dollar_sign_escaping 
tests/unit/test_adapter_telemetry.py::test_telemetry_with_snowflake_details 
tests/unit/test_catalog_relation_built_in.py::test_iceberg_base_location_built_in[config2-root_path/my_schema/my_table/subpath] 
tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_dynamic_table 
tests/unit/test_catalog_relation_built_in.py::test_change_tracking_invalid_model_config[0] 
tests/unit/test_catalog_relation_built_in.py::test_iceberg_base_location_built_in[config0-_dbt/my_schema/my_table] 
tests/unit/test_connections.py::test_connections_does_not_set_logs_in_response_to_env_var 
tests/unit/test_iceberg_rest_catalog_integration.py::TestIcebergRestCatalogIntegration::test_catalog_relation_has_catalog_linked_database_attribute 
tests/unit/test_catalog_relation_built_in.py::test_change_tracking_invalid_model_config[None] 
tests/unit/test_catalog_relation_built_in.py::test_change_tracking_model_config[False-FALSE0] 
[gw9] [  1%] PASSED tests/unit/test_catalog_relation_built_in.py::test_change_tracking_model_config[False-FALSE0] 
tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_regular_table 
[gw15] [  2%] PASSED tests/unit/test_iceberg_rest_catalog_integration.py::TestIcebergRestCatalogIntegration::test_catalog_relation_has_catalog_linked_database_attribute 
[gw0] [  3%] PASSED tests/unit/test_adapter_telemetry.py::test_telemetry_with_snowflake_details 
tests/unit/test_catalog_relation_built_in.py::test_change_tracking_model_config[False-FALSE1] 
[gw10] [  4%] PASSED tests/unit/test_catalog_relation_built_in.py::test_change_tracking_model_config[False-FALSE1] 
tests/unit/test_catalog_relation_built_in.py::test_iceberg_base_location_built_in[config4-root_path/my_schema/my_table] 
[gw8] [  5%] PASSED tests/unit/test_catalog_relation_built_in.py::test_iceberg_base_location_built_in[config4-root_path/my_schema/my_table] 
[gw11] [  6%] PASSED tests/unit/test_catalog_relation_built_in.py::test_change_tracking_invalid_model_config[0] 
[gw7] [  7%] PASSED tests/unit/test_catalog_relation_built_in.py::test_iceberg_base_location_built_in[config2-root_path/my_schema/my_table/subpath] 
tests/unit/test_connections.py::test_snowflake_oauth_expired_token_raises_error 
[gw12] [  8%] PASSED tests/unit/test_catalog_relation_built_in.py::test_change_tracking_invalid_model_config[None] 
[gw6] [  9%] PASSED tests/unit/test_catalog_relation_built_in.py::test_iceberg_base_location_built_in[config0-_dbt/my_schema/my_table] 
[gw13] [ 10%] PASSED tests/unit/test_connections.py::test_connections_does_not_set_logs_in_response_to_env_var 
tests/unit/test_catalog_relation_built_in.py::test_change_tracking_model_config[True-TRUE0] 
tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_dollar_sign_escaping 
tests/unit/test_catalog_relation_built_in.py::test_change_tracking_model_config[None-None] 
tests/unit/test_catalog_relation_built_in.py::test_change_tracking_invalid_model_config[] 
tests/unit/test_catalog_relation_built_in.py::test_iceberg_base_location_built_in[config3-_dbt/my_schema/my_table/subpath] 
[gw8] [ 11%] PASSED tests/unit/test_catalog_relation_built_in.py::test_change_tracking_model_config[None-None] 
tests/unit/test_catalog_relation_built_in.py::test_change_tracking_model_config[True-TRUE1] 
tests/unit/test_connections.py::test_connections_sets_logs_in_response_to_env_var 
[gw9] [ 12%] PASSED tests/unit/test_catalog_relation_built_in.py::test_change_tracking_model_config[True-TRUE0] 
[gw11] [ 13%] PASSED tests/unit/test_catalog_relation_built_in.py::test_change_tracking_invalid_model_config[] 
[gw7] [ 14%] PASSED tests/unit/test_catalog_relation_built_in.py::test_iceberg_base_location_built_in[config3-_dbt/my_schema/my_table/subpath] 
[gw10] [ 15%] PASSED tests/unit/test_catalog_relation_built_in.py::test_change_tracking_model_config[True-TRUE1] 
tests/unit/test_catalog_relation_built_in.py::test_iceberg_base_location_built_in[config1-_dbt/my_schema/my_table] 
[gw6] [ 17%] PASSED tests/unit/test_catalog_relation_built_in.py::test_iceberg_base_location_built_in[config1-_dbt/my_schema/my_table] 
tests/unit/test_iceberg_rest_catalog_integration.py::TestIcebergRestCatalogIntegration::test_macro_integration_with_catalog_linked_database_set 
[gw15] [ 18%] PASSED tests/unit/test_iceberg_rest_catalog_integration.py::TestIcebergRestCatalogIntegration::test_macro_integration_with_catalog_linked_database_set 
[gw14] [ 19%] PASSED tests/unit/test_connections.py::test_snowflake_oauth_expired_token_raises_error 
tests/unit/test_connections.py::test_connnections_credentials_replaces_underscores_with_hyphens 
tests/unit/test_iceberg_rest_catalog_integration.py::TestIcebergRestCatalogIntegration::test_catalog_relation_all_attributes_present 
tests/unit/test_parse_model.py::test_base_location[config1-_dbt/fake_schema/fake_table] 
tests/unit/test_parse_model.py::test_base_location[config2-root_path/fake_schema/fake_table/subpath] 
[gw12] [ 20%] PASSED tests/unit/test_connections.py::test_connections_sets_logs_in_response_to_env_var 
tests/unit/test_parse_model.py::test_base_location[config4-root_path/fake_schema/fake_table] 
tests/unit/test_parse_model.py::test_cluster_by[config0-fake_value] 
tests/unit/test_iceberg_rest_catalog_integration.py::TestIcebergRestCatalogIntegration::test_macro_integration_without_catalog_relation 
tests/unit/test_parse_model.py::test_base_location[config0-_dbt/fake_schema/fake_table] 
[gw13] [ 21%] PASSED tests/unit/test_connections.py::test_connnections_credentials_replaces_underscores_with_hyphens 
[gw11] [ 22%] PASSED tests/unit/test_parse_model.py::test_base_location[config0-_dbt/fake_schema/fake_table] 
[gw15] [ 23%] PASSED tests/unit/test_parse_model.py::test_cluster_by[config0-fake_value] 
[gw7] [ 24%] PASSED tests/unit/test_parse_model.py::test_base_location[config1-_dbt/fake_schema/fake_table] 
[gw6] [ 25%] PASSED tests/unit/test_parse_model.py::test_base_location[config4-root_path/fake_schema/fake_table] 
[gw10] [ 26%] PASSED tests/unit/test_parse_model.py::test_base_location[config2-root_path/fake_schema/fake_table/subpath] 
[gw8] [ 27%] PASSED tests/unit/test_iceberg_rest_catalog_integration.py::TestIcebergRestCatalogIntegration::test_catalog_relation_all_attributes_present 
tests/unit/test_iceberg_rest_catalog_integration.py::TestIcebergRestCatalogIntegration::test_missing_catalog_linked_database_raises_error 
[gw9] [ 28%] PASSED tests/unit/test_iceberg_rest_catalog_integration.py::TestIcebergRestCatalogIntegration::test_macro_integration_without_catalog_relation 
tests/unit/test_parse_model.py::test_base_location[config3-_dbt/fake_schema/fake_table/subpath] 
tests/unit/test_parse_model.py::test_cluster_by[config1-fake_value, fake_value_1] 
[gw12] [ 29%] PASSED tests/unit/test_parse_model.py::test_base_location[config3-_dbt/fake_schema/fake_table/subpath] 
tests/unit/test_renamed_relations.py::test_renameable_relation 
tests/unit/test_relation_as_case_sensitive.py::test_relation_as_case_sensitive_quoting_true 
tests/unit/test_private_keys.py::test_private_key_from_file 
[gw14] [ 30%] PASSED tests/unit/test_iceberg_rest_catalog_integration.py::TestIcebergRestCatalogIntegration::test_missing_catalog_linked_database_raises_error 
tests/unit/test_private_keys.py::test_private_key_from_string_pem 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_externalbrowser_authentication 
tests/unit/test_parse_model.py::test_catalog_name_with_non_model_config 
tests/unit/test_parse_model.py::test_catalog_name 
[gw13] [ 31%] PASSED tests/unit/test_parse_model.py::test_cluster_by[config1-fake_value, fake_value_1] 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_oauth_authentication 
[gw9] [ 32%] PASSED tests/unit/test_parse_model.py::test_catalog_name 
[gw6] [ 34%] PASSED tests/unit/test_relation_as_case_sensitive.py::test_relation_as_case_sensitive_quoting_true 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_private_key_authentication 
[gw8] [ 35%] PASSED tests/unit/test_parse_model.py::test_catalog_name_with_non_model_config 
[gw11] [ 36%] PASSED tests/unit/test_renamed_relations.py::test_renameable_relation 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_jwt_authentication 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_cancel_open_connections_single 
[gw4] [ 37%] PASSED tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_regular_table 
[gw2] [ 38%] PASSED tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_iceberg_dynamic_precedence 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_cancel_open_connections_empty 
[gw1] [ 39%] PASSED tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_dynamic_table 
[gw3] [ 40%] PASSED tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_iceberg_table_dollar_sign_escaping 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_private_key_string_authentication_no_passphrase 
[gw5] [ 41%] PASSED tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_special_characters 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_private_key_authentication_no_passphrase 
tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_multiline_comment 
tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_regular_view 
tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_empty_comment 
tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_macros_load 
tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_iceberg_table 
[gw0] [ 42%] PASSED tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_dollar_sign_escaping 
tests/unit/test_iceberg_rest_catalog_integration.py::TestIcebergRestCatalogIntegration::test_integration_with_environment_variable_for_macro 
[gw0] [ 43%] PASSED tests/unit/test_iceberg_rest_catalog_integration.py::TestIcebergRestCatalogIntegration::test_integration_with_environment_variable_for_macro 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_reuse_connections_with_keep_alive 
[gw1] [ 44%] PASSED tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_empty_comment 
[gw5] [ 45%] PASSED tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_macros_load 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_quoting_on_rename 
[gw2] [ 46%] PASSED tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_iceberg_table 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_quoting_on_truncate 
[gw4] [ 47%] PASSED tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_regular_view 
[gw3] [ 48%] PASSED tests/unit/test_alter_relation_comment_macro.py::TestSnowflakeAlterRelationCommentMacro::test_alter_relation_comment_multiline_comment 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_quoting_on_drop_schema 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_quoting_on_drop 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_query_tag 
[gw7] [ 50%] PASSED tests/unit/test_private_keys.py::test_private_key_from_file 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_private_key_string_authentication 
[gw10] [ 51%] PASSED tests/unit/test_private_keys.py::test_private_key_from_string_pem 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_user_pass_authentication 
[gw12] [ 52%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_oauth_authentication 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_client_has_query_tag 
[gw11] [ 53%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_private_key_authentication_no_passphrase 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_pre_post_hooks_warehouse 
[gw15] [ 54%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_externalbrowser_authentication 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_cancel_open_connections_master 
[gw13] [ 55%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_private_key_authentication 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_client_session_keep_alive_false_by_default 
[gw9] [ 56%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_cancel_open_connections_single 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_get_relation_with_quotes 
[gw14] [ 57%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_jwt_authentication 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_client_session_keep_alive_true 
[gw8] [ 58%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_cancel_open_connections_empty 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_get_relation_without_quotes 
[gw6] [ 59%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_private_key_string_authentication_no_passphrase 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_pre_post_hooks_no_warehouse 
[gw5] [ 60%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_quoting_on_truncate 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterConversions::test_convert_date_type 
[gw5] [ 61%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterConversions::test_convert_date_type 
tests/unit/test_snowflake_adapter.py::SnowflakeConnectionsTest::test_comment_stripping_regex 
[gw1] [ 62%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_quoting_on_rename 
[gw5] [ 63%] PASSED tests/unit/test_snowflake_adapter.py::SnowflakeConnectionsTest::test_comment_stripping_regex 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterConversions::test_convert_boolean_type 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterCredentials::test_invalid_private_key_path 
[gw1] [ 64%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterConversions::test_convert_boolean_type 
[gw5] [ 65%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterCredentials::test_invalid_private_key_path 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterCredentials::test_invalid_private_key_string 
[gw10] [ 67%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_user_pass_authentication 
[gw1] [ 68%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterCredentials::test_invalid_private_key_string 
[gw2] [ 69%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_quoting_on_drop_schema 
[gw4] [ 70%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_quoting_on_drop 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterCredentials::test_malformed_private_key_string 
[gw5] [ 71%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterCredentials::test_malformed_private_key_string 
tests/unit/test_snowflake_adapter.py::TestSnowflakeColumn::test_float_from_description 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterCredentials::test_private_key_string 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterConversions::test_convert_number_type 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterConversions::test_convert_datetime_type 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterCredentials::test_private_key_string_encrypted 
[gw0] [ 72%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_reuse_connections_with_keep_alive 
[gw4] [ 73%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterConversions::test_convert_number_type 
[gw7] [ 74%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_authenticator_private_key_string_authentication 
[gw10] [ 75%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeColumn::test_float_from_description 
[gw2] [ 76%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterConversions::test_convert_datetime_type 
[gw3] [ 77%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_query_tag 
[gw1] [ 78%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterCredentials::test_private_key_string 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterConversions::test_convert_time_type 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterConversions::test_convert_text_type 
tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_user_pass_authentication 
[gw5] [ 79%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterCredentials::test_private_key_string_encrypted 
[gw7] [ 80%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterConversions::test_convert_time_type 
[gw3] [ 81%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapterConversions::test_convert_text_type 
[gw12] [ 82%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_client_has_query_tag 
tests/unit/test_snowflake_adapter.py::TestSnowflakeColumn::test_sized_decimal_from_description 
[gw12] [ 84%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeColumn::test_sized_decimal_from_description 
[gw11] [ 85%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_pre_post_hooks_warehouse 
tests/unit/test_snowflake_adapter.py::TestSnowflakeColumn::test_sized_varchar_from_description 
[gw11] [ 86%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeColumn::test_sized_varchar_from_description 
[gw15] [ 87%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_cancel_open_connections_master 
tests/unit/test_snowflake_adapter.py::TestSnowflakeColumn::test_text_from_description 
[gw15] [ 88%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeColumn::test_text_from_description 
[gw13] [ 89%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_client_session_keep_alive_false_by_default 
tests/unit/test_snowflake_adapter.py::TestSnowflakeColumn::test_vector_from_description 
[gw13] [ 90%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeColumn::test_vector_from_description 
[gw9] [ 91%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_get_relation_with_quotes 
tests/unit/test_snowflake_adapter.py::TestSnowflakeColumnStructuredTypes::test_array_from_description 
[gw9] [ 92%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeColumnStructuredTypes::test_array_from_description 
[gw14] [ 93%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_client_session_keep_alive_true 
tests/unit/test_snowflake_adapter.py::TestSnowflakeColumnStructuredTypes::test_map_from_description 
[gw14] [ 94%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeColumnStructuredTypes::test_map_from_description 
[gw8] [ 95%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_get_relation_without_quotes 
tests/unit/test_snowflake_adapter.py::TestSnowflakeColumnStructuredTypes::test_object_from_description_iceberg 
[gw8] [ 96%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeColumnStructuredTypes::test_object_from_description_iceberg 
[gw6] [ 97%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_pre_post_hooks_no_warehouse 
tests/unit/test_snowflake_adapter.py::TestSnowflakeColumnStructuredTypes::test_object_from_description_simple 
[gw6] [ 98%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeColumnStructuredTypes::test_object_from_description_simple 
[gw0] [100%] PASSED tests/unit/test_snowflake_adapter.py::TestSnowflakeAdapter::test_user_pass_authentication 

=========================================================================================== warnings summary ============================================================================================
.hatch/dbt-snowflake/lib/python3.11/site-packages/dbt/cli/options.py:6: 17 warnings
  /Users/yutliu/dbt-adapter-snowflake/dbt-adapters/dbt-snowflake/.hatch/dbt-snowflake/lib/python3.11/site-packages/dbt/cli/options.py:6: DeprecationWarning: 'parser.OptionParser' is deprecated and will be removed in Click 9.0. The old parser is available in 'optparse'.
    from click.parser import OptionParser, ParsingState

.hatch/dbt-snowflake/lib/python3.11/site-packages/dbt/cli/options.py:6: 17 warnings
  /Users/yutliu/dbt-adapter-snowflake/dbt-adapters/dbt-snowflake/.hatch/dbt-snowflake/lib/python3.11/site-packages/dbt/cli/options.py:6: DeprecationWarning: 'parser.ParsingState' is deprecated and will be removed in Click 9.0. The old parser is available in 'optparse'.
    from click.parser import OptionParser, ParsingState

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================== 94 passed, 34 warnings in 5.20s ====================================================================================
(dbt_venv) ➜  dbt-snowflake git:(semantic-view/issue-1260) ✗ 
```

3. Code-quality check passed:
```
(dbt_venv) ➜  dbt-snowflake git:(semantic-view/issue-1260) ✗ hatch run code-quality
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for case conflicts.................................................Passed
Check for dbt-core usage in an adapter...................................Passed
black....................................................................Passed
flake8...................................................................Passed
mypy.....................................................................Passed
(dbt_venv) ➜  dbt-snowflake git:(semantic-view/issue-1260) ✗ 
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX