### PR TITLE
feat(snowflake): Add COPY GRANTS support for dynamic tables

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Features-20250707-131918.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20250707-131918.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add COPY GRANTS support for dynamic tables to inherit object-level privileges during table creation and replacement
+time: 2025-07-07T13:19:18.6N+1000
+custom:
+  Author: shaariqch
+  Issue: "1154"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
@@ -62,6 +62,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
     row_access_policy: Optional[str] = None
     table_tag: Optional[str] = None
     cluster_by: Optional[Union[str, list[str]]] = None
+    copy_grants: Optional[bool] = None
 
     @classmethod
     def from_dict(cls, config_dict: Dict[str, Any]) -> Self:
@@ -83,6 +84,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
             "row_access_policy": config_dict.get("row_access_policy"),
             "table_tag": config_dict.get("table_tag"),
             "cluster_by": config_dict.get("cluster_by"),
+            "copy_grants": config_dict.get("copy_grants"),
         }
 
         return super().from_dict(kwargs_dict)  # type:ignore
@@ -103,6 +105,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
             ),
             "table_tag": relation_config.config.extra.get("table_tag"),  # type:ignore
             "cluster_by": cluster_by(relation_config),
+            "copy_grants": relation_config.config.extra.get("copy_grants"),  # type:ignore
         }
 
         if refresh_mode := relation_config.config.extra.get("refresh_mode"):  # type:ignore

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
@@ -39,6 +39,7 @@
         {{ optional('with row access policy', dynamic_table.row_access_policy, equals_char='') }}
         {{ optional('with tag', dynamic_table.table_tag, quote_char='(', equals_char='') }}
         {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
+        {% if dynamic_table.copy_grants -%} copy grants {%- endif %}
         as (
             {{ sql }}
         )
@@ -76,6 +77,7 @@
         {{ optional('row_access_policy', dynamic_table.row_access_policy) }}
         {{ optional('table_tag', dynamic_table.table_tag) }}
         {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
+        {% if dynamic_table.copy_grants -%} copy grants {%- endif %}
         as (
             {{ sql }}
         )

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
@@ -52,6 +52,7 @@ create or replace dynamic table {{ relation }}
     {{ optional('with row access policy', dynamic_table.row_access_policy, equals_char='') }}
     {{ optional('with tag', dynamic_table.table_tag, quote_char='(', equals_char='') }}
     {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
+    {% if dynamic_table.copy_grants -%} copy grants {%- endif %}
     as (
         {{ sql }}
     )
@@ -89,6 +90,7 @@ create or replace dynamic iceberg table {{ relation }}
     {{ optional('row_access_policy', dynamic_table.row_access_policy) }}
     {{ optional('table_tag', dynamic_table.table_tag) }}
     {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
+    {% if dynamic_table.copy_grants -%} copy grants {%- endif %}
     as (
         {{ sql }}
     )

--- a/dbt-snowflake/tests/functional/adapter/test_grants.py
+++ b/dbt-snowflake/tests/functional/adapter/test_grants.py
@@ -62,3 +62,18 @@ class TestSnapshotGrants(BaseSnapshotGrants):
 
 class TestSnapshotCopyGrantsSnowflake(BaseCopyGrantsSnowflake, BaseSnapshotGrants):
     pass
+
+
+class TestDynamicTableCopyGrantsSnowflake(BaseCopyGrantsSnowflake):
+    """Test copy_grants functionality for dynamic tables"""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+copy_grants": True,
+                "+materialized": "dynamic_table",
+                "+target_lag": "1 minute",
+                "+snowflake_warehouse": "DBT_TESTING_ALT",
+            },
+        }


### PR DESCRIPTION
Resolves #1154

## Summary

Adds `copy_grants` configuration option for dynamic table materialization, allowing dynamic tables to inherit existing object-level privileges during creation and replacement.

### Changes
- Added `copy_grants: Optional[bool]` field to `SnowflakeDynamicTableConfig`
- Updated `from_dict()` and `parse_relation_config()` to handle the new config
- Added `COPY GRANTS` clause to both INFO_SCHEMA and BUILT_IN (Iceberg) dynamic table macros in `create.sql` and `replace.sql`

### Usage

```sql
{{ config(
    materialized='dynamic_table',
    target_lag='1 hour',
    snowflake_warehouse='MY_WH',
    copy_grants=true
) }}

select * from {{ ref('source_table') }}
```

Or at project level in `dbt_project.yml`:
```yaml
models:
  +copy_grants: true
```

## Test plan
- [x] Code quality checks pass (black, flake8, mypy)
- [x] Unit tests pass locally
- [ ] Integration tests (CI will run)
- [x] Added test class `TestDynamicTableCopyGrantsSnowflake` in `test_grants.py`
- [x] Added test class `TestDynamicTableCopyGrants` in `test_basic.py`

## Checklist
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have created a changelog entry using `changie new`