### PR TITLE
fix(redshift): gate cross-database USE/RESET USE behind use_show_apis

### DIFF
--- a/dbt-redshift/.changes/unreleased/Fixes-20260410-120000.yaml
+++ b/dbt-redshift/.changes/unreleased/Fixes-20260410-120000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Gate cross-database USE/RESET USE in pre_model_hook, post_model_hook, create_schema, and drop_schema behind the use_show_apis check to prevent incorrect database switching when datasharing is not enabled
+time: 2026-04-10T12:00:00.000000+05:30
+custom:
+    Author: tauhid621
+    Issue: NA

--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -586,7 +586,7 @@ class RedshiftAdapter(SQLAdapter):
         )
 
     def _needs_database_change(self, config: Mapping[str, Any]) -> bool:
-        return self._is_different_database(config.get("database"))
+        return self.use_show_apis() and self._is_different_database(config.get("database"))
 
     def pre_model_hook(self, config: Mapping[str, Any]) -> Optional[str]:
         if self._needs_query_group_change(config):
@@ -604,7 +604,7 @@ class RedshiftAdapter(SQLAdapter):
     @contextmanager
     def _use_database_context(self, relation):
         """Issue USE <database> / RESET USE around cross-database operations."""
-        needs_use = self._is_different_database(relation.database)
+        needs_use = self.use_show_apis() and self._is_different_database(relation.database)
         if needs_use:
             self._use_database(self._normalize_database(str(relation.database)))
         try:

--- a/dbt-redshift/tests/unit/test_model_hooks.py
+++ b/dbt-redshift/tests/unit/test_model_hooks.py
@@ -1,11 +1,13 @@
 from dbt.adapters.redshift import RedshiftAdapter
 
 
-def _make_adapter(mocker, default_query_group=None, default_database="dev"):
+def _make_adapter(mocker, default_query_group=None, default_database="dev", use_show_apis=False):
     mock_config = mocker.MagicMock()
     mock_config.credentials.query_group = default_query_group
     mock_config.credentials.database = default_database
-    return RedshiftAdapter(mock_config, mocker.MagicMock())
+    adapter = RedshiftAdapter(mock_config, mocker.MagicMock())
+    mocker.patch.object(adapter, "use_show_apis", return_value=use_show_apis)
+    return adapter
 
 
 class TestNeedsQueryGroupChange:
@@ -36,24 +38,28 @@ class TestNeedsDatabaseChange:
     """Unit tests for RedshiftAdapter._needs_database_change."""
 
     def test_no_model_database(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         assert adapter._needs_database_change({}) is False
 
     def test_model_same_as_default(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         assert adapter._needs_database_change({"database": "dev"}) is False
 
     def test_model_same_as_default_case_insensitive(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         assert adapter._needs_database_change({"database": "DEV"}) is False
 
     def test_model_quoted_same_as_default(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         assert adapter._needs_database_change({"database": '"dev"'}) is False
 
     def test_model_differs_from_default(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         assert adapter._needs_database_change({"database": "other_db"}) is True
+
+    def test_model_differs_but_show_apis_disabled(self, mocker):
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=False)
+        assert adapter._needs_database_change({"database": "other_db"}) is False
 
 
 class TestModelHooks:
@@ -68,7 +74,7 @@ class TestModelHooks:
         mock_execute.assert_called_once_with("SET query_group TO 'model_qg'")
 
     def test_pre_model_hook_uses_database(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         mock_execute = mocker.patch.object(adapter, "execute")
 
         adapter.pre_model_hook({"database": "other_db"})
@@ -76,15 +82,25 @@ class TestModelHooks:
         mock_execute.assert_called_once_with('USE "other_db"')
 
     def test_pre_model_hook_uses_quoted_database(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         mock_execute = mocker.patch.object(adapter, "execute")
 
         adapter.pre_model_hook({"database": '"other_db"'})
 
         mock_execute.assert_called_once_with('USE "other_db"')
 
+    def test_pre_model_hook_skips_use_when_show_apis_disabled(self, mocker):
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=False)
+        mock_execute = mocker.patch.object(adapter, "execute")
+
+        adapter.pre_model_hook({"database": "other_db"})
+
+        mock_execute.assert_not_called()
+
     def test_pre_model_hook_sets_both(self, mocker):
-        adapter = _make_adapter(mocker, default_query_group=None, default_database="dev")
+        adapter = _make_adapter(
+            mocker, default_query_group=None, default_database="dev", use_show_apis=True
+        )
         mock_execute = mocker.patch.object(adapter, "execute")
 
         adapter.pre_model_hook({"query_group": "model_qg", "database": "other_db"})
@@ -94,7 +110,9 @@ class TestModelHooks:
         mock_execute.assert_any_call('USE "other_db"')
 
     def test_pre_model_hook_no_change(self, mocker):
-        adapter = _make_adapter(mocker, default_query_group="qg", default_database="dev")
+        adapter = _make_adapter(
+            mocker, default_query_group="qg", default_database="dev", use_show_apis=True
+        )
         mock_execute = mocker.patch.object(adapter, "execute")
 
         adapter.pre_model_hook({"query_group": "qg", "database": "dev"})
@@ -118,15 +136,25 @@ class TestModelHooks:
         mock_execute.assert_called_once_with("SET query_group TO 'default_qg'")
 
     def test_post_model_hook_resets_database(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         mock_execute = mocker.patch.object(adapter, "execute")
 
         adapter.post_model_hook({"database": "other_db"}, None)
 
         mock_execute.assert_called_once_with("RESET USE")
 
+    def test_post_model_hook_skips_reset_when_show_apis_disabled(self, mocker):
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=False)
+        mock_execute = mocker.patch.object(adapter, "execute")
+
+        adapter.post_model_hook({"database": "other_db"}, None)
+
+        mock_execute.assert_not_called()
+
     def test_post_model_hook_no_change(self, mocker):
-        adapter = _make_adapter(mocker, default_query_group="qg", default_database="dev")
+        adapter = _make_adapter(
+            mocker, default_query_group="qg", default_database="dev", use_show_apis=True
+        )
         mock_execute = mocker.patch.object(adapter, "execute")
 
         adapter.post_model_hook({"query_group": "qg", "database": "dev"}, None)

--- a/dbt-redshift/tests/unit/test_schema_operations.py
+++ b/dbt-redshift/tests/unit/test_schema_operations.py
@@ -3,11 +3,13 @@ import pytest
 from dbt.adapters.redshift import RedshiftAdapter
 
 
-def _make_adapter(mocker, default_database="dev"):
+def _make_adapter(mocker, default_database="dev", use_show_apis=False):
     mock_config = mocker.MagicMock()
     mock_config.credentials.query_group = None
     mock_config.credentials.database = default_database
-    return RedshiftAdapter(mock_config, mocker.MagicMock())
+    adapter = RedshiftAdapter(mock_config, mocker.MagicMock())
+    mocker.patch.object(adapter, "use_show_apis", return_value=use_show_apis)
+    return adapter
 
 
 def _make_relation(mocker, database):
@@ -44,7 +46,7 @@ class TestSchemaOperations:
     """Unit tests for create_schema / drop_schema cross-database support."""
 
     def test_create_schema_cross_db_issues_use(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         relation = _make_relation(mocker, database="other_db")
         mock_execute = mocker.patch.object(adapter, "execute")
         mock_super = mocker.patch("dbt.adapters.sql.SQLAdapter.create_schema")
@@ -56,7 +58,7 @@ class TestSchemaOperations:
         mock_execute.assert_any_call("RESET USE")
 
     def test_create_schema_same_db_no_use(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         relation = _make_relation(mocker, database="dev")
         mock_execute = mocker.patch.object(adapter, "execute")
         mocker.patch("dbt.adapters.sql.SQLAdapter.create_schema")
@@ -65,8 +67,19 @@ class TestSchemaOperations:
 
         mock_execute.assert_not_called()
 
+    def test_create_schema_cross_db_skips_use_when_show_apis_disabled(self, mocker):
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=False)
+        relation = _make_relation(mocker, database="other_db")
+        mock_execute = mocker.patch.object(adapter, "execute")
+        mock_super = mocker.patch("dbt.adapters.sql.SQLAdapter.create_schema")
+
+        adapter.create_schema(relation)
+
+        mock_execute.assert_not_called()
+        mock_super.assert_called_once_with(relation)
+
     def test_drop_schema_cross_db_issues_use(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         relation = _make_relation(mocker, database="other_db")
         mock_execute = mocker.patch.object(adapter, "execute")
         mock_super = mocker.patch("dbt.adapters.sql.SQLAdapter.drop_schema")
@@ -78,7 +91,7 @@ class TestSchemaOperations:
         mock_execute.assert_any_call("RESET USE")
 
     def test_drop_schema_same_db_no_use(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         relation = _make_relation(mocker, database="dev")
         mock_execute = mocker.patch.object(adapter, "execute")
         mocker.patch("dbt.adapters.sql.SQLAdapter.drop_schema")
@@ -87,8 +100,19 @@ class TestSchemaOperations:
 
         mock_execute.assert_not_called()
 
+    def test_drop_schema_cross_db_skips_use_when_show_apis_disabled(self, mocker):
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=False)
+        relation = _make_relation(mocker, database="other_db")
+        mock_execute = mocker.patch.object(adapter, "execute")
+        mock_super = mocker.patch("dbt.adapters.sql.SQLAdapter.drop_schema")
+
+        adapter.drop_schema(relation)
+
+        mock_execute.assert_not_called()
+        mock_super.assert_called_once_with(relation)
+
     def test_create_schema_resets_on_error(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         relation = _make_relation(mocker, database="other_db")
         mock_execute = mocker.patch.object(adapter, "execute")
         mocker.patch(
@@ -102,7 +126,7 @@ class TestSchemaOperations:
         mock_execute.assert_any_call("RESET USE")
 
     def test_drop_schema_resets_on_error(self, mocker):
-        adapter = _make_adapter(mocker, default_database="dev")
+        adapter = _make_adapter(mocker, default_database="dev", use_show_apis=True)
         relation = _make_relation(mocker, database="other_db")
         mock_execute = mocker.patch.object(adapter, "execute")
         mocker.patch(


### PR DESCRIPTION
Fixes: https://dbtlabs.atlassian.net/browse/ADAP-1316

## Summary
- Gates `USE <database>` / `RESET USE` in `pre_model_hook`, `post_model_hook`, `create_schema`, and `drop_schema` behind the `use_show_apis()` check
- Without this guard, the adapter issues `USE` even when datasharing is not enabled, causing incorrect database switching that breaks DDL in environments where model config database and the actual relation database may diverge
- Adds unit tests verifying `USE` is skipped when `use_show_apis` is disabled

## Test plan
- [x] Unit tests pass for `test_model_hooks.py` (22 tests)
- [x] Unit tests pass for `test_schema_operations.py` (13 tests)
- [ ] Integration test with dbt Cloud CI job that uses cross-database model config

🤖 Generated with [Claude Code](https://claude.com/claude-code)