### PR TITLE
put sql_header behind REQUIRE_SQL_HEADER_IN_TEST_CONFIGS flag

### DIFF
--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/tests/test.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/tests/test.sql
@@ -2,7 +2,7 @@
 
   {% set relations = [] %}
   {% set limit = config.get('limit') %}
-  {% set sql_header = config.get('sql_header') %}
+  {% set sql_header = config.get('sql_header') if flags.REQUIRE_SQL_HEADER_IN_TEST_CONFIGS else none %}
 
   {% set sql_with_limit %}
     {{ get_limit_subquery_sql(sql, limit) }}

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/tests/unit.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/tests/unit.sql
@@ -1,7 +1,7 @@
 {%- materialization unit, default -%}
 
   {% set relations = [] %}
-  {% set sql_header = config.get('sql_header') %}
+  {% set sql_header = config.get('sql_header') if flags.REQUIRE_SQL_HEADER_IN_TEST_CONFIGS else none %}
 
   {% set expected_rows = config.get('expected_rows') %}
   {% set expected_sql = config.get('expected_sql') %}


### PR DESCRIPTION
resolves dbt-labs/dbt-core#9775

### Problem

The `test.sql` and `unit.sql` materialization macros unconditionally read `sql_header` from test config and prepend it to the compiled SQL. This needs to be gated behind the `require_sql_header_in_test_configs` behavior change flag defined in dbt-core to avoid breaking existing projects that may have `sql_header` in test configs with invalid values.

### Solution

Gate `sql_header` retrieval in both `test.sql` and `unit.sql` materializations behind `flags.REQUIRE_SQL_HEADER_IN_TEST_CONFIGS`:

```jinja
{% set sql_header = config.get('sql_header') if flags.REQUIRE_SQL_HEADER_IN_TEST_CONFIGS else none %}
```

When the flag is `false` (default), `sql_header` is set to `none` so it won't be prepended to test SQL. When `true`, it works as before.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX