### PR TITLE
Set client prefetch threads to 1 to prevent deadlock at exit

### DIFF
--- a/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
@@ -394,6 +394,7 @@ class SnowflakeConnectionManager(SQLConnectionManager):
                     application="dbt",
                     insecure_mode=creds.insecure_mode,
                     session_parameters=session_parameters,
+                    client_prefetch_threads=1, # disable client prefetch because it can cause deadlock at exit, see https://github.com/snowflakedb/snowflake-connector-python/issues/2213
                     **creds.auth_args(),
                 )
 


### PR DESCRIPTION
Workaround for https://github.com/snowflakedb/snowflake-connector-python/issues/2213

### Problem

Snowflake queries can hang at exit

### Solution

This hanging only happens when there is a deadlock during the prefetch phase of the query - if there is only 1 thread, it cannot deadlock.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
