### PR TITLE
top level changelog

### DIFF
--- a/.changes/unreleased/Under the Hood-20241217-110536.yaml
+++ b/.changes/unreleased/Under the Hood-20241217-110536.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Added new equals macro that handles null value checks in sql
-time: 2024-12-17T11:05:36.363421+02:00
-custom:
-    Author: adrianburusdbt,versusfacit
-    Issue: "159"

--- a/.github/workflows/_generate-changelog.yml
+++ b/.github/workflows/_generate-changelog.yml
@@ -79,6 +79,7 @@ jobs:
         -   uses: actions/checkout@v4
             with:
                 ref: ${{ inputs.branch }}
+
         -   id: changelog
             run: |
                 path=".changes/${{ needs.version.outputs.base }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+This repository is organized as a monorepo. Each adapter's individual changelog can be found in its respective subdirectory:
+
+- [dbt-adapters](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-adapters/CHANGELOG.md)
+- [dbt-tests-adapter](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-tests-adapter/CHANGELOG.md)
+- [dbt-athena](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-athena/CHANGELOG.md)
+- [dbt-bigquery](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-bigquery/CHANGELOG.md)
+- [dbt-postgres](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-postgres/CHANGELOG.md)
+- [dbt-redshift](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-redshift/CHANGELOG.md)
+- [dbt-snowflake](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-snowflake/CHANGELOG.md)
+- [dbt-spark](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-spark/CHANGELOG.md)


### PR DESCRIPTION
resolves #858

### Problem

Changelogs are hard to find because they're in subdirectories and on the `stable` branch, where they are released from.

### Solution

Create a top level changelog that makes them easy to find.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
