### PR TITLE
Bump google-cloud-storage upper bound from <3.2 to <4

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Dependencies-20260310-120000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Dependencies-20260310-120000.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump upper bound of google-cloud-storage to <4
+time: 2026-03-10T12:00:00.000000+00:00
+custom:
+  Author: andreyvdl
+  PR: ""

--- a/dbt-bigquery/pyproject.toml
+++ b/dbt-bigquery/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "dbt-adapters>=1.19.0,<2.0",
     # 3.20 introduced pyarrow>=3.0 under the `pandas` extra
     "google-cloud-bigquery[pandas]>=3.0,<4.0",
-    "google-cloud-storage>=2.4,<3.2",
+    "google-cloud-storage>=2.4,<4",
     "google-cloud-dataproc~=5.0",
     # ----
     # Expect compatibility with all new versions of these packages, so lower bounds only.


### PR DESCRIPTION
### Problem
                                                                                                              
  The upper bound for `google-cloud-storage` was pinned to `<3.2`, which prevents users from installing newer
  patch and minor releases of the library (e.g. 3.2.x and above). This causes unnecessary dependency conflicts
   for users who have other packages requiring a newer version of `google-cloud-storage`.

  ### Solution

  Bump the upper bound of `google-cloud-storage` from `<3.2` to `<4` to allow all compatible 3.x releases.
  This follows the same pattern used for `google-cloud-bigquery` which is already bounded at `<4.0`.

  ### Checklist

  - [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md)
  and understand what's expected of me
  - [x] I have run this code in development and it appears to resolve the stated issue
  - [x] This PR includes tests, or tests are not required/relevant for this PR
  - [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter
  interface, etc) or this PR has already received feedback and approval from Product or DX
