### PR TITLE
🩹 Remove table_owner from text only cols

### DIFF
--- a/dbt-adapters/src/dbt/adapters/base/impl.py
+++ b/dbt-adapters/src/dbt/adapters/base/impl.py
@@ -1329,7 +1329,6 @@ class BaseAdapter(metaclass=AdapterMeta):
                 "table_name",
                 "table_type",
                 "table_comment",
-                "table_owner",
                 "column_name",
                 "column_type",
                 "column_comment",

--- a/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
@@ -118,10 +118,30 @@ class SnowflakeAdapter(SQLAdapter):
     def _catalog_filter_table(
         cls, table: "agate.Table", used_schemas: FrozenSet[Tuple[str, str]]
     ) -> "agate.Table":
+        from dbt_common.clients.agate_helper import table_from_rows
+        from dbt.adapters.base.impl import _catalog_filter_schemas
+
         # On snowflake, users can set QUOTED_IDENTIFIERS_IGNORE_CASE, so force
         # the column names to their lowercased forms.
+
         lowered = table.rename(column_names=[c.lower() for c in table.column_names])
-        return super()._catalog_filter_table(lowered, used_schemas)
+
+        table = table_from_rows(
+            lowered.rows,
+            lowered.column_names,
+            text_only_columns=[
+                "table_database",
+                "table_schema",
+                "table_name",
+                "table_type",
+                "table_owner",
+                "table_comment",
+                "column_name",
+                "column_type",
+                "column_comment",
+            ],
+        )
+        return table.where(_catalog_filter_schemas(used_schemas))
 
     def _make_match_kwargs(self, database, schema, identifier):
         # if any path part is already quoted then consider same casing but without quotes


### PR DESCRIPTION


<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
PR #1057 added several new column names to the `text_only_columns` arg to the `table_from_rows` call in the `_catalog_filter_table` class method. This method is called as part of the `dbt docs generate` task.

However, some of the new column names included are not included in the list of columns returned by certain adapter implementations for the `__get_catalog` and `__get_catalog_relations`.
For example, the relevant BigQuery and Athena macros do not return a column named `table_owner` (see #1135).

This results in the agate type checker emitting a warning when attempting typing checking runs.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
Any columns added to the `text_only_columns` argument for the call to `table_from_rows` in the base implementation should presumably be columns that are returned by all adapters implementations.

This PR removes the `table_owner` name from the list of text_only_columns included in the base implementation of `_catalog_filter_table` and moves this to a Snowflake-specific adapter implementation.

I investigated whether agate provides a means of suppressing this warning but there does not appear to be a mechanism to do so. Additionally, I am unsure whether this would be desirable. 

resolves #1135
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
