### PR TITLE
Allow for pre-releases for postgres

### DIFF
--- a/dbt-postgres/.changes/unreleased/Dependencies-20251007-123129.yaml
+++ b/dbt-postgres/.changes/unreleased/Dependencies-20251007-123129.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump minimum dbt-core to \`1.11.0b2\`
+time: 2025-10-07T12:31:29.841541-05:00
+custom:
+  Author: QMalcolm
+  PR: "1373"

--- a/dbt-postgres/pyproject.toml
+++ b/dbt-postgres/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "psycopg2-binary>=2.9,<3.0",
     "dbt-adapters>=1.7.0,<2.0",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-    "dbt-core>=1.8.0",
+    "dbt-core>=1.11.0b2",
     # installed via dbt-adapters but used directly
     "dbt-common>=1.0.4,<2.0",
     "agate>=1.0,<2.0",


### PR DESCRIPTION
resolves #1373 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

### Problem

Releasing dbt-postgres 1.10.0b1 was failing because dbt-postgres didn't allow for the inclusing of dbt-core pre-release versions.

### Solution

Bump the minimum dbt-core required by dbt-postgres, and allow for pre-release versions by making the minimum a pre-release version.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
