### PR TITLE
pinning hatch version for dbt-spark

### DIFF
--- a/dbt-spark/dagger/run_dbt_spark_tests.py
+++ b/dbt-spark/dagger/run_dbt_spark_tests.py
@@ -102,6 +102,9 @@ async def test_spark(test_args):
             .with_directory("/scripts", client.host().directory("./dagger/scripts"))
             .with_exec(["./scripts/install_os_reqs.sh"])
             .with_exec(["pip", "install", "-U", "pip", "hatch"])
+            .with_exec(
+                ["pip", "install", "virtualenv<21"]
+            )  # TODO: remove once hatch releases a fix for https://github.com/pypa/hatch/issues/2193
             .with_(env_variables(TESTING_ENV_VARS))
         )
 

--- a/dbt-spark/hatch.toml
+++ b/dbt-spark/hatch.toml
@@ -104,8 +104,3 @@ integration-tests = [
     "pip install -r dagger/requirements.txt",
     "python dagger/run_dbt_spark_tests.py {args:--profile apache_spark}",
 ]
-
-[tool.hatch.env]
-requires = [
-"virtualenv==20.26.6",
-]


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

`dbt-spark` integration tests are failing due to a recent issue with `virtuanenv` ( 21.0.0 ). 

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

This PR will pin the version of `virtualenv` to an older version
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
