### PR TITLE
fix(bigquery): pass job_retry=None to job.result() to respect job_execution_timeout

### DIFF
--- a/dbt-bigquery/src/dbt/adapters/bigquery/connections.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/connections.py
@@ -644,7 +644,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
                 max_results=limit,
                 timeout=polling_timeout,
                 retry=DEFAULT_JOB_RETRY.with_timeout(timeout),
-                job_retry=None,  # dbt manages retries via create_reopen_with_deadline
+                job_retry=None,  # dbt manages job resubmission retries via create_reopen_with_deadline
             )
         except TimeoutError:
             exc = f"Operation did not complete within the designated timeout of {timeout} seconds."

--- a/dbt-bigquery/src/dbt/adapters/bigquery/connections.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/connections.py
@@ -644,6 +644,7 @@ class BigQueryConnectionManager(BaseConnectionManager):
                 max_results=limit,
                 timeout=polling_timeout,
                 retry=DEFAULT_JOB_RETRY.with_timeout(timeout),
+                job_retry=None,  # dbt manages retries via create_reopen_with_deadline
             )
         except TimeoutError:
             exc = f"Operation did not complete within the designated timeout of {timeout} seconds."

--- a/dbt-bigquery/tests/unit/test_bigquery_connection_manager.py
+++ b/dbt-bigquery/tests/unit/test_bigquery_connection_manager.py
@@ -254,6 +254,30 @@ class TestBigQueryConnectionManager(unittest.TestCase):
         self.assertEqual(call_kwargs["timeout"], 150)
 
     @patch("dbt.adapters.bigquery.connections.QueryJobConfig")
+    def test_job_retry_is_none_in_result_call(self, MockQueryJobConfig):
+        """Test that job.result() is called with job_retry=None.
+
+        job_retry=None prevents the BigQuery Python client from silently re-submitting
+        failed jobs inside job.result(). Without this, a job failing with backendError
+        could be re-submitted multiple times, each with a fresh polling_timeout window,
+        causing total runtime to far exceed job_execution_timeout.
+        """
+        mock_job = Mock(job_id="test_job", location="US", project="project")
+        mock_job.result.return_value = iter([])
+        self.mock_client.query.return_value = mock_job
+
+        self.connections._query_and_results(
+            self.mock_connection,
+            "SELECT 1",
+            {"dry_run": False},
+            job_id="test_job",
+        )
+
+        call_kwargs = mock_job.result.call_args[1]
+        self.assertIn("job_retry", call_kwargs)
+        self.assertIsNone(call_kwargs["job_retry"])
+
+    @patch("dbt.adapters.bigquery.connections.QueryJobConfig")
     def test_retryable_google_api_error_is_reraised(self, MockQueryJobConfig):
         """Test that retryable GoogleAPICallError is re-raised for retry mechanism"""
         exceptions = dbt.adapters.bigquery.impl.google.cloud.exceptions

--- a/dbt-bigquery/tests/unit/test_bigquery_connection_manager.py
+++ b/dbt-bigquery/tests/unit/test_bigquery_connection_manager.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 from requests.exceptions import ConnectionError
-from unittest.mock import patch, MagicMock, Mock, ANY
+from unittest.mock import patch, MagicMock, Mock, ANY, create_autospec
 
 import dbt.adapters
 import google.cloud.bigquery
@@ -262,7 +262,10 @@ class TestBigQueryConnectionManager(unittest.TestCase):
         could be re-submitted multiple times, each with a fresh polling_timeout window,
         causing total runtime to far exceed job_execution_timeout.
         """
-        mock_job = Mock(job_id="test_job", location="US", project="project")
+        mock_job = create_autospec(google.cloud.bigquery.QueryJob, instance=True)
+        mock_job.job_id = "test_job"
+        mock_job.location = "US"
+        mock_job.project = "project"
         mock_job.result.return_value = iter([])
         self.mock_client.query.return_value = mock_job
 


### PR DESCRIPTION
## Summary

- `query_job.result()` was not passing `job_retry=None`, causing the BigQuery Python client to default to `DEFAULT_JOB_RETRY`, which silently re-submits failed jobs on `backendError`
- Each re-submission resets the `polling_timeout` window, so total runtime could multiply far beyond `job_execution_timeout` (customer observed: 4h timeout → 17h runtime)
- Fix passes `job_retry=None` to `job.result()`, consistent with the existing `job_retry=None` already on `client.query()`, making `create_reopen_with_deadline` the sole retry mechanism

## Root cause

Without this fix, a job failing with `backendError` (BigQuery internal error) was silently re-submitted by the BQ Python client inside `job.result()`. Each retry got a fresh `polling_timeout` (`job_execution_timeout` + 30s) window, so total wall time = `polling_timeout × N retries`.

Related: https://github.com/dbt-labs/dbt-adapters/issues/1500

## Test plan
- [ ] New unit test `test_job_retry_is_none_in_result_call` asserts `job_retry=None` is passed to `job.result()`
- [ ] All 19 existing unit tests in `test_bigquery_connection_manager.py` pass
- [ ] `test_result_failure_triggers_retry` confirms the outer `create_reopen_with_deadline` retry path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)