### PR TITLE
Update dbt-adapters minimum to 1.19.0 in adapters supporting UDFs

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Dependencies-20251117-181808.yaml
+++ b/dbt-bigquery/.changes/unreleased/Dependencies-20251117-181808.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump minimum dbt-adapters to 1.19.0
+time: 2025-11-17T18:18:08.938-06:00
+custom:
+  Author: QMalcolm
+  PR: "1421"

--- a/dbt-bigquery/pyproject.toml
+++ b/dbt-bigquery/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "dbt-common>=1.10,<2.0",
-    "dbt-adapters>=1.16,<2.0",
+    "dbt-adapters>=1.19.0,<2.0",
     # 3.20 introduced pyarrow>=3.0 under the `pandas` extra
     "google-cloud-bigquery[pandas]>=3.0,<4.0",
     "google-cloud-storage>=2.4,<3.2",

--- a/dbt-postgres/.changes/unreleased/Dependencies-20251117-181843.yaml
+++ b/dbt-postgres/.changes/unreleased/Dependencies-20251117-181843.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump minimum dbt-adapters to 1.19.0
+time: 2025-11-17T18:18:43.599237-06:00
+custom:
+  Author: QMalcolm
+  PR: "1421"

--- a/dbt-postgres/pyproject.toml
+++ b/dbt-postgres/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "psycopg2-binary>=2.9,<3.0",
-    "dbt-adapters>=1.7.0,<2.0",
+    "dbt-adapters>=1.19.0,<2.0",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
     "dbt-core>=1.8.0rc1",
     # installed via dbt-adapters but used directly

--- a/dbt-redshift/.changes/unreleased/Dependencies-20251117-181856.yaml
+++ b/dbt-redshift/.changes/unreleased/Dependencies-20251117-181856.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump minimum dbt-adapters to 1.19.0█
+time: 2025-11-17T18:18:56.857769-06:00
+custom:
+  Author: QMalcolm
+  PR: "1421"

--- a/dbt-redshift/pyproject.toml
+++ b/dbt-redshift/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "dbt-common>=1.10,<2.0",
-    "dbt-adapters>=1.11,<2.0",
+    "dbt-adapters>=1.19.0,<2.0",
     "dbt-postgres>=1.8,<1.10",
     # dbt-redshift depends deeply on this package. it does not follow SemVer, therefore there have been breaking changes in previous patch releases
     # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.

--- a/dbt-snowflake/.changes/unreleased/Dependencies-20251117-181911.yaml
+++ b/dbt-snowflake/.changes/unreleased/Dependencies-20251117-181911.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump minimum dbt-adapters to 1.19.0█
+time: 2025-11-17T18:19:11.5421-06:00
+custom:
+  Author: QMalcolm
+  PR: "1421"

--- a/dbt-snowflake/pyproject.toml
+++ b/dbt-snowflake/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "dbt-common>=1.10,<2.0",
-    "dbt-adapters>=1.16.6,<2.0",
+    "dbt-adapters>=1.19.0,<2.0",
     # lower bound pin due to CVE-2025-24794
     "snowflake-connector-python[secure-local-storage]>=4.0.0,<5.0.0",
     "certifi<2025.4.26",


### PR DESCRIPTION
resolves #1421

### Problem

People were installing the beta version of some `dbt-<adapter>` adapters to try UDFs and would run into an issue where UDF macros / materializations wouldn't be available. This is because an older version of `dbt-adapters` was still installed

### Solution

Bump the minimum `dbt-adapters` version to 1.19.0 in the affected adapters.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
