### PR TITLE
Feat/parallel partition copy in bigquery

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Features-20260205-080204.yaml
+++ b/dbt-bigquery/.changes/unreleased/Features-20260205-080204.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: 'Add parallel partition copying for insert_overwrite incremental strategy, significantly improving performance for tables with many partitions.'
+time: 2026-02-05T08:02:04.000000+00:00
+custom:
+    Author: AxelThevenot leohoare
+    Issue: "559"

--- a/dbt-bigquery/.changes/unreleased/Features-20260205-080204.yaml
+++ b/dbt-bigquery/.changes/unreleased/Features-20260205-080204.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: 'Add parallel partition copying for insert_overwrite incremental strategy, significantly improving performance for tables with many partitions.'
+body: Add parallel partition copying for insert_overwrite incremental strategy for BigQuery.
 time: 2026-02-05T08:02:04.000000+00:00
 custom:
     Author: AxelThevenot leohoare

--- a/dbt-bigquery/src/dbt/adapters/bigquery/connections.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/connections.py
@@ -428,48 +428,54 @@ class BigQueryConnectionManager(BaseConnectionManager):
         _, iterator = self.raw_execute(sql, use_legacy_sql=True)
         return self.get_table_from_response(iterator)
 
-    def copy_bq_table(self, source, destination, write_disposition) -> None:
+    def copy_bq_table(self, source, destination, write_disposition, partition_ids=None) -> None:
         conn = self.get_thread_connection()
         client: Client = conn.handle
 
         # -------------------------------------------------------------------------------
-        #  BigQuery allows to use copy API using two different formats:
-        #  1. client.copy_table(source_table_id, destination_table_id)
-        #     where source_table_id = "your-project.source_dataset.source_table"
-        #  2. client.copy_table(source_table_ids, destination_table_id)
-        #     where source_table_ids = ["your-project.your_dataset.your_table_name", ...]
-        #  Let's use uniform function call and always pass list there
+        #  BigQuery allows to use copy API on the same table in parallel
+        #  so each source (and if partition of each source if given) is copied
+        #  into the destination table in parallel.
         # -------------------------------------------------------------------------------
-        if type(source) is not list:
-            source = [source]
-
-        source_ref_array = [
-            self.table_ref(src_table.database, src_table.schema, src_table.table)
-            for src_table in source
-        ]
+        source_ref = self.table_ref(source.database, source.schema, source.table)
         destination_ref = self.table_ref(
             destination.database, destination.schema, destination.table
         )
 
         logger.debug(
-            'Copying table(s) "{}" to "{}" with disposition: "{}"',
-            ", ".join(source_ref.path for source_ref in source_ref_array),
+            'Copying table "{}" to "{}" with disposition: "{}"',
+            source_ref.path,
             destination_ref.path,
             write_disposition,
         )
 
         msg = 'copy table "{}" to "{}"'.format(
-            ", ".join(source_ref.path for source_ref in source_ref_array),
+            source_ref.path,
             destination_ref.path,
         )
+
+        copy_jobs = []
+
         with self.exception_handler(msg):
-            copy_job = client.copy_table(
-                source_ref_array,
-                destination_ref,
-                job_config=CopyJobConfig(write_disposition=write_disposition),
-                retry=self._retry.create_reopen_with_deadline(conn),
-            )
-            copy_job.result(timeout=self._retry.create_job_execution_timeout(fallback=300))
+            # Runs all the copy jobs in parallel
+            for partition_id in partition_ids or [None]:
+                source_ref_partition = (
+                    f"{source_ref}${partition_id}" if partition_id else source_ref
+                )
+                destination_ref_partition = (
+                    f"{destination_ref}${partition_id}" if partition_id else destination_ref
+                )
+                copy_job = client.copy_table(
+                    source_ref_partition,
+                    destination_ref_partition,
+                    job_config=CopyJobConfig(write_disposition=write_disposition),
+                    retry=self._retry.create_reopen_with_deadline(conn),
+                )
+                copy_jobs.append(copy_job)
+
+            # Waits for the jobs to finish
+            for copy_job in copy_jobs:
+                copy_job.result(timeout=self._retry.create_job_execution_timeout(fallback=300))
 
     def write_dataframe_to_table(
         self,

--- a/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
@@ -464,7 +464,7 @@ class BigQueryAdapter(BaseAdapter):
         return bq_schema
 
     @available.parse(lambda *a, **k: "")
-    def copy_table(self, source, destination, materialization):
+    def copy_table(self, source, destination, materialization, partition_ids=None):
         if materialization == "incremental":
             write_disposition = WRITE_APPEND
         elif materialization == "table":
@@ -476,7 +476,7 @@ class BigQueryAdapter(BaseAdapter):
                 f"{materialization}"
             )
 
-        self.connections.copy_bq_table(source, destination, write_disposition)
+        self.connections.copy_bq_table(source, destination, write_disposition, partition_ids)
 
         return "COPY TABLE with materialization: {}".format(materialization)
 

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/incremental_strategy/insert_overwrite.sql
@@ -17,6 +17,7 @@
 {% endmacro %}
 
 {% macro bq_copy_partitions(tmp_relation, target_relation, partitions, partition_by) %}
+  {% set partition_ids = [] %}
 
   {% for partition in partitions %}
     {% if partition_by.data_type == 'int64' %}
@@ -30,10 +31,10 @@
     {% elif partition_by.granularity == 'year' %}
       {% set partition = partition.strftime("%Y") %}
     {% endif %}
-    {% set tmp_relation_partitioned = api.Relation.create(database=tmp_relation.database, schema=tmp_relation.schema, identifier=tmp_relation.table ~ '$' ~ partition, type=tmp_relation.type) %}
-    {% set target_relation_partitioned = api.Relation.create(database=target_relation.database, schema=target_relation.schema, identifier=target_relation.table ~ '$' ~ partition, type=target_relation.type) %}
-    {% do adapter.copy_table(tmp_relation_partitioned, target_relation_partitioned, "table") %}
+    {% do partition_ids.append(partition) %}
   {% endfor %}
+
+  {% do adapter.copy_table(tmp_relation, target_relation, 'table', partition_ids) %}
 
 {% endmacro %}
 

--- a/dbt-bigquery/tests/unit/test_bigquery_adapter.py
+++ b/dbt-bigquery/tests/unit/test_bigquery_adapter.py
@@ -632,7 +632,7 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
         adapter.connections = MagicMock()
         adapter.copy_table("source", "destination", "table")
         adapter.connections.copy_bq_table.assert_called_once_with(
-            "source", "destination", dbt.adapters.bigquery.impl.WRITE_TRUNCATE
+            "source", "destination", dbt.adapters.bigquery.impl.WRITE_TRUNCATE, None
         )
 
     def test_copy_table_materialization_incremental(self):
@@ -640,7 +640,16 @@ class TestBigQueryAdapter(BaseTestBigQueryAdapter):
         adapter.connections = MagicMock()
         adapter.copy_table("source", "destination", "incremental")
         adapter.connections.copy_bq_table.assert_called_once_with(
-            "source", "destination", dbt.adapters.bigquery.impl.WRITE_APPEND
+            "source", "destination", dbt.adapters.bigquery.impl.WRITE_APPEND, None
+        )
+
+    def test_copy_table_with_partition_ids(self):
+        adapter = self.get_adapter("oauth")
+        adapter.connections = MagicMock()
+        partition_ids = ["20200101", "20200102", "20200103"]
+        adapter.copy_table("source", "destination", "table", partition_ids)
+        adapter.connections.copy_bq_table.assert_called_once_with(
+            "source", "destination", dbt.adapters.bigquery.impl.WRITE_TRUNCATE, partition_ids
         )
 
     def test_parse_partition_by(self):


### PR DESCRIPTION
resolves #559

### Problem

When using the `insert_overwrite` incremental strategy with many partitions, the partition copy operation is slow because partitions are copied sequentially. For tables with 100+ partitions, this can take several minutes as each partition must wait for the previous one to complete.

This was originally implemented in dbt-bigquery (dbt-labs/dbt-bigquery#1237 by @AxelThevenot) but needs to be ported to the dbt-adapters monorepo.

### Solution

Modified the `copy_bq_table` function in `connections.py` to accept an optional `partition_ids` parameter. When provided, it creates separate copy jobs for each partition and submits them all at once, then waits for all jobs to complete in parallel.

Changes:
- `connections.py`: Updated `copy_bq_table` to handle a list of `partition_ids`, creating parallel copy jobs with partition-suffixed table references (`table$partition_id`)
- `impl.py`: Updated `copy_table` to pass through the `partition_ids` parameter
- `insert_overwrite.sql`: Modified `bq_copy_partitions` macro to collect all partition IDs and make a single call to `adapter.copy_table` with the full list

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
