### PR TITLE
Fix dbt clone for Snowflake Iceberg tables

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20260317-100403.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260317-100403.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix dbt clone for Iceberg tables by using CREATE ICEBERG TABLE syntax when source is an Iceberg table
+time: 2026-03-17T10:04:03.215641-04:00
+custom:
+    Author: jcolvin
+    Issue: "1767"

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/clone.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/clone.sql
@@ -3,8 +3,14 @@
 {% endmacro %}
 
 {% macro snowflake__create_or_replace_clone(this_relation, defer_relation) %}
+    {%- set source_relation = load_cached_relation(defer_relation) -%}
+    {%- set is_iceberg = source_relation is not none and source_relation.is_iceberg_format -%}
     create or replace
-      {{ "transient" if config.get("transient", true) }}
+      {% if is_iceberg -%}
+        iceberg
+      {%- else -%}
+        {{ "transient" if config.get("transient", true) }}
+      {%- endif %}
       table {{ this_relation }}
       clone {{ defer_relation }}
       {{ "copy grants" if config.get("copy_grants", false) }}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/clone.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/clone.sql
@@ -24,11 +24,13 @@
 
     {#- Cache miss: query Snowflake directly -#}
     {%- set show_sql -%}
-        show tables like '{{ relation.identifier }}' in {{ relation.database }}.{{ relation.schema }}
+        show tables like '{{ relation.identifier }}' in schema {{ relation.database }}.{{ relation.schema }}
     {%- endset -%}
     {%- set results = run_query(show_sql) -%}
-    {%- if results and results | length > 0 -%}
-        {{ return(results.columns.get('is_iceberg').values()[0] in ('Y', 'YES')) }}
-    {%- endif -%}
+    {%- for row in results -%}
+        {%- if row['name'] == relation.identifier -%}
+            {{ return(row['is_iceberg'] in ('Y', 'YES')) }}
+        {%- endif -%}
+    {%- endfor -%}
     {{ return(false) }}
 {% endmacro %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/clone.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/clone.sql
@@ -22,15 +22,5 @@
         {{ return(source_relation.is_iceberg_format) }}
     {%- endif -%}
 
-    {#- Cache miss: query Snowflake directly -#}
-    {%- set show_sql -%}
-        show tables like '{{ relation.identifier }}' in schema {{ relation.database }}.{{ relation.schema }}
-    {%- endset -%}
-    {%- set results = run_query(show_sql) -%}
-    {%- for row in results -%}
-        {%- if row['name'] == relation.identifier -%}
-            {{ return(row['is_iceberg'] in ('Y', 'YES')) }}
-        {%- endif -%}
-    {%- endfor -%}
     {{ return(false) }}
 {% endmacro %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/clone.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/clone.sql
@@ -3,8 +3,7 @@
 {% endmacro %}
 
 {% macro snowflake__create_or_replace_clone(this_relation, defer_relation) %}
-    {%- set source_relation = load_cached_relation(defer_relation) -%}
-    {%- set is_iceberg = source_relation is not none and source_relation.is_iceberg_format -%}
+    {%- set is_iceberg = snowflake__is_iceberg_table(defer_relation) -%}
     create or replace
       {% if is_iceberg -%}
         iceberg
@@ -15,4 +14,21 @@
       clone {{ defer_relation }}
       {{ "copy grants" if config.get("copy_grants", false) }}
       {{ "copy tags" if config.get("copy_tags", false) }}
+{% endmacro %}
+
+{% macro snowflake__is_iceberg_table(relation) %}
+    {%- set source_relation = load_cached_relation(relation) -%}
+    {%- if source_relation is not none -%}
+        {{ return(source_relation.is_iceberg_format) }}
+    {%- endif -%}
+
+    {#- Cache miss: query Snowflake directly -#}
+    {%- set show_sql -%}
+        show tables like '{{ relation.identifier }}' in {{ relation.database }}.{{ relation.schema }}
+    {%- endset -%}
+    {%- set results = run_query(show_sql) -%}
+    {%- if results and results | length > 0 -%}
+        {{ return(results.columns.get('is_iceberg').values()[0] in ('Y', 'YES')) }}
+    {%- endif -%}
+    {{ return(false) }}
 {% endmacro %}

--- a/dbt-snowflake/tests/functional/adapter/dbt_clone/test_dbt_clone.py
+++ b/dbt-snowflake/tests/functional/adapter/dbt_clone/test_dbt_clone.py
@@ -31,7 +31,10 @@ def copy_state(project_root):
     state_path = os.path.join(project_root, "state")
     if not os.path.exists(state_path):
         os.makedirs(state_path)
-    shutil.copyfile(f"{project_root}/target/manifest.json", f"{project_root}/state/manifest.json")
+    shutil.copyfile(
+        os.path.join(project_root, "target", "manifest.json"),
+        os.path.join(project_root, "state", "manifest.json"),
+    )
 
 
 def run_and_save_state(project_root):

--- a/dbt-snowflake/tests/functional/adapter/dbt_clone/test_dbt_clone.py
+++ b/dbt-snowflake/tests/functional/adapter/dbt_clone/test_dbt_clone.py
@@ -27,6 +27,19 @@ class TestSnowflakeClonePossible(BaseClonePossible):
     pass
 
 
+def copy_state(project_root):
+    state_path = os.path.join(project_root, "state")
+    if not os.path.exists(state_path):
+        os.makedirs(state_path)
+    shutil.copyfile(f"{project_root}/target/manifest.json", f"{project_root}/state/manifest.json")
+
+
+def run_and_save_state(project_root):
+    results = run_dbt(["run"])
+    assert len(results) == 1
+    copy_state(project_root)
+
+
 table_model_1_sql = """
     {{ config(
         materialized='table',
@@ -55,23 +68,9 @@ class TestSnowflakeCloneTrainsentTable:
         outputs["otherschema"]["schema"] = other_schema
         return {"test": {"outputs": outputs, "target": "default"}}
 
-    def copy_state(self, project_root):
-        state_path = os.path.join(project_root, "state")
-        if not os.path.exists(state_path):
-            os.makedirs(state_path)
-        shutil.copyfile(
-            f"{project_root}/target/manifest.json", f"{project_root}/state/manifest.json"
-        )
-
-    def run_and_save_state(self, project_root, with_snapshot=False):
-        results = run_dbt(["run"])
-        assert len(results) == 1
-
-        self.copy_state(project_root)
-
     def test_can_clone_transient_table(self, project, other_schema):
         project.create_test_schema(other_schema)
-        self.run_and_save_state(project.project_root)
+        run_and_save_state(project.project_root)
 
         clone_args = [
             "clone",
@@ -85,13 +84,15 @@ class TestSnowflakeCloneTrainsentTable:
         assert len(results) == 1
 
 
-iceberg_table_model_sql = """
-    {{ config(
+ICEBERG_EXTERNAL_VOLUME = os.getenv("SNOWFLAKE_TEST_ICEBERG_EXTERNAL_VOLUME", "s3_iceberg_snow")
+
+iceberg_table_model_sql = f"""
+    {{{{ config(
         materialized='table',
         table_format='iceberg',
-        external_volume='s3_iceberg_snow',
+        external_volume='{ICEBERG_EXTERNAL_VOLUME}',
         base_location_subpath='clone_test',
-    ) }}
+    ) }}}}
 
     select 1 as id
     """
@@ -115,23 +116,9 @@ class TestSnowflakeCloneIcebergTable:
         outputs["otherschema"]["schema"] = other_schema
         return {"test": {"outputs": outputs, "target": "default"}}
 
-    def copy_state(self, project_root):
-        state_path = os.path.join(project_root, "state")
-        if not os.path.exists(state_path):
-            os.makedirs(state_path)
-        shutil.copyfile(
-            f"{project_root}/target/manifest.json", f"{project_root}/state/manifest.json"
-        )
-
-    def run_and_save_state(self, project_root):
-        results = run_dbt(["run"])
-        assert len(results) == 1
-
-        self.copy_state(project_root)
-
     def test_can_clone_iceberg_table(self, project, other_schema):
         project.create_test_schema(other_schema)
-        self.run_and_save_state(project.project_root)
+        run_and_save_state(project.project_root)
 
         clone_args = [
             "clone",

--- a/dbt-snowflake/tests/functional/adapter/dbt_clone/test_dbt_clone.py
+++ b/dbt-snowflake/tests/functional/adapter/dbt_clone/test_dbt_clone.py
@@ -85,5 +85,73 @@ class TestSnowflakeCloneTrainsentTable:
         assert len(results) == 1
 
 
+iceberg_table_model_sql = """
+    {{ config(
+        materialized='table',
+        table_format='iceberg',
+        external_volume='s3_iceberg_snow',
+        base_location_subpath='clone_test',
+    ) }}
+
+    select 1 as id
+    """
+
+
+class TestSnowflakeCloneIcebergTable:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "iceberg_model.sql": iceberg_table_model_sql,
+        }
+
+    @pytest.fixture(scope="class")
+    def other_schema(self, unique_schema):
+        return unique_schema + "_other"
+
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target, unique_schema, other_schema):
+        outputs = {"default": dbt_profile_target, "otherschema": deepcopy(dbt_profile_target)}
+        outputs["default"]["schema"] = unique_schema
+        outputs["otherschema"]["schema"] = other_schema
+        return {"test": {"outputs": outputs, "target": "default"}}
+
+    def copy_state(self, project_root):
+        state_path = os.path.join(project_root, "state")
+        if not os.path.exists(state_path):
+            os.makedirs(state_path)
+        shutil.copyfile(
+            f"{project_root}/target/manifest.json", f"{project_root}/state/manifest.json"
+        )
+
+    def run_and_save_state(self, project_root):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        self.copy_state(project_root)
+
+    def test_can_clone_iceberg_table(self, project, other_schema):
+        project.create_test_schema(other_schema)
+        self.run_and_save_state(project.project_root)
+
+        clone_args = [
+            "clone",
+            "--state",
+            "state",
+            "--target",
+            "otherschema",
+        ]
+
+        results = run_dbt(clone_args)
+        assert len(results) == 1
+
+        # Verify the cloned relation is also an Iceberg table
+        with project.adapter.connection_named("__test"):
+            schema_relations = project.adapter.list_relations(
+                database=project.database, schema=other_schema
+            )
+            assert len(schema_relations) == 1
+            assert schema_relations[0].is_iceberg_format
+
+
 class TestSnowflakeCloneSameSourceAndTarget(BaseCloneSameSourceAndTarget):
     pass

--- a/dbt-snowflake/tests/functional/adapter/dbt_clone/test_dbt_clone.py
+++ b/dbt-snowflake/tests/functional/adapter/dbt_clone/test_dbt_clone.py
@@ -134,11 +134,16 @@ class TestSnowflakeCloneIcebergTable:
         results = run_dbt(clone_args)
         assert len(results) == 1
 
-        # Verify the cloned relation is also an Iceberg table
+        # Verify the cloned relation is also an Iceberg table. Query metadata directly
+        # via list_relations_without_caching (issues SHOW OBJECTS) rather than
+        # list_relations: the relations cache stores the freshly cloned relation as a
+        # plain table without table_format, so it would report is_iceberg=N even though
+        # Snowflake created a real Iceberg table.
         with project.adapter.connection_named("__test"):
-            schema_relations = project.adapter.list_relations(
-                database=project.database, schema=other_schema
-            )
+            schema_relation = project.adapter.Relation.create(
+                database=project.database, schema=other_schema, identifier=""
+            ).without_identifier()
+            schema_relations = project.adapter.list_relations_without_caching(schema_relation)
             assert len(schema_relations) == 1
             assert schema_relations[0].is_iceberg_format
 


### PR DESCRIPTION
## Summary

- Detect Iceberg source tables in the clone macro via `load_cached_relation` and emit `CREATE OR REPLACE ICEBERG TABLE ... CLONE ...` instead of `CREATE OR REPLACE [TRANSIENT] TABLE ... CLONE ...`
- Omit the `transient` keyword for Iceberg clones (Iceberg tables cannot be transient)
- Add functional test for cloning an Iceberg table

Resolves #1767

## Test plan

- [ ] Existing clone tests pass (`TestSnowflakeClonePossible`, `TestSnowflakeCloneTrainsentTable`)
- [ ] New `TestSnowflakeCloneIcebergTable` test passes against a Snowflake account with an Iceberg-enabled external volume
- [ ] Verify generated SQL with `--log-level debug` shows `CREATE OR REPLACE ICEBERG TABLE` for Iceberg sources and `CREATE OR REPLACE TRANSIENT TABLE` for regular sources