### PR TITLE
Snowflake support for Iceberg V3 tables and Dynamic tables

### DIFF
--- a/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
@@ -50,6 +50,7 @@ class BuiltInCatalogRelation:
     max_data_extension_time_in_days: Optional[int] = None
     storage_serialization_policy: Optional[str] = None
     change_tracking: Optional[str] = None
+    iceberg_version: Optional[int] = None
 
 
 class BuiltInCatalogIntegration(CatalogIntegration):
@@ -62,6 +63,7 @@ class BuiltInCatalogIntegration(CatalogIntegration):
     max_data_extension_time_in_days: Optional[int] = None
     storage_serialization_policy = None
     change_tracking = None
+    iceberg_version: Optional[int] = None
 
     def __init__(self, config: CatalogIntegrationConfig) -> None:
         # we overwrite this because the base provides too much config
@@ -84,6 +86,10 @@ class BuiltInCatalogIntegration(CatalogIntegration):
 
             self.data_retention_time_in_days = adapter_properties.get(
                 SnowflakeIcebergTableRelationParameters.data_retention_time_in_days
+            )
+
+            self.iceberg_version = adapter_properties.get(
+                SnowflakeIcebergTableRelationParameters.iceberg_version
             )
 
     def build_relation(self, model: RelationConfig) -> BuiltInCatalogRelation:
@@ -123,6 +129,7 @@ class BuiltInCatalogIntegration(CatalogIntegration):
             max_data_extension_time_in_days=max_data_extension_time_in_days,
             change_tracking=self._resolve_change_tracking(model),
             data_retention_time_in_days=data_retention_time_in_days,
+            iceberg_version=parse_model.iceberg_version(model) or self.iceberg_version,
         )
 
     def _resolve_change_tracking(self, model: RelationConfig) -> Optional[str]:

--- a/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_iceberg_rest.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_iceberg_rest.py
@@ -25,6 +25,7 @@ class IcebergRestCatalogRelation:
     target_file_size: Optional[str] = None
     max_data_extension_time_in_days: Optional[int] = None
     auto_refresh: Optional[bool] = None
+    iceberg_version: Optional[int] = None
 
 
 class IcebergRestCatalogIntegration(CatalogIntegration):
@@ -38,6 +39,7 @@ class IcebergRestCatalogIntegration(CatalogIntegration):
     catalog_linked_database_type: Optional[str] = None
     max_data_extension_time_in_days: Optional[int] = None
     target_file_size: Optional[str] = None
+    iceberg_version: Optional[int] = None
 
     def __init__(self, config: CatalogIntegrationConfig) -> None:
         # we overwrite this because the base provides too much config
@@ -54,6 +56,7 @@ class IcebergRestCatalogIntegration(CatalogIntegration):
             self.max_data_extension_time_in_days = adapter_properties.get(
                 "max_data_extension_time_in_days"
             )
+            self.iceberg_version = adapter_properties.get("iceberg_version")
 
         if not self.catalog_linked_database:
             raise InvalidCatalogIntegrationConfigError(
@@ -91,4 +94,5 @@ class IcebergRestCatalogIntegration(CatalogIntegration):
             target_file_size=parse_model.target_file_size(model) or self.target_file_size,
             max_data_extension_time_in_days=parse_model.max_data_extension_time_in_days(model)
             or self.max_data_extension_time_in_days,
+            iceberg_version=parse_model.iceberg_version(model) or self.iceberg_version,
         )

--- a/dbt-snowflake/src/dbt/adapters/snowflake/constants.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/constants.py
@@ -41,4 +41,5 @@ SnowflakeIcebergTableRelationParameters = SimpleNamespace(
     max_data_extension_time_in_days="max_data_extension_time_in_days",
     change_tracking="change_tracking",
     automatic_clustering="automatic_clustering",
+    iceberg_version="iceberg_version",
 )

--- a/dbt-snowflake/src/dbt/adapters/snowflake/parse_model.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/parse_model.py
@@ -130,3 +130,7 @@ def table_format(model: RelationConfig) -> Optional[str]:
 
 def target_file_size(model: RelationConfig) -> Optional[str]:
     return model.config.get("target_file_size") if model.config else None
+
+
+def iceberg_version(model: RelationConfig) -> Optional[int]:
+    return model.config.get("iceberg_version") if model.config else None

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
@@ -71,6 +71,7 @@
         {{ optional('external_volume', catalog_relation.external_volume, "'") }}
         catalog = 'SNOWFLAKE'  -- required, and always SNOWFLAKE for built-in Iceberg tables
         base_location = '{{ catalog_relation.base_location }}'
+        {{ optional('iceberg_version', catalog_relation.iceberg_version)}}
         {{ optional('refresh_mode', dynamic_table.refresh_mode) }}
         {{ optional('initialize', dynamic_table.initialize) }}
         {{ optional('row_access_policy', dynamic_table.row_access_policy) }}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
@@ -84,6 +84,7 @@ create or replace dynamic iceberg table {{ relation }}
     {{ optional('external_volume', catalog_relation.external_volume, "'") }}
     catalog = 'snowflake'
     base_location = '{{ catalog_relation.base_location }}'
+    {{ optional('iceberg_version', catalog_relation.iceberg_version)}}
     {{ optional('refresh_mode', dynamic_table.refresh_mode) }}
     {{ optional('initialize', dynamic_table.initialize) }}
     {{ optional('row_access_policy', dynamic_table.row_access_policy) }}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
@@ -165,6 +165,7 @@ create or replace iceberg table {{ relation }}
     catalog = 'SNOWFLAKE'  -- required, and always SNOWFLAKE for built-in Iceberg tables
     base_location = '{{ catalog_relation.base_location }}'
     {% if partition_by_string -%} partition by ({{ partition_by_string }}) {%- endif %}
+    {{ optional('iceberg_version', catalog_relation.iceberg_version)}}
     {{ optional('storage_serialization_policy', catalog_relation.storage_serialization_policy, "'")}}
     {{ optional('max_data_extension_time_in_days', catalog_relation.max_data_extension_time_in_days)}}
     {{ optional('data_retention_time_in_days', catalog_relation.data_retention_time_in_days)}}
@@ -251,6 +252,7 @@ create iceberg table {{ relation }}
     {%- endif %}
     {% if partition_by_string -%} partition by ({{ partition_by_string }}) {%- endif %}
     {{ optional('external_volume', catalog_relation.external_volume, "'") }}
+    {{ optional('iceberg_version', catalog_relation.iceberg_version)}}
     {{ optional('target_file_size', catalog_relation.target_file_size, "'") }}
     {{ optional('auto_refresh', catalog_relation.auto_refresh) }}
     {{ optional('max_data_extension_time_in_days', catalog_relation.max_data_extension_time_in_days)}}
@@ -320,6 +322,7 @@ create iceberg table {{ relation }} (
 )
 {% if partition_by_string -%} partition by ({{ partition_by_string }}) {%- endif %}
 {{ optional('external_volume', catalog_relation.external_volume, "'") }}
+{{ optional('iceberg_version', catalog_relation.iceberg_version)}}
 {{ optional('target_file_size', catalog_relation.target_file_size, "'") }}
 {{ optional('auto_refresh', catalog_relation.auto_refresh) }}
 {{ optional('max_data_extension_time_in_days', catalog_relation.max_data_extension_time_in_days)}}

--- a/dbt-snowflake/tests/functional/iceberg/models.py
+++ b/dbt-snowflake/tests/functional/iceberg/models.py
@@ -190,3 +190,43 @@ _MODEL_TABLE_FOR_SWAP_ICEBERG = """
 }}
 select 1 as id
 """
+
+_MODEL_ICEBERG_V3_TABLE = """
+{{
+  config(
+    materialized = "table",
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+    iceberg_version=3,
+  )
+}}
+select 1 as id
+"""
+
+_MODEL_ICEBERG_V3_BUILTIN_TABLE = """
+{{
+  config(
+    materialized = "table",
+    catalog="snowflake",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+    iceberg_version=3,
+  )
+}}
+select 1 as id
+"""
+
+_MODEL_DYNAMIC_TABLE_ICEBERG_V3 = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='1 minute',
+    refresh_mode='INCREMENTAL',
+    table_format='iceberg',
+    external_volume='s3_iceberg_snow',
+    iceberg_version=3,
+) }}
+
+select * from {{ ref('first_table') }}
+"""

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
@@ -137,3 +137,18 @@ SIMPLE_MODEL = """
 ) }}
 SELECT 1 as id
 """
+
+
+DYNAMIC_ICEBERG_V3_TABLE = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+    iceberg_version=3,
+) }}
+select * from {{ ref('my_seed') }}
+"""

--- a/dbt-snowflake/tests/unit/test_catalog_relation_built_in.py
+++ b/dbt-snowflake/tests/unit/test_catalog_relation_built_in.py
@@ -87,3 +87,19 @@ def test_change_tracking_invalid_model_config(fake_integration, user_input):
     with pytest.raises(ValueError) as e:
         fake_integration.build_relation(model)
     assert "Invalid value for change_tracking" in str(e.value)
+
+
+@pytest.mark.parametrize(
+    "config,expected",
+    [
+        ({}, None),
+        ({"iceberg_version": None}, None),
+        ({"iceberg_version": 2}, 2),
+        ({"iceberg_version": 3}, 3),
+    ],
+)
+def test_iceberg_version_model_config(fake_integration, config, expected):
+    model = deepcopy(model_base)
+    model.config.update(config)
+    relation = fake_integration.build_relation(model)
+    assert relation.iceberg_version == expected

--- a/dbt-snowflake/tests/unit/test_parse_model.py
+++ b/dbt-snowflake/tests/unit/test_parse_model.py
@@ -10,6 +10,7 @@ from dbt.adapters.snowflake.parse_model import (
     cluster_by,
     partition_by,
     catalog_name,
+    iceberg_version,
 )
 
 
@@ -85,3 +86,17 @@ def test_catalog_name_with_non_model_config():
     exported_config = ExportConfig(export_as=ExportDestinationType.TABLE)
     model = make_model(exported_config)
     assert catalog_name(model) == None
+
+
+@pytest.mark.parametrize(
+    "config,expected",
+    [
+        ({"iceberg_version": 2}, 2),
+        ({"iceberg_version": 3}, 3),
+        ({"iceberg_version": None}, None),
+        ({}, None),
+    ],
+)
+def test_iceberg_version(config, expected):
+    model = make_model(config)
+    assert iceberg_version(model) == expected


### PR DESCRIPTION
This PR aims to add Iceberg V3 support for Snowflake Iceberg tables (Snowflake and externally managed) and Dynamic Iceberg tables.
This is a table-level parameter that should be set to 3 if needed and is applicable to all catalogs (built-in and REST).

This feature is currently in private preview and is planned to go public in the coming few months.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
