### PR TITLE
implement aws tags for schema

### DIFF
--- a/dbt-athena/README.md
+++ b/dbt-athena/README.md
@@ -161,6 +161,7 @@ A dbt profile can be configured to run against AWS Athena using the following co
 | spark_work_group      | Identifier of Athena Spark workgroup for running Python models                           | Optional  | `my-spark-workgroup`                       |
 | seed_s3_upload_args   | Dictionary containing boto3 ExtraArgs when uploading to S3                               | Optional  | `{"ACL": "bucket-owner-full-control"}`     |
 | lf_tags_database      | Default LF tags for new database if it's created by dbt                                  | Optional  | `tag_key: tag_value`                       |
+| aws_tags_database     | Default AWS resource tags for new database if it's created by dbt                        | Optional  | `tag_key: tag_value`                       |
 
 **Example profiles.yml entry:**
 

--- a/dbt-athena/src/dbt/adapters/athena/connections.py
+++ b/dbt-athena/src/dbt/adapters/athena/connections.py
@@ -75,6 +75,7 @@ class AthenaCredentials(Credentials):
     # Credentials in profile "athena", target "athena" invalid: Unable to create schema for 'dict'
     seed_s3_upload_args: Optional[Dict[str, Any]] = None
     lf_tags_database: Optional[Dict[str, str]] = None
+    aws_tags_database: Optional[Dict[str, str]] = None
 
     @property
     def type(self) -> str:
@@ -106,6 +107,7 @@ class AthenaCredentials(Credentials):
             "debug_query_state",
             "seed_s3_upload_args",
             "lf_tags_database",
+            "aws_tags_database",
             "spark_work_group",
         )
 

--- a/dbt-athena/src/dbt/include/athena/macros/adapters/schema.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/adapters/schema.sql
@@ -3,6 +3,7 @@
     create schema if not exists {{ relation.without_identifier().render_hive() }}
   {% endcall %}
 
+  {{ adapter.add_aws_tags_to_database(relation) }}
   {{ adapter.add_lf_tags_to_database(relation) }}
 
 {% endmacro %}


### PR DESCRIPTION
resolves #1544 
[docs](https://github.com/dbt-labs/dbt-adapters/issues/1544) dbt-labs/docs.getdbt.com/#

### Problem

dbt does not provide a way of tagging glue catalog resources that it creates which is a platform requirement at my organisation.

### Solution

mimicing the default `lf_tags_database` approach with a `aws_tags_database` config option.
and mimicing the application of tags to the relation schema upon schema creation.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
