### PR TITLE
Migrate get_partitions_metadata from Legacy SQL to Standard SQL

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Features-20260323-120000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Features-20260323-120000.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Migrate get_partitions_metadata from Legacy SQL to Standard SQL using INFORMATION_SCHEMA.PARTITIONS
+time: 2026-03-23T12:00:00.000000-07:00
+custom:
+  Author: aahel
+  Issue: "1725"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/connections.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/connections.py
@@ -423,14 +423,15 @@ class BigQueryConnectionManager(BaseConnectionManager):
         return f"https://console.cloud.google.com/bigquery?project={project_id}&j=bq:{location}:{job_id}&page=queryresults"
 
     def get_partitions_metadata(self, table):
-        def standard_to_legacy(table):
-            return table.project + ":" + table.dataset + "." + table.identifier
+        sql = f"""
+            SELECT partition_id
+            FROM `{table.project}.{table.dataset}.INFORMATION_SCHEMA.PARTITIONS`
+            WHERE table_name = '{table.identifier}'
+        """
 
-        legacy_sql = "SELECT * FROM [" + standard_to_legacy(table) + "$__PARTITIONS_SUMMARY__]"
-
-        sql = self._add_query_comment(legacy_sql)
+        sql = self._add_query_comment(sql)
         # auto_begin is ignored on bigquery, and only included for consistency
-        _, iterator = self.raw_execute(sql, use_legacy_sql=True)
+        _, iterator = self.raw_execute(sql, use_legacy_sql=False)
         return self.get_table_from_response(iterator)
 
     def copy_bq_table(self, source, destination, write_disposition) -> None:


### PR DESCRIPTION
resolves #1725
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#N/A

### Problem

BigQuery is deprecating Legacy SQL starting June 1, 2026. New GCP projects created after that date will not support legacy SQL at all. `get_partitions_metadata()` currently uses Legacy SQL with `$__PARTITIONS_SUMMARY__`, which will stop working.

### Solution

Replace the `$__PARTITIONS_SUMMARY__` legacy SQL query with a Standard SQL query against `INFORMATION_SCHEMA.PARTITIONS`.

Only `partition_id` is selected since it's the only column used by all internal callers and the only column fully compatible between the two sources.

**Trade-offs:**
- `$__PARTITIONS_SUMMARY__` was free; `INFORMATION_SCHEMA.PARTITIONS` is billed per query
- Column differences: the legacy meta-table returned `project_id`, `dataset_id`, `table_id`, `partition_id`, `creation_time`, `last_modified_time`. `INFORMATION_SCHEMA.PARTITIONS` has different columns — only `partition_id` is shared and fully compatible. Custom macros accessing other columns from `get_partitions_metadata()` results will need updating.

**Potential breaking change — IAM permissions:**
- Legacy `$__PARTITIONS_SUMMARY__` required: `bigquery.jobs.create` + `bigquery.tables.getData`
- `INFORMATION_SCHEMA.PARTITIONS` requires: `bigquery.tables.get` + `bigquery.tables.list`
- Users with custom IAM roles that grant `bigquery.tables.getData` but not `bigquery.tables.get`/`bigquery.tables.list` will need their permissions updated. This does not affect users with standard predefined roles (`roles/bigquery.dataViewer`, `roles/bigquery.dataEditor`, `roles/bigquery.admin`) as those include all required permissions.

**References:**
- [BigQuery Release Notes (Feb 25, 2026)](https://docs.cloud.google.com/bigquery/docs/release-notes#February_25_2026)
- [INFORMATION_SCHEMA.PARTITIONS docs](https://cloud.google.com/bigquery/docs/information-schema-partitions)
- [INFORMATION_SCHEMA pricing](https://cloud.google.com/bigquery/docs/information-schema-intro#pricing)
- [Legacy partition metadata](https://cloud.google.com/bigquery/docs/managing-partitioned-tables)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX