### PR TITLE
fix(redshift): remove unused alias from delete+insert incremental strategy

### DIFF
--- a/dbt-redshift/.changes/unreleased/20260120-fix-delete-insert-alias.yaml
+++ b/dbt-redshift/.changes/unreleased/20260120-fix-delete-insert-alias.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove unused table alias from delete+insert incremental strategy to fix Redshift syntax error
+time: 2026-01-20T12:00:00.000000000Z
+custom:
+  Author: hrm13
+  Issue: "958"

--- a/dbt-redshift/src/dbt/include/redshift/macros/materializations/incremental_delete_insert.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/materializations/incremental_delete_insert.sql
@@ -13,7 +13,7 @@
     delete from {{ target }}
     where ({{ unique_key_str }}) in (
         select distinct {{ unique_key_str }}
-        from {{ source }} as DBT_INTERNAL_SOURCE
+        from {{ source }}
     )
     {% for predicate in predicates %}
     and {{ predicate }}


### PR DESCRIPTION
resolves #958

## Problem

Since `dbt-adapters==1.14.4`, incremental models using the `delete+insert` strategy on Redshift fail with:

```
syntax error at or near "as" in context "from "analytics"."schema_name"."table_name" as"
```

The generated SQL looks like:

```sql
delete from "analytics"."schema"."table" 
where (composite_key) in (
    select distinct composite_key
    from "table__dbt_tmp" as DBT_INTERNAL_SOURCE
);
```

Redshift does not support table aliases in DELETE statements. The `as DBT_INTERNAL_SOURCE` alias was added in PR #910 but is not actually used in this macro (unlike in the merge macro where it's used to prefix column names).

## Solution

Remove the unused `as DBT_INTERNAL_SOURCE` alias from the subquery in `redshift__get_delete_insert_merge_sql`. The alias serves no purpose here since:

1. The subquery only selects `unique_key_str` columns without any table prefix
2. Unlike `get_merge_sql`, there's no column disambiguation needed between source and destination

This is a minimal, surgical fix that restores compatibility with Redshift while maintaining the same query semantics.

## Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX