### PR TITLE
Fix get_fixture_sql which always leads to a compliation error if column_name_to_data_types is not falsy

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20251119-143859.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20251119-143859.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix get_fixture_sql which always leads to a compliation error if column_name_to_data_types is not falsy
+time: 2025-11-19T14:38:59.834685+01:00
+custom:
+    Author: darkclouder
+    Issue: none

--- a/dbt-adapters/src/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/unit_test_sql/get_fixture_sql.sql
@@ -8,12 +8,10 @@
 {%-   set columns_in_relation = adapter.get_columns_in_relation(this_or_defer_relation) -%}
 
 {%-   set column_name_to_data_types = {} -%}
-{%-   set column_name_to_quoted = {} -%}
 {%-   for column in columns_in_relation -%}
 
 {#-- This needs to be a case-insensitive comparison --#}
 {%-     do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}
-{%-     do column_name_to_quoted.update({column.name|lower: column.quoted}) -%}
 {%-   endfor -%}
 {%- endif -%}
 
@@ -32,7 +30,7 @@
 {%-   set default_row_copy = default_row.copy() -%}
 {%-   do default_row_copy.update(formatted_row) -%}
 select
-{%-   for column_name, column_value in default_row_copy.items() %} {{ column_value }} as {{ column_name_to_quoted[column_name] }}{% if not loop.last -%}, {%- endif %}
+{%-   for column_name, column_value in default_row_copy.items() %} {{ column_value }} as {{ adapter.quote(column_name) }}{% if not loop.last -%}, {%- endif %}
 {%-   endfor %}
 {%-   if not loop.last %}
 union all
@@ -41,7 +39,7 @@ union all
 
 {%- if (rows | length) == 0 -%}
     select
-    {%- for column_name, column_value in default_row.items() %} {{ column_value }} as {{ column_name_to_quoted[column_name] }}{% if not loop.last -%},{%- endif %}
+    {%- for column_name, column_value in default_row.items() %} {{ column_value }} as {{ adapter.quote(column_name) }}{% if not loop.last -%},{%- endif %}
     {%- endfor %}
     limit 0
 {%- endif -%}


### PR DESCRIPTION
### Problem
`column_name_to_quoted` is set inside `{%- if not column_name_to_data_types -%}`.
When `column_name_to_data_types` is not falsy, this variable is not set.
I.e. whenever anything truthy for `column_name_to_data_types` is passed, this macro will always lead to a compilation error.

I'm currently working on a PR for dbt-core where `get_fixture_sql` gets passed a dictionary for `column_name_to_data_types`. So far `column_name_to_data_types` is always passed as `None`.

### Solution
Defining a var inside an if statement and using it afterwards outside is generally a bad practice.
I decided to use `adapter.quote` instead of what comes back from `adapter.get_columns_in_relation`, so this should always work, independent from if the if case exists or not.
Thanks to that we don't even need the variable `column_name_to_quoted`.
Feel free to add any comments and suggestions on what's better to use than `adapter.quote`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
