### PR TITLE
Feature/dbt bigquery/dataset replication add

### DIFF
--- a/dbt-bigquery/src/dbt/adapters/bigquery/dataset.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/dataset.py
@@ -1,6 +1,7 @@
-from typing import List
+from typing import Dict, List, Optional, Any
 
-from google.cloud.bigquery import AccessEntry, Dataset
+from google.cloud.bigquery import AccessEntry, Client, Dataset
+from google.api_core import exceptions as google_exceptions
 
 from dbt.adapters.events.logging import AdapterLogger
 
@@ -45,3 +46,112 @@ def add_access_entry_to_dataset(dataset: Dataset, access_entry: AccessEntry) -> 
     access_entries.append(access_entry)
     dataset.access_entries = access_entries
     return dataset
+
+
+def get_dataset_replication_config(client: Client, project: str, dataset: str) -> Dict[str, Any]:
+    """Query current replication configuration from INFORMATION_SCHEMA."""
+    # Query the dataset-scoped INFORMATION_SCHEMA; no extra WHERE needed.
+    query = (
+        f"SELECT replica_location, is_primary_replica "
+        f"FROM `{project}.{dataset}.INFORMATION_SCHEMA.SCHEMATA_REPLICAS`"
+    )
+    try:
+        result_iter = client.query(query).result()
+        replicas: List[str] = []
+        primary: Optional[str] = None
+        for row in result_iter:
+            replicas.append(row.replica_location)
+            if row.is_primary_replica:
+                primary = row.replica_location
+        return {"replicas": replicas, "primary": primary}
+    except (
+        google_exceptions.NotFound,
+        google_exceptions.BadRequest,
+        google_exceptions.GoogleAPIError,
+    ) as exc:
+        logger.warning(f"Unable to fetch replication info for `{project}.{dataset}`: {exc}")
+        return {"replicas": [], "primary": None}
+
+
+def needs_replication_update(
+    current_config: Dict[str, Any],
+    desired_replicas: List[str],
+    desired_primary: Optional[str] = None,
+) -> bool:
+    """Determine if replication configuration needs to be updated.
+
+    Args:
+        current_config (Dict[str, Any]): Current config from get_dataset_replication_config
+        desired_replicas (List[str]): Desired replica locations
+        desired_primary (Optional[str]): Desired primary replica location
+
+    Returns:
+        bool: True if update is needed, False otherwise
+    """
+    current_replicas = set(current_config.get("replicas", []))
+    desired_replicas_set = set(desired_replicas)
+
+    if current_replicas != desired_replicas_set:
+        return True
+
+    return bool(desired_primary and current_config.get("primary") != desired_primary)
+
+
+def apply_dataset_replication(
+    client: Client,
+    project: str,
+    dataset: str,
+    desired_replicas: List[str],
+    desired_primary: Optional[str] = None,
+) -> None:
+    """Apply replication configuration using ALTER SCHEMA DDL."""
+    current = get_dataset_replication_config(client, project, dataset)
+
+    if not needs_replication_update(current, desired_replicas, desired_primary):
+        logger.debug(f"Dataset {project}.{dataset} replication already configured correctly")
+        return
+
+    logger.info(f"Configuring replication for dataset {project}.{dataset}")
+
+    current_replicas = set(current.get("replicas", []))
+    desired_replicas_set = set(desired_replicas)
+
+    # Add new replicas
+    to_add = desired_replicas_set - current_replicas
+    for location in to_add:
+        sql = f"ALTER SCHEMA `{project}.{dataset}` ADD REPLICA `{location}`"
+        logger.info(f"Adding replica: {location}")
+        try:
+            client.query(sql).result()
+        except google_exceptions.GoogleAPIError as e:
+            # Ignore "already exists", warn otherwise
+            if "already exists" not in str(e).lower():
+                logger.warning(f"Failed to add replica {location}: {e}")
+
+    # Remove old replicas
+    to_remove = current_replicas - desired_replicas_set
+    for location in to_remove:
+        sql = f"ALTER SCHEMA `{project}.{dataset}` DROP REPLICA `{location}`"
+        logger.info(f"Dropping replica: {location}")
+        try:
+            client.query(sql).result()
+        except google_exceptions.GoogleAPIError as e:
+            logger.warning(f"Failed to drop replica {location}: {e}")
+
+    # Set primary replica if specified and different
+    if desired_primary:
+        if desired_primary not in desired_replicas_set:
+            logger.warning(
+                f"Desired primary replica '{desired_primary}' is not in desired replicas {sorted(desired_replicas_set)}. "
+                "Skipping setting primary replica."
+            )
+        elif current.get("primary") != desired_primary:
+            sql = (
+                f"ALTER SCHEMA `{project}.{dataset}` "
+                f"SET OPTIONS (default_replica = `{desired_primary}`)"
+            )
+            logger.info(f"Setting primary replica: {desired_primary}")
+            try:
+                client.query(sql).result()
+            except google_exceptions.GoogleAPIError as e:
+                logger.warning(f"Failed to set primary replica '{desired_primary}': {e}")

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/adapters/schema.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/adapters/schema.sql
@@ -1,0 +1,23 @@
+{% macro bigquery__create_schema(relation) -%}
+  {%- set dataset_replicas = config.get('dataset_replicas') -%}
+  {%- set primary_replica = config.get('primary_replica') -%}
+
+  {# Normalize dataset_replicas to a list of strings #}
+  {%- if dataset_replicas is string -%}
+    {# Allow comma-separated strings #}
+    {%- set dataset_replicas = dataset_replicas.split(',') | map('trim') | list -%}
+  {%- endif -%}
+  {%- if dataset_replicas is not none and dataset_replicas is not sequence -%}
+    {{ log("Invalid dataset_replicas config; expected list or comma-separated string. Skipping replication.", info=True) }}
+    {%- set dataset_replicas = none -%}
+  {%- endif -%}
+
+  {%- if dataset_replicas -%}
+    {{ log("Configuring dataset " ~ relation.schema ~ " with replicas: " ~ dataset_replicas | join(', '), info=True) }}
+    {%- if primary_replica -%}
+      {{ log("  Primary replica: " ~ primary_replica, info=True) }}
+    {%- endif -%}
+  {%- endif -%}
+
+  {% do adapter.create_dataset_with_replication(relation, dataset_replicas, primary_replica) %}
+{% endmacro %}


### PR DESCRIPTION
This pull request adds support for configuring dataset replication in BigQuery through dbt, allowing users to specify replica locations and a primary replica when creating datasets. The changes introduce new configuration options, logic for applying replication settings, and validation to ensure correct usage. Additionally, unit tests are added to verify the new replication logic.

**Dataset Replication Support**

* Added `dataset_replicas` and `primary_replica` configuration options to [`BigqueryConfig`](https://github.com/dbt-labs/dbt-adapters/blob/gavin-burns-US:dbt-adapters:main/dbt-bigquery/src/dbt/adapters/bigquery/impl.py#L125-L126), enabling users to define dataset replication settings in dbt.
* Introduced the [`create_dataset_with_replication`](https://github.com/dbt-labs/dbt-adapters/blob/gavin-burns-US:dbt-adapters:main/dbt-bigquery/src/dbt/adapters/bigquery/impl.py#L349-L375) method in `BigQueryAdapter`, which creates a dataset and applies replication configuration if specified. This method is called from the new macro.
* Updated the [`create_dataset`](https://github.com/dbt-labs/dbt-adapters/blob/gavin-burns-US:dbt-adapters:main/dbt-bigquery/src/dbt/adapters/bigquery/connections.py#L557-L594) method in `connections.py` to accept replication parameters and apply replication configuration using a new helper function. Includes validation to avoid malformed configs.

**Replication Logic Implementation**

* Added helper functions in [`dataset.py`](https://github.com/dbt-labs/dbt-adapters/blob/gavin-burns-US:dbt-adapters:main/dbt-bigquery/src/dbt/adapters/bigquery/dataset.py#L50-L157) ([`get_dataset_replication_config`](https://github.com/dbt-labs/dbt-adapters/blob/gavin-burns-US:dbt-adapters:main/dbt-bigquery/src/dbt/adapters/bigquery/dataset.py#L50-L73), [`needs_replication_update`](https://github.com/dbt-labs/dbt-adapters/blob/gavin-burns-US:dbt-adapters:main/dbt-bigquery/src/dbt/adapters/bigquery/dataset.py#L76-L97), [`apply_dataset_replication`](https://github.com/dbt-labs/dbt-adapters/blob/gavin-burns-US:dbt-adapters:main/dbt-bigquery/src/dbt/adapters/bigquery/dataset.py#L100-L157)) to query current replication settings, determine if updates are needed, and apply changes using BigQuery DDL statements.

**Macro and Testing**

* Added a new macro [`bigquery__create_schema`](https://github.com/dbt-labs/dbt-adapters/blob/gavin-burns-US:dbt-adapters:main/dbt-bigquery/src/dbt/include/bigquery/macros/adapters/schema.sql) to handle dataset creation with replication configuration, including normalization and validation of macro arguments.
* Added [unit tests](https://github.com/dbt-labs/dbt-adapters/blob/gavin-burns-US:dbt-adapters:main/dbt-bigquery/tests/unit/test_dataset.py#L95-L126) for `needs_replication_update` to verify correct behavior under various scenarios.

This adds native BigQuery dataset replication configuration support to dbt, allowing users to configure replicas directly in `dbt_project.yml`, schema files, or model configs without custom hooks.
[BigQuery-Dataset-Replication-Configuration-Example.md](https://github.com/user-attachments/files/22935787/BigQuery-Dataset-Replication-Configuration-Example.md)
[pr-summary.md](https://github.com/user-attachments/files/22935788/pr-summary.md)
