### PR TITLE
Update `dbt-adapters` link to `main` branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This repository is organized as a monorepo. Each adapter's individual changelog can be found in its respective subdirectory:
 
-- [dbt-adapters](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-adapters/CHANGELOG.md)
+- [dbt-adapters](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/CHANGELOG.md)
 - [dbt-tests-adapter](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-tests-adapter/CHANGELOG.md)
 - [dbt-athena](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-athena/CHANGELOG.md)
 - [dbt-bigquery](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-bigquery/CHANGELOG.md)


### PR DESCRIPTION
### Problem

[PyPI](https://pypi.org/project/dbt-adapters/#history) lists a bunch of release versions that aren't covered in the [changelog for `dbt-adapters`](https://github.com/dbt-labs/dbt-adapters/blob/stable/dbt-adapters/CHANGELOG.md) that is linked from the [main `CHANGELOG` page](https://github.com/dbt-labs/dbt-adapters/blob/main/CHANGELOG.md).

The root cause is that `dbt-adapters` isn't released off stable like the rest of them are.

### Solution

Update [this](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/CHANGELOG.md) to point to `main` for `dbt-adapters` but the rest should point to the `stable` branches.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] N/A - I have run this code in development and it appears to resolve the stated issue
- [X] N/A - This PR includes tests, or tests are not required/relevant for this PR
- [X] N/A - This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX