### PR TITLE
Fix/snapshot dbt scd

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20251113-130218.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20251113-130218.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix dbt_scd_id in snapshot as hash of unique_key and check_cols when check strategy is configured
+time: 2025-11-13T13:02:18.8291969+02:00
+custom:
+    Author: spyrosviz
+    Issue: "1436"

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
@@ -170,7 +170,7 @@
     )
     {%- endset %}
 
-    {% set scd_args = api.Relation.scd_args(primary_key, updated_at) %}
+    {% set scd_args = api.Relation.scd_args(primary_key, check_cols_config) %}
     {% set scd_id_expr = snapshot_hash_arguments(scd_args) %}
 
     {% do return({


### PR DESCRIPTION
resolves #1436

### Problem
Currently in snapshot the dbt_scd_id is computed as the hash of the columns provided in unique_key and updated_at both in check and timestamp strategy. According to documentation when strategy is check, then the dbt_scd_id should be the hash of unique_key and check_cols provided in snapshot configuration. This PR solves the above issue.

### Solution
Inside dbt-adapters package in dbt-adapters\src\dbt\include\global_project\macros\materializations\snapshots\strategies.sql
the scd_args is defined in both macro snapshot_check_strategy and snapshot_timestamp_strategy as 
{% set scd_args = api.Relation.scd_args(primary_key, updated_at) %}.
I have changed the code in macro snapshot_check_strategy as 
{% set scd_args = api.Relation.scd_args(primary_key, check_cols_config) %}
accordingly with the documentation

### Checklist
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
