### PR TITLE
Fix truncation of Glue table descriptions in Athena adapter

### DIFF
--- a/dbt-athena/src/dbt/adapters/athena/impl.py
+++ b/dbt-athena/src/dbt/adapters/athena/impl.py
@@ -1035,7 +1035,7 @@ class AthenaAdapter(SQLAdapter):
         # Update table description
         if persist_relation_docs:
             # Prepare dbt description
-            clean_table_description = ellipsis_comment(clean_sql_comment(model["description"]))
+            clean_table_description = ellipsis_comment(clean_sql_comment(model["description"]), 2048)
             # Get current description from Glue
             glue_table_description = table.get("Description", "")
             # Get current description parameter from Glue
@@ -1085,7 +1085,7 @@ class AthenaAdapter(SQLAdapter):
                 if col_name in model["columns"]:
                     col_comment = model["columns"][col_name]["description"]
                     # Prepare column description from dbt
-                    clean_col_comment = ellipsis_comment(clean_sql_comment(col_comment))
+                    clean_col_comment = ellipsis_comment(clean_sql_comment(col_comment), 255)
                     # Get current column comment from Glue
                     glue_col_comment = col_obj.get("Comment", "")
                     # Check that column description is already attached to Glue table


### PR DESCRIPTION
Problem
Currently, when persisting table descriptions to Glue using the Athena adapter, the table description is truncated to 255 characters, which is the limit applied to column descriptions. However, Glue allows up to 2048 characters for table descriptions. This incorrect behavior causes detailed descriptions to be lost.

Docs: table, column

Solution
This PR updates the truncation logic to differentiate between table and column descriptions:

For tables, the limit is changed from 255 to 2048 (leaving a safe margin for Glue).
clean_table_description = ellipsis_comment(clean_sql_comment(model["description"]), 2048)

For columns, the limit remains 255, as per Glue’s restriction.
clean_col_comment = ellipsis_comment(clean_sql_comment(col_comment), 255)

Key changes:

Updated the persist_docs_to_glue function to apply ellipsis_comment with the correct limit for each case.

No changes to the public interface or adapter contracts.

Trade-offs:

Simple and direct fix with no performance impact.

Maintains Glue compatibility and prevents information loss.

Checklist
 I have read the contributing guide and understand what's expected of me
 I have run this code in development and it appears to resolve the stated issue
 This PR includes tests, or tests are not required/relevant for this PR
 This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX