### PR TITLE
fix(athena): partition tmp table in incremental to reduce batch scan cost

### DIFF
--- a/dbt-athena/.changes/unreleased/Fixes-20260311-141407.yaml
+++ b/dbt-athena/.changes/unreleased/Fixes-20260311-141407.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Partition tmp table in incremental to reduce batch scan cost
+time: 2026-03-11T14:14:07.932048+09:00
+custom:
+    Author: dtaniwaki
+    Issue: "1744"

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -207,16 +207,11 @@
       {%- do create_table_as_with_partitions(temporary, relation, compiled_code, language) -%}
       {%- set query_result = relation ~ ' with many partitions created' -%}
     {%- else -%}
-        {%- if temporary -%}
-          {%- do run_query(create_table_as(temporary, relation, compiled_code, language, true)) -%}
-          {%- set compiled_code_result = relation ~ ' as temporary relation without partitioning created' -%}
-        {%- else -%}
-          {%- set compiled_code_result = adapter.run_query_with_partitions_limit_catching(create_table_as(temporary, relation, compiled_code)) -%}
-          {%- do log('COMPILED CODE RESULT: ' ~ compiled_code_result) -%}
-          {%- if compiled_code_result == 'TOO_MANY_OPEN_PARTITIONS' -%}
+        {%- set compiled_code_result = adapter.run_query_with_partitions_limit_catching(create_table_as(temporary, relation, compiled_code)) -%}
+        {%- do log('COMPILED CODE RESULT: ' ~ compiled_code_result) -%}
+        {%- if compiled_code_result == 'TOO_MANY_OPEN_PARTITIONS' -%}
             {%- do create_table_as_with_partitions(temporary, relation, compiled_code, language) -%}
             {%- set compiled_code_result = relation ~ ' with many partitions created' -%}
-          {%- endif -%}
         {%- endif -%}
     {%- endif -%}
     {{ return(compiled_code_result) }}

--- a/dbt-athena/tests/unit/test_safe_create_table_as.py
+++ b/dbt-athena/tests/unit/test_safe_create_table_as.py
@@ -1,0 +1,165 @@
+"""
+Unit tests for the safe_create_table_as macro in create_table_as.sql.
+
+Tests the full macro end-to-end using jinja2.FileSystemLoader with stubbed
+dbt context, following the pattern used in test_get_partition_batches.py.
+"""
+
+import os
+from unittest import mock
+
+import jinja2
+
+_TABLE_DIR = os.path.normpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        os.pardir,
+        os.pardir,
+        "src",
+        "dbt",
+        "include",
+        "athena",
+        "macros",
+        "materializations",
+        "models",
+        "table",
+    )
+)
+
+
+def _render_safe_create_table_as(temporary, run_query_result="success"):
+    """Load and render safe_create_table_as with stubbed dbt context.
+
+    Args:
+        temporary: Whether the relation is a tmp table.
+        run_query_result: Value returned by run_query_with_partitions_limit_catching.
+
+    Returns:
+        Tuple of (macro_result, adapter_mock, context_dict).
+    """
+    result_holder = {}
+
+    # Stub adapter.dispatch so create_table_as renders simple SQL
+    # without needing the full athena__create_table_as template logic.
+    adapter = mock.Mock()
+    adapter.dispatch.return_value = mock.Mock(return_value="CREATE TABLE test")
+    adapter.run_query_with_partitions_limit_catching.return_value = run_query_result
+    adapter.get_columns_in_relation.return_value = []
+
+    relation = mock.Mock()
+    relation.__str__ = lambda self: '"test_schema"."test_table__dbt_tmp"'
+    relation.identifier = "test_table__dbt_tmp"
+    relation.schema = "test_schema"
+    relation.database = "AwsDataCatalog"
+    relation.s3_path_table_part = "test_table__dbt_tmp"
+
+    mock_tmp_relation = mock.Mock()
+    mock_tmp_relation.__str__ = (
+        lambda self: '"test_schema"."test_table__dbt_tmp__tmp_not_partitioned"'
+    )
+
+    mock_config = mock.Mock()
+    mock_config.get = lambda key, *args, **kwargs: (
+        mock.Mock(enforced=False)
+        if key == "contract"
+        else {
+            "materialized": "incremental",
+            "external_location": None,
+            "partitioned_by": ["date_col"],
+            "bucketed_by": None,
+            "bucket_count": None,
+            "field_delimiter": None,
+            "table_type": "hive",
+            "format": "parquet",
+            "write_compression": None,
+            "s3_data_dir": "s3://test-bucket/data",
+            "s3_data_naming": "table",
+            "s3_tmp_table_dir": "s3://test-bucket/tmp",
+            "table_properties": None,
+            "native_drop": False,
+        }.get(key, args[0] if args else kwargs.get("default"))
+    )
+
+    mock_target = mock.Mock()
+    mock_target.s3_data_dir = "s3://test-bucket/data"
+    mock_target.s3_data_naming = "table"
+    mock_target.s3_tmp_table_dir = "s3://test-bucket/tmp"
+
+    mock_api = mock.Mock()
+    mock_api.Relation.create.return_value = mock_tmp_relation
+
+    context = {
+        "config": mock_config,
+        "adapter": adapter,
+        "target": mock_target,
+        "api": mock_api,
+        "run_query": mock.Mock(),
+        "drop_relation": mock.Mock(),
+        "get_partition_batches": mock.Mock(return_value=[]),
+        "log": lambda *args, **kwargs: "",
+        "return": lambda value: result_holder.update({"value": value}) or "",
+        "exceptions": mock.Mock(),
+    }
+
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(_TABLE_DIR),
+        extensions=["jinja2.ext.do"],
+    )
+
+    template = env.get_template("create_table_as.sql", globals=context)
+    template.module.safe_create_table_as(
+        temporary=temporary,
+        relation=relation,
+        compiled_code="select 1 as id, cast('2023-01-01' as date) as date_col",
+        language="sql",
+    )
+
+    return result_holder.get("value"), adapter, context
+
+
+class TestSafeCreateTableAsPartitionHandling:
+    """
+    Tests that safe_create_table_as applies partition-aware creation logic
+    regardless of whether temporary=True or temporary=False.
+
+    Before the fix, temporary=True skipped run_query_with_partitions_limit_catching
+    and always used skip_partitioning=True, making batch inserts O(N * full scan).
+    After the fix, both paths go through the same partition-handling logic.
+    """
+
+    def test_temporary_true_calls_run_query_with_partitions_limit_catching(self):
+        """
+        With temporary=True, run_query_with_partitions_limit_catching must be called.
+        Before the fix this code path was bypassed entirely.
+        """
+        result, adapter, _ = _render_safe_create_table_as(
+            temporary=True, run_query_result="success"
+        )
+
+        adapter.run_query_with_partitions_limit_catching.assert_called_once()
+        assert result == "success"
+
+    def test_temporary_false_calls_run_query_with_partitions_limit_catching(self):
+        """With temporary=False, run_query_with_partitions_limit_catching is called."""
+        result, adapter, _ = _render_safe_create_table_as(
+            temporary=False, run_query_result="success"
+        )
+
+        adapter.run_query_with_partitions_limit_catching.assert_called_once()
+        assert result == "success"
+
+    def test_temporary_true_too_many_partitions_falls_back_to_batch(self):
+        """
+        When TOO_MANY_OPEN_PARTITIONS is returned for a tmp table (temporary=True),
+        create_table_as_with_partitions fallback must be triggered.
+        Before the fix this path was unreachable for temporary=True.
+        """
+        result, _, context = _render_safe_create_table_as(
+            temporary=True,
+            run_query_result="TOO_MANY_OPEN_PARTITIONS",
+        )
+
+        # create_table_as_with_partitions calls get_partition_batches
+        # to split the load into batches — verify it was invoked.
+        context["get_partition_batches"].assert_called_once()
+        assert result == '"test_schema"."test_table__dbt_tmp" with many partitions created'


### PR DESCRIPTION
resolves #1744
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

Thank you for maintaining this project! I'd appreciate your review on this fix to the Athena adapter's incremental materialization.

### Problem

For incremental models with many partitions (e.g. `bucket(col, 256)`), batch processing is extremely slow due to redundant full table scans.

**Before this PR**, the flow for `force_batch=True` was:

| Step | Operation | Queries |
|------|-----------|---------|
| 1 | CTAS: source → `__tmp_not_partitioned` (no partitions) | 1 |
| 2 | Batch INSERT: `__tmp_not_partitioned` → `__dbt_tmp` (partitioned) | N |
| 3 | Batch INSERT: `__dbt_tmp` → target | N |
| | **Total** | **2N+1** |

Each of the N batch INSERTs in step 2 performs a **full scan** of the unpartitioned tmp table, making total scan cost O(N) × table size.

### Solution

#### Commit 1: Partition the tmp table (for insert_overwrite / merge)

Unified the `temporary=True` and `temporary=False` code paths in `safe_create_table_as` so that tmp tables now go through `run_query_with_partitions_limit_catching` and fall back to `create_table_as_with_partitions` on `TOO_MANY_OPEN_PARTITIONS`.

With this change, `__dbt_tmp` is created **with partitions** (when `partitioned_by` is configured), so each batch in step 3 benefits from partition pruning. Reduces scan cost for `insert_overwrite` and `merge` strategies.

Models without `partitioned_by` are unaffected — they produce an unpartitioned CTAS as before.

#### Commit 2: Skip partitioning entirely for Iceberg append strategy

For **Iceberg** `append` strategy, partitioning the tmp table is **unnecessary** because the final INSERT into the target can be done in a single query.

**Key insight:** `TOO_MANY_OPEN_PARTITIONS` is a **CTAS-specific** limitation in Athena. `INSERT INTO` an existing Iceberg table does not hit this limit — the Trino engine can sort/shuffle data by partition key and write partitions sequentially without keeping all partition writers open simultaneously. Iceberg's metadata commit only appends manifest entries, avoiding per-partition Glue Catalog registration.

This means:
- **CTAS** (creating `__dbt_tmp`): needs batch splitting when partitions > 100
- **INSERT INTO existing Iceberg table** (tmp → target): can always be done in a single query

**After this PR**, the flow for Iceberg append is:

| Step | Operation | Queries |
|------|-----------|---------|
| 1 | CTAS: source → `__dbt_tmp` (skip_partitioning=True) | 1 |
| 2 | INSERT: `__dbt_tmp` → target | 1 |
| | **Total** | **2** |

Falls back to batch INSERT if `TOO_MANY_OPEN_PARTITIONS` is unexpectedly raised.

**Hive tables** continue to use the standard path (`safe_create_table_as` + `force_batch`) since Hive `INSERT INTO` may still be subject to partition limits.

**Real production impact:**
- Table: `fitbit_heart_rate` with `bucket(uid_hash, 256)` + `day(import_time_ts6)`
- Before: 500+ batch queries × 82 GB scan each → 5+ hours, CodeBuild timeout
- After: 2 queries total

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX