### PR TITLE
[backport] Fix record/replay support for handle.session_id in Snowflake adapter (#1581)

### DIFF
--- a/dbt-snowflake/src/dbt/adapters/snowflake/record/handle.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/record/handle.py
@@ -1,12 +1,43 @@
-from dbt.adapters.record import RecordReplayHandle
+import dataclasses
+from typing import Optional
 
+from dbt_common.record import Record, Recorder, record_function
+
+from dbt.adapters.record import RecordReplayHandle
 from dbt.adapters.snowflake.record.cursor.cursor import SnowflakeRecordReplayCursor
+
+
+@dataclasses.dataclass
+class HandleGetSessionIdParams:
+    connection_name: str
+
+
+@dataclasses.dataclass
+class HandleGetSessionIdResult:
+    session_id: Optional[int]
+
+
+@Recorder.register_record_type
+class HandleGetSessionIdRecord(Record):
+    params_cls = HandleGetSessionIdParams
+    result_cls = HandleGetSessionIdResult
+    group = "Database"
 
 
 class SnowflakeRecordReplayHandle(RecordReplayHandle):
     """A custom extension of RecordReplayHandle that returns a
-    snowflake-connector-specific SnowflakeRecordReplayCursor object."""
+    snowflake-connector-specific SnowflakeRecordReplayCursor object and adds
+    the session_id property which is specific to snowflake-connector."""
 
     def cursor(self):
         cursor = None if self.native_handle is None else self.native_handle.cursor()
         return SnowflakeRecordReplayCursor(cursor, self.connection)
+
+    @property
+    def connection_name(self) -> Optional[str]:
+        return self.connection.name
+
+    @property
+    @record_function(HandleGetSessionIdRecord, method=True, id_field_name="connection_name")
+    def session_id(self):
+        return self.native_handle.session_id

--- a/dbt-snowflake/tests/unit/test_record_cursor.py
+++ b/dbt-snowflake/tests/unit/test_record_cursor.py
@@ -1,0 +1,186 @@
+from dbt.adapters.snowflake.connections import SnowflakeConnectionManager
+from dbt.adapters.snowflake.record.cursor.cursor import SnowflakeRecordReplayCursor
+from dbt.adapters.snowflake.record.handle import SnowflakeRecordReplayHandle
+
+
+class MockCursor:
+    """Mock cursor that mimics snowflake-connector-python's SnowflakeCursor."""
+
+    @property
+    def rowcount(self) -> int:
+        return 42
+
+    @property
+    def sqlstate(self) -> str:
+        return "00000"
+
+    @property
+    def sfqid(self) -> str:
+        return "01abc123-0001-abcd-0000-00012345abcd"
+
+    def execute(self, operation, parameters=None) -> None:
+        pass
+
+    @property
+    def unexpected_prop(self) -> bool:
+        return True
+
+    def unexpected_func(self) -> int:
+        return 1
+
+
+class MockHandle:
+    """Mock handle that mimics snowflake-connector-python's SnowflakeConnection."""
+
+    def __init__(self, session_id=123456789):
+        self._session_id = session_id
+
+    @property
+    def session_id(self) -> int:
+        return self._session_id
+
+    def cursor(self):
+        return MockCursor()
+
+    @property
+    def unexpected_prop(self) -> bool:
+        return True
+
+    def unexpected_func(self) -> int:
+        return 1
+
+
+class MockConnection:
+    name = "test_connection"
+
+
+def test_snowflake_record_cursor_sqlstate():
+    """Test that the sqlstate property works correctly."""
+    recorded_cursor = SnowflakeRecordReplayCursor(MockCursor(), MockConnection())  # type: ignore
+    assert recorded_cursor.sqlstate == "00000"
+
+
+def test_snowflake_record_cursor_sfqid():
+    """Test that the sfqid property works correctly."""
+    recorded_cursor = SnowflakeRecordReplayCursor(MockCursor(), MockConnection())  # type: ignore
+    assert recorded_cursor.sfqid == "01abc123-0001-abcd-0000-00012345abcd"
+
+
+def test_snowflake_record_cursor_inherited_properties():
+    """Test that inherited properties from RecordReplayCursor work correctly."""
+    recorded_cursor = SnowflakeRecordReplayCursor(MockCursor(), MockConnection())  # type: ignore
+
+    # Test inherited rowcount property
+    assert recorded_cursor.rowcount == 42
+
+    # Test inherited execute method
+    recorded_cursor.execute("SELECT 1")
+
+
+def test_snowflake_record_cursor_unexpected_access():
+    """Test that unexpected property/method access fires a warning but still works."""
+    recorded_cursor = SnowflakeRecordReplayCursor(MockCursor(), MockConnection())  # type: ignore
+
+    events = []
+    # Mock event firing
+    recorded_cursor._fire_event = events.append
+
+    # Test that an unexpected property works, but fires a warning
+    assert recorded_cursor.unexpected_prop is True
+    assert len(events) == 1
+    assert events[0].__class__.__name__ == "RecordReplayIssue"
+    assert "unexpected_prop" in events[0].msg
+    events.clear()
+
+    # Test that an unexpected function works, but fires a warning
+    assert recorded_cursor.unexpected_func() == 1
+    assert len(events) == 1
+    assert events[0].__class__.__name__ == "RecordReplayIssue"
+    assert "unexpected_func" in events[0].msg
+
+
+def test_get_response_no_unexpected_access_warnings():
+    """Ensure get_response() doesn't trigger any unexpected attribute access warnings.
+
+    This is a regression test. If new cursor attributes are accessed in get_response()
+    without being added to SnowflakeRecordReplayCursor, this test will fail.
+    """
+    events = []
+
+    mock_cursor = MockCursor()
+    recorded_cursor = SnowflakeRecordReplayCursor(mock_cursor, MockConnection())  # type: ignore
+    recorded_cursor._fire_event = events.append
+
+    # Call get_response - this is the actual code path
+    response = SnowflakeConnectionManager.get_response(recorded_cursor)
+
+    # Verify no unexpected access warnings were fired
+    assert len(events) == 0, (
+        f"Unexpected attribute access in get_response(): {[e.msg for e in events]}. "
+        "Add the missing attribute(s) to SnowflakeRecordReplayCursor."
+    )
+
+    # Verify the response was created successfully
+    assert response is not None
+    assert response.code == "00000"  # SQL success state from mock cursor
+
+
+# =============================================================================
+# SnowflakeRecordReplayHandle Tests
+# =============================================================================
+
+
+def test_snowflake_record_handle_session_id():
+    """Test that the session_id property works correctly."""
+    recorded_handle = SnowflakeRecordReplayHandle(MockHandle(), MockConnection())  # type: ignore
+    assert recorded_handle.session_id == 123456789
+
+
+def test_snowflake_record_handle_cursor():
+    """Test that cursor() returns a SnowflakeRecordReplayCursor."""
+    recorded_handle = SnowflakeRecordReplayHandle(MockHandle(), MockConnection())  # type: ignore
+    cursor = recorded_handle.cursor()
+    assert isinstance(cursor, SnowflakeRecordReplayCursor)
+
+
+def test_snowflake_record_handle_unexpected_access():
+    """Test that unexpected property/method access fires a warning but still works."""
+    recorded_handle = SnowflakeRecordReplayHandle(MockHandle(), MockConnection())  # type: ignore
+
+    events = []
+    # Mock event firing
+    recorded_handle._fire_event = events.append
+
+    # Test that an unexpected property works, but fires a warning
+    assert recorded_handle.unexpected_prop is True
+    assert len(events) == 1
+    assert events[0].__class__.__name__ == "RecordReplayIssue"
+    assert "unexpected_prop" in events[0].msg
+    events.clear()
+
+    # Test that an unexpected function works, but fires a warning
+    assert recorded_handle.unexpected_func() == 1
+    assert len(events) == 1
+    assert events[0].__class__.__name__ == "RecordReplayIssue"
+    assert "unexpected_func" in events[0].msg
+
+
+def test_handle_session_id_no_unexpected_access_warnings():
+    """Ensure accessing session_id doesn't trigger unexpected attribute access warnings.
+
+    This is a regression test. If new handle attributes are accessed in cancel()
+    or elsewhere without being added to SnowflakeRecordReplayHandle, this test will fail.
+    """
+    events = []
+
+    recorded_handle = SnowflakeRecordReplayHandle(MockHandle(), MockConnection())  # type: ignore
+    recorded_handle._fire_event = events.append
+
+    # Access session_id - this is used in SnowflakeConnectionManager.cancel()
+    _ = recorded_handle.session_id
+
+    # Verify no unexpected access warnings were fired
+    assert len(events) == 0, (
+        f"Unexpected attribute access on handle: {[e.msg for e in events]}. "
+        "Add the missing attribute(s) to SnowflakeRecordReplayHandle."
+    )


### PR DESCRIPTION
Backports #1581

# Conflicts:
#	dbt-snowflake/tests/unit/test_record_cursor.py

Since #1535 isn't backported, we're not backporting #1572 so i had to manually resolve the conflicts in the test file.

