### PR TITLE
Add branch validation to publish-oss workflow

### DIFF
--- a/.github/workflows/publish-oss.yml
+++ b/.github/workflows/publish-oss.yml
@@ -57,7 +57,48 @@ permissions:
     id-token: write
 
 jobs:
+    validate-inputs:
+        name: "Validate branch and deploy-to combination"
+        runs-on: ${{ vars.DEFAULT_RUNNER }}
+        steps:
+            - name: "Validate branch for prod deployment"
+              if: inputs.deploy-to == 'prod'
+              run: |
+                  package="${{ inputs.package }}"
+                  branch="${{ inputs.branch }}"
+                  version="${{ inputs.version }}"
+
+                  # dbt-adapters and dbt-tests-adapter must always publish prod from main
+                  if [[ "$package" == "dbt-adapters" || "$package" == "dbt-tests-adapter" ]]; then
+                      if [[ "$branch" != "main" ]]; then
+                          echo "::error::$package prod releases must use branch 'main', got '$branch'"
+                          exit 1
+                      fi
+                  else
+                      # For adapter packages, determine if this is a pre-release
+                      is_prerelease=false
+                      if [[ "$version" =~ (rc|a|b|alpha|beta|dev) ]]; then
+                          is_prerelease=true
+                      fi
+
+                      if [[ "$is_prerelease" == "true" ]]; then
+                          # Pre-releases should be from main
+                          if [[ "$branch" != "main" ]]; then
+                              echo "::error::$package prod pre-releases must use branch 'main', got '$branch'"
+                              exit 1
+                          fi
+                      else
+                          # Final releases should be from stable
+                          if [[ "$branch" != "stable" ]]; then
+                              echo "::error::$package prod final releases must use branch 'stable', got '$branch'"
+                              exit 1
+                          fi
+                      fi
+                  fi
+                  echo "Branch validation passed: package=$package branch=$branch version=$version"
+
     work-branch:
+        needs: validate-inputs
         runs-on: ${{ vars.DEFAULT_RUNNER }}
         outputs:
             name: ${{ steps.branch.outputs.name }}


### PR DESCRIPTION
docs N/A

### Problem

The `publish-oss` workflow's `branch` input is a free-text field with no validation. This means a prod release can accidentally be triggered from the wrong branch (e.g. releasing `dbt-adapters` from `stable` instead of `main`, or a final adapter release from `main` instead of `stable`).

### Solution

Add a `validate-inputs` job that runs before any other work and enforces the correct branch for prod deployments:
- `dbt-adapters` and `dbt-tests-adapter` must always use `main` for prod
- Adapter packages must use `stable` for prod final releases
- Adapter packages must use `main` for prod pre-releases (rc/beta/alpha/dev)

Test deployments are unconstrained. The validation produces clear `::error::` annotations in the GitHub Actions UI.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX