### PR TITLE
Cap logbook in dbt-spark to less than 1.9

### DIFF
--- a/dbt-spark/.changes/unreleased/Dependencies-20251106-103919.yaml
+++ b/dbt-spark/.changes/unreleased/Dependencies-20251106-103919.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Cap logbook at less than 1.9 to avoid breaking change
+time: 2025-11-06T10:39:19.285967-06:00
+custom:
+  Author: QMalcolm
+  PR: N/A

--- a/dbt-spark/hatch.toml
+++ b/dbt-spark/hatch.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pytest-csv~=3.0",
     "pytest-dotenv",
     "pytest-logbook~=1.2",
+    "logbook<1.9",
     "pytest-mock",
     "pytest-xdist",
 ]
@@ -70,6 +71,7 @@ dependencies = [
     "pytest>=7.0,<8.0",
     "pytest-csv~=3.0",
     "pytest-logbook~=1.2",
+    "logbook<1.9",
     "pytest-mock",
     "pytest-xdist",
 ]
@@ -90,6 +92,7 @@ dependencies = [
     "pytest>=7.0,<8.0",
     "pytest-csv~=3.0",
     "pytest-logbook~=1.2",
+    "logbook<1.9",
     "pytest-mock",
     "pytest-xdist",
 ]


### PR DESCRIPTION
resolves #N/A
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#


### Problem

dbt-spark CI was failing due to a logbook breaking change. 

### Solution

Cap logbook for dbt-spark

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
