### PR TITLE
perf(athena): cache `_get_data_catalog()` result to avoid repeated STS calls

### DIFF
--- a/dbt-athena/.changes/unreleased/Features-20260304-143653.yaml
+++ b/dbt-athena/.changes/unreleased/Features-20260304-143653.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Cache `_get_data_catalog()` result to avoid repeated STS calls
+time: 2026-03-04T14:36:53.558771+09:00
+custom:
+    Author: dtaniwaki
+    Issue: "1704"

--- a/dbt-athena/src/dbt/adapters/athena/impl.py
+++ b/dbt-athena/src/dbt/adapters/athena/impl.py
@@ -702,6 +702,7 @@ class AthenaAdapter(SQLAdapter):
             info_schema_name_map.add(relation)
         return info_schema_name_map
 
+    @lru_cache(maxsize=32)
     def _get_data_catalog(self, database: str) -> Optional[DataCatalogTypeDef]:
         if database:
             conn = self.connections.get_thread_connection()

--- a/dbt-athena/tests/unit/test_adapter.py
+++ b/dbt-athena/tests/unit/test_adapter.py
@@ -676,6 +676,18 @@ class TestAthenaAdapter:
             "Parameters": {"catalog-id": DEFAULT_ACCOUNT_ID},
         } == res
 
+    @mock_aws
+    def test__get_data_catalog_is_cached(self, mock_aws_service):
+        mock_aws_service.create_data_catalog()
+        self.adapter.acquire_connection("dummy")
+        # Clear any existing cache from previous tests
+        self.adapter._get_data_catalog.cache_clear()
+        res1 = self.adapter._get_data_catalog(DATA_CATALOG_NAME)
+        res2 = self.adapter._get_data_catalog(DATA_CATALOG_NAME)
+        assert res1 == res2
+        assert self.adapter._get_data_catalog.cache_info().hits == 1
+        assert self.adapter._get_data_catalog.cache_info().misses == 1
+
     def _test_list_relations_without_caching(self, schema_relation):
         self.adapter.acquire_connection("dummy")
         relations = self.adapter.list_relations_without_caching(schema_relation)


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/# N/A

### Problem

`_get_data_catalog("awsdatacatalog")` is called from 12 places in `impl.py` (e.g. `list_relations_without_caching`, `get_columns_in_relation`, `swap_table`, `persist_docs_to_glue`, …). For the `awsdatacatalog` case it always calls `sts.get_caller_identity()` to look up the AWS account ID, even though that value never changes within a run.

On a small project this adds up to ~6–8 STS round-trips; on larger projects it scales roughly as `S + M × 8` where S is the number of schemas and M is the number of models.

### Solution

Add `@lru_cache(maxsize=32)` to `_get_data_catalog`. The cache key is `(self, database)`, so each adapter instance caches results independently per catalog name. `maxsize=32` is large enough to cover any realistic number of distinct catalogs while bounding memory usage.

The same caching benefits custom/federated catalog lookups, which call `athena.get_data_catalog` on every invocation.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX