### PR TITLE
spike: port dbt-snowflake from snowflake-connector-python to ADBC

### DIFF
--- a/dbt-snowflake/pyproject.toml
+++ b/dbt-snowflake/pyproject.toml
@@ -25,9 +25,8 @@ classifiers = [
 dependencies = [
     "dbt-common>=1.10,<2.0",
     "dbt-adapters>=1.22.4,<2.0",
-    # lower bound pin due to CVE-2025-24794
-    "snowflake-connector-python[secure-local-storage]>=4.0.0,<5.0.0",
-    "certifi<2025.4.26",
+    "adbc-driver-snowflake>=1.4.0",
+    "pyarrow>=14.0",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
     "dbt-core>=1.10.0rc0",
     # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core

--- a/dbt-snowflake/src/dbt/adapters/snowflake/auth.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/auth.py
@@ -12,6 +12,7 @@ else:
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
 
 
 @cache
@@ -55,3 +56,19 @@ def private_key_from_file(
         password=encoded_passphrase,
         backend=default_backend(),
     )
+
+
+def private_key_to_pem_string(
+    key_string: str, passphrase: Optional[str] = None
+) -> str:
+    """Convert a private key (inline base64 DER or PEM) to an unencrypted PEM string.
+
+    ADBC's Snowflake driver expects a PEM-encoded PKCS8 string, not DER bytes.
+    """
+    private_key: PrivateKeyTypes = private_key_from_string(key_string, passphrase)
+    pem_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem_bytes.decode("utf-8")

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/seed.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/seed.sql
@@ -1,31 +1,31 @@
 {% macro snowflake__load_csv_rows(model, agate_table) %}
     {% set batch_size = get_batch_size() %}
     {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}
-    {% set bindings = [] %}
 
     {% set statements = [] %}
 
     {% for chunk in agate_table.rows | batch(batch_size) %}
-        {% set bindings = [] %}
-
-        {% for row in chunk %}
-            {% do bindings.extend(row) %}
-        {% endfor %}
-
         {% set sql %}
             insert into {{ this.render() }} ({{ cols_sql }}) values
             {% for row in chunk -%}
                 ({%- for column in agate_table.column_names -%}
-                    %s
+                    {%- set value = row[column] -%}
+                    {%- if value is none -%}
+                        null
+                    {%- elif value is boolean -%}
+                        {%- if value -%}TRUE{%- else -%}FALSE{%- endif -%}
+                    {%- elif value is number -%}
+                        {{ value }}
+                    {%- else -%}
+                        '{{ value | string | replace("'", "''") }}'
+                    {%- endif -%}
                     {%- if not loop.last%},{%- endif %}
                 {%- endfor -%})
                 {%- if not loop.last%},{%- endif %}
             {%- endfor %}
         {% endset %}
 
-        {% do adapter.add_query('BEGIN', auto_begin=False) %}
-        {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}
-        {% do adapter.add_query('COMMIT', auto_begin=False) %}
+        {% do adapter.add_query(sql, abridge_sql_log=True) %}
 
         {% if loop.index0 == 0 %}
             {% do statements.append(sql) %}


### PR DESCRIPTION
## Summary

- Replaces `snowflake-connector-python` (~100MB with native deps) with `adbc-driver-snowflake` — a lighter Go-based ADBC driver with DB-API 2.0 wrapper
- Mirrors the completed [dbt-sqlserver ADBC spike](https://github.com/dbt-labs/dbt-sqlserver/pull/633)
- Verified `dbt debug`, `dbt seed`, `dbt run`, and `dbt test` all work against a real Snowflake account (`ska67070`) using `externalbrowser` auth

### Changes
| File | Change |
|---|---|
| `pyproject.toml` | `snowflake-connector-python` + `certifi` → `adbc-driver-snowflake` + `pyarrow` |
| `connections.py` | Rewrite connection layer for ADBC (imports, `adbc_auth_args()`, `open()`, exceptions, response, SQL splitter, type codes, cancel no-op, bindings guard) |
| `auth.py` | Add `private_key_to_pem_string()` for ADBC PEM key format |
| `seed.sql` | Inline literal values instead of `%s` parameterized bindings |
| `test_connections.py` | Remove `setup_snowflake_logging` tests, add `adbc_auth_args` tests |
| `test_snowflake_adapter.py` | Replace `snowflake.connector` mocks with `snowflake_dbapi` mocks |

### Known limitations (spike scope)
| Limitation | Detail |
|---|---|
| No query cancel | `cancel()` is a no-op |
| No query ID | `AdapterResponse.query_id` always None |
| No sqlstate | Response code is always "OK" |
| Record/replay disabled | Bypassed entirely |
| No parameterized queries | Seeds inline values; other bindings usage errors |
| Simple SQL splitter | Doesn't handle `/* ; */` in block comments |

## Test plan
- [x] Unit tests pass (116/116)
- [x] `dbt debug` — externalbrowser auth connects successfully
- [x] `dbt seed` — 3/3 seeds loaded (inline values)
- [x] `dbt run` — 5/6 models pass (1 failure is missing schema, not ADBC-related)
- [x] `dbt test` — 20/20 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)