### PR TITLE
Filter catalog text_only_columns to existing columns to prevent agate warnings

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20251113-165524.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20251113-165524.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix agate warnings during catalog generation
+time: 2025-11-13T16:55:24.942479Z
+custom:
+    Author: physcat
+    Issue: "1135"

--- a/dbt-adapters/src/dbt/adapters/base/impl.py
+++ b/dbt-adapters/src/dbt/adapters/base/impl.py
@@ -1329,21 +1329,28 @@ class BaseAdapter(metaclass=AdapterMeta):
         """
         from dbt_common.clients.agate_helper import table_from_rows
 
+        # Define all possible text-only columns for catalog metadata
+        all_text_columns = [
+            "table_database",
+            "table_schema",
+            "table_name",
+            "table_type",
+            "table_comment",
+            "table_owner",
+            "column_name",
+            "column_type",
+            "column_comment",
+        ]
+
+        # Filter to only columns that actually exist in the table to avoid
+        # warnings from agate when adapters don't return all metadata columns
+        existing_text_columns = [col for col in all_text_columns if col in table.column_names]
+
         # force database + schema to be strings
         table = table_from_rows(
             table.rows,
             table.column_names,
-            text_only_columns=[
-                "table_database",
-                "table_schema",
-                "table_name",
-                "table_type",
-                "table_comment",
-                "table_owner",
-                "column_name",
-                "column_type",
-                "column_comment",
-            ],
+            text_only_columns=existing_text_columns,
         )
         return table.where(_catalog_filter_schemas(used_schemas))
 


### PR DESCRIPTION
### Problem

  Resolves #1135

When running `dbt docs generate`, agate emits RuntimeWarnings for columns specified in `text_only_columns` that don't exist in the catalog results:
```
"table_owner" does not match the name of any column in this table.
```

This happens because some adapter implementations (e.g., BigQuery, Athena) don't return all the metadata columns that were added to the `text_only_columns` list in PR #1057, specifically the `table_owner` column.

### Solution

This PR takes a defensive approach by filtering the `text_only_columns` list at runtime to only include columns that actually exist in the returned catalog data. This prevents warnings when adapters return different metadata columns while still ensuring all returned columns are properly typed as text.

**Alternative Approach Note**: I want to acknowledge PR #1404 by @morgan-dgk which addresses the same issue by removing `table_owner` from the base implementation and moving it to adapter-specific implementations. That's a valid architectural approach, and since that PR is already in progress, I'm happy to close this PR if the team prefers that solution.

The key difference between the two approaches:
- **This PR**: Generic solution that handles any missing columns automatically
- **PR #1404**: Explicit approach that moves adapter-specific columns to adapter implementations

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
