### PR TITLE
Fix grant reconciliation failure on clusters with datashares by filte…

### DIFF
--- a/dbt-redshift/.changes/unreleased/Fixes-20260327-123410.yaml
+++ b/dbt-redshift/.changes/unreleased/Fixes-20260327-123410.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix grant reconciliation failure on clusters with datashares by filtering reserved Redshift roles (ds:*, sys:*) from standardize_grants_dict
+time: 2026-03-27T12:34:10.161883+05:30
+custom:
+    Author: tauhid621
+    Issue: "1808"

--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -329,6 +329,11 @@ class RedshiftAdapter(SQLAdapter):
                 # Skip PUBLIC grants — not configurable via dbt grants
                 if identity_type == "public":
                     continue
+                # Skip Redshift reserved roles — these cannot be modified
+                # via GRANT/REVOKE.  Includes datashare roles (ds:*) and
+                # system-defined roles (sys:*).
+                if identity_name.startswith(("ds:", "sys:")):
+                    continue
                 # SHOW GRANTS reports groups as identity_type='role' with a
                 # '/' prefix on identity_name.  This is undocumented behavior.
                 if identity_type == "role" and identity_name.startswith("/"):
@@ -343,11 +348,17 @@ class RedshiftAdapter(SQLAdapter):
         else:
             # svv_relation_privileges path — identity_type is accurate
             for row in grants_table:
+                identity_name = row["identity_name"]
                 identity_type = row["identity_type"].lower()
                 # Skip PUBLIC grants — not configurable via dbt grants
                 if identity_type == "public":
                     continue
-                grantee = f"{identity_type}:{row['identity_name']}"
+                # Skip Redshift reserved roles — these cannot be modified
+                # via GRANT/REVOKE.  Includes datashare roles (ds:*) and
+                # system-defined roles (sys:*).
+                if identity_name.startswith(("ds:", "sys:")):
+                    continue
+                grantee = f"{identity_type}:{identity_name}"
                 privilege = row["privilege_type"].lower()
                 if privilege in grants_dict:
                     grants_dict[privilege].append(grantee)

--- a/dbt-redshift/tests/unit/test_standardize_grants_dict.py
+++ b/dbt-redshift/tests/unit/test_standardize_grants_dict.py
@@ -209,6 +209,55 @@ class TestStandardizeGrantsDictShowApi:
         result = adapter.standardize_grants_dict(table)
         assert result == {"select": ["user:alice"]}
 
+    def test_reserved_roles_skipped(self, adapter):
+        """Reserved roles (ds:*, sys:*) cannot be modified via GRANT/REVOKE."""
+        adapter.config.credentials.datasharing = True
+        table = _make_show_grants_table(
+            [
+                (
+                    "public",
+                    "t1",
+                    "TABLE",
+                    "SELECT",
+                    "101",
+                    "alice",
+                    "user",
+                    "f",
+                    "TABLE",
+                    "dev",
+                    "admin",
+                ),
+                (
+                    "public",
+                    "t1",
+                    "TABLE",
+                    "SELECT",
+                    "200",
+                    "ds:named_datashare",
+                    "role",
+                    "f",
+                    "TABLE",
+                    "dev",
+                    "admin",
+                ),
+                (
+                    "public",
+                    "t1",
+                    "TABLE",
+                    "SELECT",
+                    "300",
+                    "sys:dba",
+                    "role",
+                    "f",
+                    "TABLE",
+                    "dev",
+                    "admin",
+                ),
+            ]
+        )
+        result = adapter.standardize_grants_dict(table)
+        assert result == {"select": ["user:alice"]}
+
     def test_empty_table(self, adapter):
         adapter.config.credentials.datasharing = True
         table = _make_show_grants_table([])
@@ -252,6 +301,18 @@ class TestStandardizeGrantsDictSvv:
             [
                 ("alice", "user", "SELECT"),
                 ("PUBLIC", "public", "SELECT"),
+            ]
+        )
+        result = adapter.standardize_grants_dict(table)
+        assert result == {"select": ["user:alice"]}
+
+    def test_reserved_roles_skipped(self, adapter):
+        """Reserved roles (ds:*, sys:*) cannot be modified via GRANT/REVOKE."""
+        table = _make_svv_table(
+            [
+                ("alice", "user", "SELECT"),
+                ("ds:named_datashare", "role", "SELECT"),
+                ("sys:superuser", "role", "SELECT"),
             ]
         )
         result = adapter.standardize_grants_dict(table)


### PR DESCRIPTION
resolves #1808

### Problem
On Redshift RA3 clusters with outbound datashares, models using +grants fail with:

`Granting permissions to reserved role ds:named_datashare is not supported.`

Both `SHOW GRANTS` and `svv_relation_privileges` return reserved datashare roles (ds:*) and system-defined roles (sys:*). dbt's grant reconciliation treats these as unmanaged grants and attempts to revoke them, which Redshift rejects.

### Solution

Filter out identities with reserved prefixes (ds:, sys:) in `standardize_grants_dict` for both the SHOW GRANTS and SVV paths. These roles are internal to Redshift, cannot be created by users, and cannot be modified via GRANT/REVOKE.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX


### Screenshot
####Before
<img width="1141" height="91" alt="Screenshot 2026-03-27 at 1 02 51 PM" src="https://github.com/user-attachments/assets/6ee84634-5026-4b52-84c2-463fe3398038" />

#### After
<img width="1141" height="91" alt="Screenshot 2026-03-27 at 1 03 56 PM" src="https://github.com/user-attachments/assets/40b86023-6c79-4976-b371-2e98868541f5" />
