### PR TITLE
feat(1552) Allow external_volume to be configurable at model level

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Features-20260115-191308.yaml
+++ b/dbt-bigquery/.changes/unreleased/Features-20260115-191308.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: allow external_volume at config level
+time: 2026-01-15T19:13:08.979211Z
+custom:
+    Author: borjavb
+    Issue: "1552"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/catalogs/_biglake_metastore.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/catalogs/_biglake_metastore.py
@@ -16,15 +16,19 @@ class BigLakeCatalogIntegration(CatalogIntegration):
         Args:
             model: `config.model` (not `model`) from the jinja context
         """
-
         return BigQueryCatalogRelation(
             catalog_type=self.catalog_type,
             catalog_name=self.catalog_name,
             table_format=self.table_format,
             file_format=self.file_format,
-            external_volume=self.external_volume,
+            external_volume=self._get_external_volume(model),
             storage_uri=self._calculate_storage_uri(model),
         )
+
+    def _get_external_volume(self, model: RelationConfig) -> Optional[str]:
+        """Model-level external_volume takes precedence over integration-level (default)."""
+        model_external_volume = model.config.get("external_volume") if model.config else None
+        return model_external_volume or self.external_volume
 
     def _calculate_storage_uri(self, model: RelationConfig) -> Optional[str]:
         if not model.config:
@@ -33,11 +37,12 @@ class BigLakeCatalogIntegration(CatalogIntegration):
         if model_storage_uri := model.config.get("storage_uri"):
             return model_storage_uri
 
-        if not self.external_volume:
+        external_volume = self._get_external_volume(model)
+        if not external_volume:
             return None
 
         prefix = model.config.get("base_location_root") or "_dbt"
-        storage_uri = f"{self.external_volume}/{prefix}/{model.schema}/{model.name}"
+        storage_uri = f"{external_volume}/{prefix}/{model.schema}/{model.name}"
         if suffix := model.config.get("base_location_subpath"):
             storage_uri = f"{storage_uri}/{suffix}"
         return storage_uri


### PR DESCRIPTION
resolves #1552 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

 
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
`external_volume` can only be set at catalog level.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
  - Add model-level `external_volume` config support for BigQuery Iceberg tables
  - Model-level config takes precedence, integration-level serves as default

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
