### PR TITLE
Move dbt-redshift's dbt-postgres req spec to `>=1.10.0rc1,<2.0`

### DIFF
--- a/dbt-redshift/.changes/unreleased/Dependencies-20251124-141926.yaml
+++ b/dbt-redshift/.changes/unreleased/Dependencies-20251124-141926.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Update dbt-postgres requirement to allow <2.0
+time: 2025-11-24T14:19:26.663347-06:00
+custom:
+  Author: QMalcolm
+  PR: "1420"

--- a/dbt-redshift/pyproject.toml
+++ b/dbt-redshift/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "dbt-common>=1.10,<2.0",
     "dbt-adapters>=1.19.0,<2.0",
-    "dbt-postgres>=1.8,<1.10",
+    "dbt-postgres>=1.10.0rc1,<2.0",
     # dbt-redshift depends deeply on this package. it does not follow SemVer, therefore there have been breaking changes in previous patch releases
     # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
     "redshift-connector>=2.1.8,<2.2",


### PR DESCRIPTION
resolves #1420

### Problem

dbt-redshift was previously excluding `dbt-postgres>=1.10`. This was a problem when trying to install pre-releases of dbt-redshift and dbt-postgres in the same environment as the latest dbt-postgres wasn't viable for dbt-redshift. Additionally, new versions of redshift will depend on some functionalities in new versions of dbt-postgres. 


### Solution

We've updated the spec to `dbt-postgres>=1.10.0rc1,<2.0`. Before we release the next GA of dbt-redshift, the `rc1` portion of the req spec should be dropped.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
