### PR TITLE
Add timeout buffer to BigQuery polling

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fix-ensure-query-result-timeout.md
+++ b/dbt-bigquery/.changes/unreleased/Fix-ensure-query-result-timeout.md
@@ -1,0 +1,3 @@
+## Fix
+
+- Ensure BigQuery query result polling enforces the configured job execution timeout plus a short buffer to avoid indefinite hangs when connections drop mid-query. ([#1500](https://github.com/dbt-labs/dbt-adapters/issues/1500))


### PR DESCRIPTION
resolves #1500 

CC @jeremyyeo 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

Handles stuck BigQuery client calls by adding a timeout to `.result()` invocations.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
