### PR TITLE
Migrate get_show_grant_sql to use SHOW GRANTS ON TABLE

### DIFF
--- a/dbt-redshift/.changes/unreleased/Features-20260226-172322.yaml
+++ b/dbt-redshift/.changes/unreleased/Features-20260226-172322.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Migrate get_show_grant_sql to use SHOW GRANTS ON TABLE
+time: 2026-02-26T17:23:22.316316+05:30
+custom:
+    Author: tauhid621
+    Issue: "1677"

--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
@@ -108,7 +108,10 @@
 
 
 {% macro redshift__get_columns_in_relation(relation) -%}
-  {% if redshift__use_show_apis() %}
+  {# relation from temp tables does not have a database or schema. #}
+  {# use legacy pattern until SHOW COLUMNS supports temp tables #}
+
+  {% if redshift__use_show_apis() and relation.database and relation.schema %}
     {{ return(redshift__get_columns_in_relation_show(relation)) }}
   {% else %}
     {{ return(redshift__get_columns_in_relation_legacy(relation)) }}

--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters/apply_grants.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters/apply_grants.sql
@@ -1,27 +1,31 @@
 {% macro redshift__get_show_grant_sql(relation) %}
+  {% if redshift__use_show_apis() %}
+    SHOW GRANTS ON TABLE {{ relation.database }}.{{ relation.schema }}.{{ relation.identifier }}
+  {% else %}
 
-with privileges as (
+    with privileges as (
 
-    -- valid options per https://docs.aws.amazon.com/redshift/latest/dg/r_HAS_TABLE_PRIVILEGE.html
-    select 'select' as privilege_type
-    union all
-    select 'insert' as privilege_type
-    union all
-    select 'update' as privilege_type
-    union all
-    select 'delete' as privilege_type
-    union all
-    select 'references' as privilege_type
+        -- valid options per https://docs.aws.amazon.com/redshift/latest/dg/r_HAS_TABLE_PRIVILEGE.html
+        select 'select' as privilege_type
+        union all
+        select 'insert' as privilege_type
+        union all
+        select 'update' as privilege_type
+        union all
+        select 'delete' as privilege_type
+        union all
+        select 'references' as privilege_type
 
-)
+    )
 
-select
-    u.usename as grantee,
-    p.privilege_type
-from pg_user u
-cross join privileges p
-where has_table_privilege(u.usename, '{{ relation }}', privilege_type)
-    and u.usename != current_user
-    and not u.usesuper
+    select
+        u.usename as grantee,
+        p.privilege_type
+    from pg_user u
+    cross join privileges p
+    where has_table_privilege(u.usename, '{{ relation }}', privilege_type)
+        and u.usename != current_user
+        and not u.usesuper
 
+  {% endif %}
 {% endmacro %}

--- a/dbt-redshift/tests/functional/adapter/test_grants.py
+++ b/dbt-redshift/tests/functional/adapter/test_grants.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dbt.tests.adapter.grants.test_model_grants import BaseModelGrants
 from dbt.tests.adapter.grants.test_incremental_grants import BaseIncrementalGrants
 from dbt.tests.adapter.grants.test_seed_grants import BaseSeedGrants
@@ -22,3 +24,27 @@ class TestSnapshotGrantsRedshift(BaseSnapshotGrants):
 
 class TestInvalidGrantsRedshift(BaseModelGrants):
     pass
+
+
+class TestModelGrantsRedshiftWithShowApis(BaseModelGrants):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"redshift_use_show_apis": True}}
+
+
+class TestIncrementalGrantsRedshiftWithShowApis(BaseIncrementalGrants):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"redshift_use_show_apis": True}}
+
+
+class TestSeedGrantsRedshiftWithShowApis(BaseSeedGrants):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"redshift_use_show_apis": True}}
+
+
+class TestSnapshotGrantsRedshiftWithShowApis(BaseSnapshotGrants):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"redshift_use_show_apis": True}}

--- a/dbt-redshift/tests/unit/test_standardize_grants_dict.py
+++ b/dbt-redshift/tests/unit/test_standardize_grants_dict.py
@@ -1,0 +1,146 @@
+import agate
+import pytest
+
+from dbt.adapters.redshift.impl import RedshiftAdapter
+
+
+SHOW_GRANTS_COLUMNS = [
+    "schema_name",
+    "object_name",
+    "object_type",
+    "privilege_type",
+    "identity_id",
+    "identity_name",
+    "identity_type",
+    "admin_option",
+    "privilege_scope",
+    "database_name",
+    "grantor_name",
+]
+
+SHOW_GRANTS_TYPES = [agate.Text()] * len(SHOW_GRANTS_COLUMNS)
+
+LEGACY_COLUMNS = ["grantee", "privilege_type"]
+LEGACY_TYPES = [agate.Text()] * len(LEGACY_COLUMNS)
+
+
+def _make_show_grants_table(rows):
+    return agate.Table(rows, column_names=SHOW_GRANTS_COLUMNS, column_types=SHOW_GRANTS_TYPES)
+
+
+def _make_legacy_table(rows):
+    return agate.Table(rows, column_names=LEGACY_COLUMNS, column_types=LEGACY_TYPES)
+
+
+@pytest.fixture
+def adapter(mocker):
+    mock_config = mocker.MagicMock()
+    mock_mp_context = mocker.MagicMock()
+    return RedshiftAdapter(mock_config, mock_mp_context)
+
+
+def _set_use_show_apis(adapter, mocker, enabled):
+    mock_behavior = mocker.MagicMock()
+    mock_behavior.redshift_use_show_apis.no_warn = enabled
+    adapter._behavior = mock_behavior
+
+
+class TestStandardizeGrantsDictShowApi:
+    """Tests for standardize_grants_dict when redshift_use_show_apis is enabled."""
+
+    def test_includes_all_privileges(self, adapter, mocker):
+        _set_use_show_apis(adapter, mocker, enabled=True)
+        table = _make_show_grants_table(
+            [
+                (
+                    "public",
+                    "t1",
+                    "TABLE",
+                    "SELECT",
+                    "101",
+                    "alice",
+                    "user",
+                    "f",
+                    "TABLE",
+                    "dev",
+                    "admin",
+                ),
+                (
+                    "public",
+                    "t1",
+                    "TABLE",
+                    "DROP",
+                    "101",
+                    "alice",
+                    "user",
+                    "f",
+                    "TABLE",
+                    "dev",
+                    "admin",
+                ),
+                (
+                    "public",
+                    "t1",
+                    "TABLE",
+                    "ALTER",
+                    "101",
+                    "alice",
+                    "user",
+                    "f",
+                    "TABLE",
+                    "dev",
+                    "admin",
+                ),
+                (
+                    "public",
+                    "t1",
+                    "TABLE",
+                    "TRUNCATE",
+                    "101",
+                    "bob",
+                    "user",
+                    "f",
+                    "TABLE",
+                    "dev",
+                    "admin",
+                ),
+            ]
+        )
+        result = adapter.standardize_grants_dict(table)
+        assert result == {
+            "select": ["alice"],
+            "drop": ["alice"],
+            "alter": ["alice"],
+            "truncate": ["bob"],
+        }
+
+    def test_empty_table(self, adapter, mocker):
+        _set_use_show_apis(adapter, mocker, enabled=True)
+        table = _make_show_grants_table([])
+        result = adapter.standardize_grants_dict(table)
+        assert result == {}
+
+
+class TestStandardizeGrantsDictLegacy:
+    """Tests for standardize_grants_dict when redshift_use_show_apis is disabled."""
+
+    def test_basic_grants(self, adapter, mocker):
+        _set_use_show_apis(adapter, mocker, enabled=False)
+        table = _make_legacy_table(
+            [
+                ("alice", "select"),
+                ("alice", "insert"),
+                ("bob", "select"),
+            ]
+        )
+        result = adapter.standardize_grants_dict(table)
+        assert result == {
+            "select": ["alice", "bob"],
+            "insert": ["alice"],
+        }
+
+    def test_empty_table(self, adapter, mocker):
+        _set_use_show_apis(adapter, mocker, enabled=False)
+        table = _make_legacy_table([])
+        result = adapter.standardize_grants_dict(table)
+        assert result == {}


### PR DESCRIPTION
resolves #1677

### Problem
The current `redshift__get_show_grant_sql` macro relies on `pg_user` and the `has_table_privilege()` function to determine grants on a relation. These PostgreSQL catalog-based approaches have three key limitations:

1. No cross-database support — has_table_privilege() cannot resolve relations in other databases, blocking datasharing/cross-database materialization on RA3 nodes
2. Limited privilege visibility — the legacy approach only checks 5 hardcoded privilege types (select, insert, update, delete, references), missing privileges like drop, alter, truncate that may be explicitly granted
3. pg_* dependency — continued reliance on pg_user is incompatible with the ongoing migration to Redshift-native SHOW commands


### Solution
When the redshift_use_show_apis behavior flag is enabled:

- `redshift__get_show_grant_sql` now uses `SHOW GRANTS ON TABLE database.schema.identifier`, which natively supports cross-database references and returns all explicitly granted privileges
 - `standardize_grants_dict` is overridden in RedshiftAdapter to translate the SHOW GRANTS output format (identity_name, uppercase privilege_type) into dbt's expected grants dict format (lowercase privilege to list of grantees

 The legacy pg_user + has_table_privilege path is preserved behind the flag for backward compatibility.

### Testing
- Unit tests
- Integration tests

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
