### PR TITLE
Fix flaky Spark integration tests caused by session fixture mutation

### DIFF
--- a/dbt-spark/tests/functional/adapter/test_query_timeout.py
+++ b/dbt-spark/tests/functional/adapter/test_query_timeout.py
@@ -57,10 +57,12 @@ class TestQueryTimeout:
     @pytest.fixture(scope="class")
     def dbt_profile_target(self, dbt_profile_target):
         """Override profile to add timeout configuration."""
-        dbt_profile_target["query_timeout"] = 1  # 1 second timeout
-        dbt_profile_target["poll_interval"] = 1  # Poll every second for faster test
-        dbt_profile_target["query_retries"] = 0  # Disable retries for clearer errors
-        return dbt_profile_target
+        return {
+            **dbt_profile_target,
+            "query_timeout": 1,
+            "poll_interval": 1,
+            "query_retries": 0,
+        }
 
     def test_query_timeout_exceeded(self, project):
         """Test that queries exceeding timeout raise appropriate error."""


### PR DESCRIPTION
## Summary

- Fixes intermittent `databricks_http_cluster` integration test failures where unrelated tests fail with `Query exceeded timeout of 1 seconds`

## Problem

The `TestQueryTimeout` class in `test_query_timeout.py` overrides the session-scoped `dbt_profile_target` fixture at class scope to set `query_timeout=1`. However, it **mutates the session-scoped dictionary in-place**:

```python
dbt_profile_target["query_timeout"] = 1   # mutates the shared dict
dbt_profile_target["poll_interval"] = 1
dbt_profile_target["query_retries"] = 0
return dbt_profile_target
```

`TestQueryTimeout` is correctly skipped for `databricks_http_cluster` via `@pytest.mark.skip_profile`. But when pytest-xdist resolves the class-scoped fixture *before* the skip fires (which depends on test distribution order across workers), the in-place mutation poisons the session-scoped dictionary. Every subsequent test on that worker then inherits `query_timeout=1`, causing any query that takes more than 1 second to fail — even though those tests never intended to set a timeout.

This explains the intermittent nature: whether the bug triggers depends entirely on which pytest-xdist worker picks up `TestQueryTimeout` and in what order relative to other tests.

## Fix

Return a shallow copy instead of mutating the input dictionary:

```python
return {
    **dbt_profile_target,
    "query_timeout": 1,
    "poll_interval": 1,
    "query_retries": 0,
}
```

The `{**dbt_profile_target, ...}` spread creates a new dict with the overrides applied, leaving the original session-scoped dict untouched. All other tests continue to see `query_timeout=None` (no timeout) as intended.

## Test plan

- [ ] `databricks_http_cluster` integration tests pass without spurious timeout failures
- [ ] `TestQueryTimeout` continues to pass on `apache_spark` profile (the only profile it runs on)

Made with [Cursor](https://cursor.com)