### PR TITLE
fix: update Dockerfiles to use dbt-adapters monorepo URLs

### DIFF
--- a/dbt-bigquery/docker/Dockerfile
+++ b/dbt-bigquery/docker/Dockerfile
@@ -34,4 +34,4 @@ HEALTHCHECK CMD dbt --version || exit 1
 WORKDIR /usr/app/dbt/
 ENTRYPOINT ["dbt"]
 
-RUN python -m pip install --no-cache-dir "dbt-bigquery @ git+https://github.com/dbt-labs/dbt-bigquery@${commit_ref}"
+RUN python -m pip install --no-cache-dir "dbt-bigquery @ git+https://github.com/dbt-labs/dbt-adapters@${commit_ref}#subdirectory=dbt-bigquery"

--- a/dbt-postgres/docker/Dockerfile
+++ b/dbt-postgres/docker/Dockerfile
@@ -34,4 +34,4 @@ HEALTHCHECK CMD dbt --version || exit 1
 WORKDIR /usr/app/dbt/
 ENTRYPOINT ["dbt"]
 
-RUN python -m pip install --no-cache-dir "dbt-postgres @ git+https://github.com/dbt-labs/dbt-postgres@${commit_ref}"
+RUN python -m pip install --no-cache-dir "dbt-postgres @ git+https://github.com/dbt-labs/dbt-adapters@${commit_ref}#subdirectory=dbt-postgres"

--- a/dbt-redshift/docker/Dockerfile
+++ b/dbt-redshift/docker/Dockerfile
@@ -34,4 +34,4 @@ HEALTHCHECK CMD dbt --version || exit 1
 WORKDIR /usr/app/dbt/
 ENTRYPOINT ["dbt"]
 
-RUN python -m pip install --no-cache-dir "dbt-redshift @ git+https://github.com/dbt-labs/dbt-redshift@${commit_ref}"
+RUN python -m pip install --no-cache-dir "dbt-redshift @ git+https://github.com/dbt-labs/dbt-adapters@${commit_ref}#subdirectory=dbt-redshift"

--- a/dbt-snowflake/docker/Dockerfile
+++ b/dbt-snowflake/docker/Dockerfile
@@ -34,4 +34,4 @@ HEALTHCHECK CMD dbt --version || exit 1
 WORKDIR /usr/app/dbt/
 ENTRYPOINT ["dbt"]
 
-RUN python -m pip install --no-cache-dir "dbt-snowflake @ git+https://github.com/dbt-labs/dbt-snowflake@${commit_ref}"
+RUN python -m pip install --no-cache-dir "dbt-snowflake @ git+https://github.com/dbt-labs/dbt-adapters@${commit_ref}#subdirectory=dbt-snowflake"

--- a/dbt-spark/docker/Dockerfile
+++ b/dbt-spark/docker/Dockerfile
@@ -39,4 +39,4 @@ HEALTHCHECK CMD dbt --version || exit 1
 WORKDIR /usr/app/dbt/
 ENTRYPOINT ["dbt"]
 
-RUN python -m pip install --no-cache-dir "dbt-spark[${extras}] @ git+https://github.com/dbt-labs/dbt-spark@${commit_ref}"
+RUN python -m pip install --no-cache-dir "dbt-spark[${extras}] @ git+https://github.com/dbt-labs/dbt-adapters@${commit_ref}#subdirectory=dbt-spark"


### PR DESCRIPTION
## Summary

After the migration to the `dbt-adapters` monorepo, all 5 adapter Dockerfiles still reference the old separate repositories (`dbt-labs/dbt-bigquery`, `dbt-labs/dbt-postgres`, etc.) which no longer exist. This causes Docker builds to fail.

**Before:**
```dockerfile
RUN pip install "dbt-bigquery @ git+https://github.com/dbt-labs/dbt-bigquery@${commit_ref}"
```

**After:**
```dockerfile
RUN pip install "dbt-bigquery @ git+https://github.com/dbt-labs/dbt-adapters@${commit_ref}#subdirectory=dbt-bigquery"
```

### Files changed
- `dbt-bigquery/docker/Dockerfile`
- `dbt-postgres/docker/Dockerfile`
- `dbt-redshift/docker/Dockerfile`
- `dbt-snowflake/docker/Dockerfile`
- `dbt-spark/docker/Dockerfile`

Fixes #1699

## Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR fixes broken Docker builds
- [x] No code changes — only Dockerfile install URLs updated