### PR TITLE
Fix timezone bug in TestAthenaSampleMode

### DIFF
--- a/dbt-athena/tests/functional/adapter/test_sample_mode.py
+++ b/dbt-athena/tests/functional/adapter/test_sample_mode.py
@@ -8,7 +8,7 @@ from dbt.tests.adapter.sample_mode.test_sample_mode import (
 )
 from dbt.tests.util import run_dbt
 
-now = datetime.datetime.now()
+now = datetime.datetime.now(datetime.timezone.utc)
 twelve_hours_ago = now - datetime.timedelta(hours=12)
 two_days_ago = now - datetime.timedelta(days=2)
 


### PR DESCRIPTION
resolves: N/A
docs: N/A

### Problem

When running `hatch run integration-tests` locally, there was one failure:

> FAILED tests/functional/adapter/test_sample_mode.py::TestAthenaSampleMode::test_sample_mode - AssertionError: model_that_samples_input_sql:[(2, datetime.datetime(2026, 1, 17, 8, 37, 53))]

```
========================================================================================================================================================= FAILURES =========================================================================================================================================================
__________________________________________________________________________________________________________________________________________ TestAthenaSampleMode.test_sample_mode ___________________________________________________________________________________________________________________________________________
[gw7] darwin -- Python 3.12.10 /Users/juhoautio/code/dbt-adapters/dbt-athena/.hatch/dbt-athena/bin/python

self = <test_sample_mode.TestAthenaSampleMode object at 0x134143d70>, project = <dbt.tests.fixtures.project.TestProjInfo object at 0x136cb0e90>

    @mock.patch.dict(os.environ, {"DBT_EXPERIMENTAL_SAMPLE_MODE": "True"})
    def test_sample_mode(self, project) -> None:
        _ = run_dbt(["run"])
        self.assert_row_count(
            project=project,
            relation_name="model_that_samples_input_sql",
            expected_row_count=3,
        )

        _ = run_dbt(["run", "--sample=1 day"])
>       self.assert_row_count(
            project=project,
            relation_name="model_that_samples_input_sql",
            expected_row_count=2,
        )

/Users/juhoautio/code/dbt-adapters/dbt-athena/tests/functional/adapter/test_sample_mode.py:40:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <test_sample_mode.TestAthenaSampleMode object at 0x134143d70>, project = <dbt.tests.fixtures.project.TestProjInfo object at 0x136cb0e90>, relation_name = 'model_that_samples_input_sql', expected_row_count = 2

    def assert_row_count(self, project, relation_name: str, expected_row_count: int):
        relation = relation_from_name(project.adapter, relation_name)
        result = project.run_sql(f"select * from {relation}", fetch="all")

>       assert len(result) == expected_row_count, f"{relation_name}:{pformat(result)}"
E       AssertionError: model_that_samples_input_sql:[(2, datetime.datetime(2026, 1, 17, 8, 37, 53))]
E       assert 1 == 2
E        +  where 1 = len([(2, datetime.datetime(2026, 1, 17, 8, 37, 53))])

/Users/juhoautio/code/dbt-adapters/dbt-tests-adapter/src/dbt/tests/adapter/sample_mode/test_sample_mode.py:39: AssertionError
```

### Solution

Convert the timestamp to UTC timezone before using it with `strftime` and hardcoded `-0` timezone suffix.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
