### PR TITLE
Fix failing pg clone testcase

### DIFF
--- a/dbt-postgres/.changes/unreleased/Fixes-20260318-182448.yaml
+++ b/dbt-postgres/.changes/unreleased/Fixes-20260318-182448.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Fix failing clone test case due to ansi sequence
-time: 2026-03-18T18:24:48.115996+05:30
-custom:
-    Author: ash2shukla
-    Issue: "1775"

--- a/dbt-tests-adapter/.changes/unreleased/Fixes-20260318-183152.yaml
+++ b/dbt-tests-adapter/.changes/unreleased/Fixes-20260318-183152.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix failing clone test case due to incorrect message
+time: 2026-03-18T18:31:52.246984+05:30
+custom:
+    Author: "ash2shukla"
+    Issue: "1775"


### PR DESCRIPTION
resolves #1775 

### Problem
As part of https://github.com/dbt-labs/dbt-core/pull/12555/changes we removed the Manually placed "Warning:" prefix from the message in UnversionedBreakingChange this is resulting in failing TestCloneSameTargetAndState test case.

### Solution
Remove `Warning:` tag from assertion message.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
