### PR TITLE
Add invocation_id to user agent string

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Features-20250904-153341.yaml
+++ b/dbt-bigquery/.changes/unreleased/Features-20250904-153341.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Inject invocation_id into user agent string
+time: 2025-09-04T15:33:41.438521+12:00
+custom:
+    Author: jeremyyeo
+    Issue: "1280"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/clients.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/clients.py
@@ -9,6 +9,7 @@ from google.cloud.dataproc_v1 import BatchControllerClient, JobControllerClient
 from google.cloud.storage import Client as StorageClient
 from google.cloud.storage.retry import DEFAULT_RETRY as GCS_DEFAULT_RETRY
 from google.oauth2.credentials import Credentials as GoogleCredentials
+from dbt_common.invocation import get_invocation_id
 
 from dbt.adapters.events.logging import AdapterLogger
 
@@ -64,7 +65,9 @@ def _create_bigquery_client(credentials: BigQueryCredentials) -> BigQueryClient:
         credentials.execution_project,
         create_google_credentials(credentials),
         location=getattr(credentials, "location", None),
-        client_info=ClientInfo(user_agent=f"dbt-bigquery-{dbt_version.version}"),
+        client_info=ClientInfo(
+            user_agent=f"dbt-bigquery-{dbt_version.version} dbt-invocation-id/{get_invocation_id()}"
+        ),
         client_options=ClientOptions(
             quota_project_id=credentials.quota_project, api_endpoint=credentials.api_endpoint
         ),

--- a/dbt-bigquery/tests/unit/test_bigquery_adapter.py
+++ b/dbt-bigquery/tests/unit/test_bigquery_adapter.py
@@ -24,6 +24,7 @@ from dbt.context.query_header import generate_query_header_context
 from dbt.contracts.files import FileHash
 from dbt.contracts.graph.manifest import ManifestStateCheck
 from dbt.context.providers import RuntimeConfigObject, generate_runtime_macro_context
+from dbt_common.invocation import get_invocation_id
 
 from google.cloud.bigquery import AccessEntry
 
@@ -471,7 +472,9 @@ class TestBigQueryAdapterAcquire(BaseTestBigQueryAdapter):
 
 
 class HasUserAgent:
-    PAT = re.compile(r"dbt-bigquery-\d+\.\d+\.\d+((a|b|rc)\d+)?")
+    PAT = re.compile(
+        r"dbt-bigquery-\d+\.\d+\.\d+((a|b|rc)\d+)? dbt-invocation-id/" + get_invocation_id()
+    )
 
     def __eq__(self, other):
         compare = getattr(other, "user_agent", "")


### PR DESCRIPTION
resolves #1280 

### Problem
See #1280 but GCP Log Explorer doesn't appear to record the invocation id for each log entry - so user cannot be sure of which exact dbt invocation caused the log entry.

### Solution
Inject invocation_id into user agent string as the user agent string appears in each and every log entry. Not too sure of the format of the string but this does work currently:

```sh
$ dbt run
03:42:27  Running with dbt=1.11.0-a1
03:42:29  Registered adapter: bigquery=1.11.0-a1
03:42:29  Found 1 model, 497 macros
03:42:29  
03:42:29  Concurrency: 4 threads (target='bq')
03:42:29  
03:42:32  1 of 1 START sql table model dbt_jyeo.foo ...................................... [RUN]
03:42:37  1 of 1 OK created sql table model dbt_jyeo.foo ................................. [CREATE TABLE (1.0 rows, 0 processed) in 4.36s]
03:42:37  
03:42:37  Finished running 1 table model in 0 hours 0 minutes and 7.50 seconds (7.50s).
03:42:37  
03:42:37  Completed successfully
03:42:37  
03:42:37  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

Then double check the GCP UI to make sure the invocation id the same:

<img width="1443" height="1112" alt="image" src="https://github.com/user-attachments/assets/b00d4fb3-1b87-42ca-9f0b-a854e8651a0d" />

<img width="1829" height="1483" alt="image" src="https://github.com/user-attachments/assets/0bdbe0fb-cf61-416b-b822-aa839ab0cee0" />

^ Each log entry has 

```
dbt-bigquery-1.11.0a1 dbt-invocation-id/0524e3ce-e7dd-49b9-a5d4-3957f926c043 gl-python/3.11.9 grpc/1.74.0 gax/2.25.1 gapic/3.36.0 gccl/3.36.0,gzip(gfe)
```


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX

Not 100% sure about the test - just tweaked the existing regex.