### PR TITLE
Fix record/replay support for handle.session_id in Snowflake adapter

### DIFF
--- a/dbt-snowflake/src/dbt/adapters/snowflake/record/handle.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/record/handle.py
@@ -1,12 +1,43 @@
-from dbt.adapters.record import RecordReplayHandle
+import dataclasses
+from typing import Optional
 
+from dbt_common.record import Record, Recorder, record_function
+
+from dbt.adapters.record import RecordReplayHandle
 from dbt.adapters.snowflake.record.cursor.cursor import SnowflakeRecordReplayCursor
+
+
+@dataclasses.dataclass
+class HandleGetSessionIdParams:
+    connection_name: str
+
+
+@dataclasses.dataclass
+class HandleGetSessionIdResult:
+    session_id: Optional[int]
+
+
+@Recorder.register_record_type
+class HandleGetSessionIdRecord(Record):
+    params_cls = HandleGetSessionIdParams
+    result_cls = HandleGetSessionIdResult
+    group = "Database"
 
 
 class SnowflakeRecordReplayHandle(RecordReplayHandle):
     """A custom extension of RecordReplayHandle that returns a
-    snowflake-connector-specific SnowflakeRecordReplayCursor object."""
+    snowflake-connector-specific SnowflakeRecordReplayCursor object and adds
+    the session_id property which is specific to snowflake-connector."""
 
     def cursor(self):
         cursor = None if self.native_handle is None else self.native_handle.cursor()
         return SnowflakeRecordReplayCursor(cursor, self.connection)
+
+    @property
+    def connection_name(self) -> Optional[str]:
+        return self.connection.name
+
+    @property
+    @record_function(HandleGetSessionIdRecord, method=True, id_field_name="connection_name")
+    def session_id(self):
+        return self.native_handle.session_id


### PR DESCRIPTION
### Problem

When running dbt-snowflake in record/replay mode, the following warning is logged whenever cancel() is invoked:

> "Unexpected attribute 'session_id' accessed on SnowflakeRecordReplayHandle"

The `cancel()` method in `SnowflakeConnectionManager` accesses `handle.session_id` to cancel running queries. When we wrap the native handle with `SnowflakeRecordReplayHandle`, this attribute access falls through to the base class `__getattr__`, which logs a warning before forwarding to the native handle.

This does not cause errors, just triggers a warning.

### Solution

- Add `session_id` property to `SnowflakeRecordReplayHandle` with @record_function decorator for proper record/replay support
- Add `HandleGetSessionIdRecord` class to handle recording/replaying of the session ID value
- Add unit tests for `SnowflakeRecordReplayHandle` including a regression test that will fail if new handle attributes are accessed without being added to the class

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
