### PR TITLE
Fix crash in materialized_view_config_changeset when MV has no rows

### DIFF
--- a/dbt-redshift/.changes/unreleased/Fixes-20260225-000000.yaml
+++ b/dbt-redshift/.changes/unreleased/Fixes-20260225-000000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix crash in materialized_view_config_changeset when materialized view has no rows
+time: 2026-02-25T00:00:00.000000+00:00
+custom:
+    Author: dydyxylish
+    Issue: "1256"

--- a/dbt-redshift/src/dbt/adapters/redshift/relation.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/relation.py
@@ -80,6 +80,13 @@ class RedshiftRelation(BaseRelation):
     ) -> Optional[RedshiftMaterializedViewConfigChangeset]:
         config_change_collection = RedshiftMaterializedViewConfigChangeset()
 
+        # svv_table_info returns no rows for materialized views with no data.
+        # In this case we cannot compare configurations, so return None to trigger
+        # a simple refresh instead of crashing.
+        mv_table = relation_results.get("materialized_view")
+        if not mv_table or len(mv_table.rows) == 0:
+            return None
+
         existing_materialized_view = RedshiftMaterializedViewConfig.from_relation_results(
             relation_results
         )


### PR DESCRIPTION
resolves #1256
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

### Problem

When a Redshift materialized view exists but contains **no rows**, `svv_table_info` returns zero rows for it. The existing code assumed at least one row is always returned, causing a crash:

```
RedshiftMaterializedViewConfig.__init__() missing 3 required positional arguments:
  'mv_name', 'schema_name', and 'database_name'
```

Root cause cascade:
1. `svv_table_info` returns 0 rows → `_get_first_row()` returns an empty `agate.Row`
2. All field lookups return `None` → `filter_null_values()` strips every key
3. `RedshiftMaterializedViewConfig(**{})` is called without required args → `TypeError`

### Solution

Add an early-return guard in `RedshiftRelation.materialized_view_config_changeset` that checks whether `svv_table_info` returned any rows. When the result set is empty, the method returns `None`, which causes the global materialization macro to call `refresh_materialized_view(target_relation)` — the correct behavior when an MV has no data to compare configurations against.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX