### PR TITLE
Update function macros to use correct function property names

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20251002-115032.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20251002-115032.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix referenced function property names in function macros
+time: 2025-10-02T11:50:32.228639-05:00
+custom:
+  Author: QMalcolm
+  Issue: "1365"

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/functions/scalar.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/functions/scalar.sql
@@ -12,7 +12,9 @@
 {% endmacro %}
 
 {% macro default__scalar_function_create_replace_signature_sql(target_relation) %}
-    CREATE OR REPLACE FUNCTION {{ target_relation.render() }} ({{ formatted_scalar_function_args_sql()}}) RETURNS {{ model.return_type.type }} AS
+    CREATE OR REPLACE FUNCTION {{ target_relation.render() }} ({{ formatted_scalar_function_args_sql()}})
+    RETURNS {{ model.returns.data_type }}
+    AS
 {% endmacro %}
 
 {% macro formatted_scalar_function_args_sql() %}
@@ -22,7 +24,7 @@
 {% macro default__formatted_scalar_function_args_sql() %}
     {% set args = [] %}
     {% for arg in model.arguments -%}
-        {%- do args.append(arg.name ~ ' ' ~ arg.type) -%}
+        {%- do args.append(arg.name ~ ' ' ~ arg.data_type) -%}
     {%- endfor %}
     {{ args | join(', ') }}
 {% endmacro %}

--- a/dbt-bigquery/.changes/unreleased/Fixes-20251002-121022.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20251002-121022.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix references to function properties in function macros
+time: 2025-10-02T12:10:22.720046-05:00
+custom:
+  Author: QMalcolm
+  Issue: "1365"

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/functions/scalar.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/functions/scalar.sql
@@ -1,6 +1,6 @@
 {% macro bigquery__scalar_function_create_replace_signature_sql(target_relation) %}
     CREATE OR REPLACE FUNCTION {{ target_relation.render() }} ({{ formatted_scalar_function_args_sql()}})
-    RETURNS {{ model.return_type.type }}
+    RETURNS {{ model.returns.data_type }}
     AS
 {% endmacro %}
 

--- a/dbt-bigquery/tests/functional/functions/files.py
+++ b/dbt-bigquery/tests/functional/functions/files.py
@@ -8,9 +8,9 @@ functions:
     description: Calculate the price for the xlarge version of a standard item
     arguments:
       - name: price
-        type: numeric
+        data_type: numeric
         description: The price of the standard item
-    return_type:
-      type: numeric
+    returns:
+      data_type: numeric
       description: The resulting xlarge price
 """

--- a/dbt-redshift/.changes/unreleased/Fixes-20251002-120929.yaml
+++ b/dbt-redshift/.changes/unreleased/Fixes-20251002-120929.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix references to function properties in function macros
+time: 2025-10-02T12:09:29.303025-05:00
+custom:
+  Author: QMalcolm
+  Issue: "1365"

--- a/dbt-redshift/src/dbt/include/redshift/macros/materializations/functions/scalar.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/materializations/functions/scalar.sql
@@ -1,6 +1,6 @@
 {% macro redshift__scalar_function_create_replace_signature_sql(target_relation) %}
     CREATE OR REPLACE FUNCTION {{ target_relation.render() }} ({{ formatted_scalar_function_args_sql()}})
-        RETURNS {{ model.return_type.type }}
+        RETURNS {{ model.returns.data_type }}
     {# TODO: Stop defaulting to VOLATILE once we have a way to set the volatility #}
     {# We set a default here because redshift requires a volatility to be set #}
     VOLATILE
@@ -10,7 +10,7 @@
 {% macro redshift__formatted_scalar_function_args_sql() %}
     {% set args = [] %}
     {% for arg in model.arguments -%}
-        {%- do args.append(arg.type) -%}
+        {%- do args.append(arg.data_type) -%}
     {%- endfor %}
     {{ args | join(', ') }}
 {% endmacro %}

--- a/dbt-snowflake/.changes/unreleased/Fixes-20251002-120639.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20251002-120639.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix references to function properties in funciton macros
+time: 2025-10-02T12:06:39.049296-05:00
+custom:
+  Author: QMalcolm
+  Issue: "1365"

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/functions/scalar.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/functions/scalar.sql
@@ -1,6 +1,6 @@
 {% macro snowflake__scalar_function_create_replace_signature_sql(target_relation) %}
     CREATE OR REPLACE FUNCTION {{ target_relation.render() }} ({{ formatted_scalar_function_args_sql()}})
-    RETURNS {{ model.return_type.type }}
+    RETURNS {{ model.returns.data_type }}
     LANGUAGE SQL
     AS
 {% endmacro %}

--- a/dbt-tests-adapter/.changes/unreleased/Fixes-20251002-115259.yaml
+++ b/dbt-tests-adapter/.changes/unreleased/Fixes-20251002-115259.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix file fixtures for functions to use proper function property names
+time: 2025-10-02T11:52:59.273372-05:00
+custom:
+  Author: QMalcolm
+  Issue: "1365"

--- a/dbt-tests-adapter/src/dbt/tests/adapter/functions/files.py
+++ b/dbt-tests-adapter/src/dbt/tests/adapter/functions/files.py
@@ -8,9 +8,9 @@ functions:
     description: Calculate the price for the xlarge version of a standard item
     arguments:
       - name: price
-        type: float
+        data_type: float
         description: The price of the standard item
-    return_type:
-      type: float
+    returns:
+      data_type: float
       description: The resulting xlarge price
 """


### PR DESCRIPTION
resolves #1365 

### Problem

The following function node properties are being renamed in core:
`return_type` -> `returns`
`return_type.type` -> `returns.data_type`
`arguments[x].type` -> `arguments[x].data_type`

As such we need to update the function macros to refer to the correct property names

### Solution

Update references to those function properties

### Related core PR

https://github.com/dbt-labs/dbt-core/pull/12065

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
