### PR TITLE
update bigframes model packages test

### DIFF
--- a/dbt-bigquery/tests/functional/adapter/test_python_model.py
+++ b/dbt-bigquery/tests/functional/adapter/test_python_model.py
@@ -358,6 +358,9 @@ class TestBigframesModelsMerge:
         assert len(result) == 1
 
 
+# we specify the notebook template id here
+# because the default template has disabled
+# public internet access.
 models__bigframes_model_packages = f"""
 def model(dbt, session):
     dbt.config(


### PR DESCRIPTION
If a user doesn't have a default runtime template for their Collab notebook (what "BigFrames" uses for compute) dbt-bigquery creates one with public internet access _disabled_. This makes a "pip install" command fail.

The reason we're running into this now is that we had a pre-existing default template that must have been deleted so we created a new template with the access disabled so the test began failing.

This PR updates the fixture to run against a template with internet enabled. 