### PR TITLE
feat(snowflake): use CREATE OR ALTER for dynamic table config changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,9 @@ cython_debug/
 # MacOS
 .DS_Store
 
+# Cursor
+.cursor/
+
 # VSCode
 .vscode/
 .venv/

--- a/dbt-snowflake/.changes/unreleased/Features-20260408-154451.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260408-154451.yaml
@@ -2,5 +2,5 @@ kind: Features
 body: 'Snowflake dynamic tables: use CREATE OR REPLACE only with --full-refresh (and when replacing an existing non-dynamic-table relation of the same name). For existing dynamic tables without --full-refresh, configuration-driven updates use CREATE OR ALTER instead of CREATE OR REPLACE. Dynamic iceberg tables continue to use ALTER DYNAMIC TABLE because Snowflake does not yet support CREATE OR ALTER DYNAMIC ICEBERG TABLE. Note: dbt does not compare compiled SQL to SHOW DYNAMIC TABLES text, so model body-only changes with identical config still require --full-refresh.'
 time: 2026-04-08T15:44:51.442042-07:00
 custom:
-    Author: dbt-labs
+    Author: igorbelianski-cyber
     Issue: "1825"

--- a/dbt-snowflake/.changes/unreleased/Features-20260408-154451.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260408-154451.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: 'Snowflake dynamic tables: use CREATE OR REPLACE only with --full-refresh (and when replacing an existing non-dynamic-table relation of the same name). For existing dynamic tables without --full-refresh, configuration-driven updates use CREATE OR ALTER instead of CREATE OR REPLACE. Dynamic iceberg tables continue to use ALTER DYNAMIC TABLE because Snowflake does not yet support CREATE OR ALTER DYNAMIC ICEBERG TABLE. Note: dbt does not compare compiled SQL to SHOW DYNAMIC TABLES text, so model body-only changes with identical config still require --full-refresh.'
+time: 2026-04-08T15:44:51.442042-07:00
+custom:
+    Author: dbt-labs
+    Issue: "1825"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
@@ -206,11 +206,16 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
                 # Strip "IMMUTABLE WHERE (" prefix and ")" suffix
                 immutable_where = immutable_where_str[17:-1]  # len("IMMUTABLE WHERE (") = 17
 
-        # Snowflake may return empty string for unset cluster_by
-        # Normalize to Python None for consistency
+        # Snowflake may return empty string for unset cluster_by — normalize to None.
+        # When all cluster_by elements are plain column references, Snowflake wraps
+        # the entire expression with LINEAR(...) as the default clustering method
+        # (e.g. "id" → "LINEAR(id)", "id, value" → "LINEAR(id, value)").
+        # Strip the wrapper so the value matches the user's config.
         cluster_by = dynamic_table.get("cluster_by")
         if cluster_by is not None and str(cluster_by).strip() not in ("", "NONE", "None"):
             cluster_by = str(cluster_by).strip()
+            if cluster_by.upper().startswith("LINEAR(") and cluster_by.endswith(")"):
+                cluster_by = cluster_by[7:-1]
         else:
             cluster_by = None
 
@@ -275,7 +280,7 @@ class SnowflakeDynamicTableRefreshModeConfigChange(RelationConfigChange):
 
     @property
     def requires_full_refresh(self) -> bool:
-        return True
+        return False
 
 
 @dataclass(frozen=True, eq=True, unsafe_hash=True)

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/dynamic_table.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/dynamic_table.sql
@@ -35,7 +35,7 @@
 
     {% set full_refresh_mode = should_full_refresh() %}
 
-    -- determine the scenario we're in: create, full_refresh, alter, refresh data
+    -- determine the scenario we're in: create, full_refresh, create_or_alter, refresh data
     {% if existing_relation is none %}
         {% set build_sql = get_create_sql(target_relation, sql) %}
     {% elif full_refresh_mode or not existing_relation.is_dynamic_table %}
@@ -51,7 +51,7 @@
             {{ exceptions.warn("No configuration changes were identified on: `" ~ target_relation ~ "`. Continuing.") }}
 
         {% elif on_configuration_change == 'apply' %}
-            {% set build_sql = snowflake__get_alter_dynamic_table_as_sql(existing_relation, configuration_changes, target_relation, sql) %}
+            {% set build_sql = snowflake__get_create_or_alter_dynamic_table_sql(existing_relation, configuration_changes, target_relation, sql) %}
         {% elif on_configuration_change == 'continue' %}
             {% set build_sql = '' %}
             {{ exceptions.warn("Configuration changes were identified and `on_configuration_change` was set to `continue` for `" ~ target_relation ~ "`") }}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/alter.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/alter.sql
@@ -1,4 +1,4 @@
-{% macro snowflake__alter_dynamic_table_built_in_sql(existing_relation, configuration_changes) -%}
+{% macro snowflake__get_alter_dynamic_table_as_sql(existing_relation, configuration_changes) -%}
 {#-
     Produce DDL that alters a dynamic iceberg table using ALTER DYNAMIC TABLE statements.
 

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/alter.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/alter.sql
@@ -1,15 +1,13 @@
-{% macro snowflake__get_alter_dynamic_table_as_sql(
-    existing_relation,
-    configuration_changes,
-    target_relation,
-    sql
-) -%}
-    {{- log('Applying ALTER to: ' ~ existing_relation) -}}
+{% macro snowflake__alter_dynamic_table_built_in_sql(existing_relation, configuration_changes) -%}
+{#-
+    Produce DDL that alters a dynamic iceberg table using ALTER DYNAMIC TABLE statements.
 
-    {% if configuration_changes.requires_full_refresh %}
-        {{- get_replace_sql(existing_relation, target_relation, sql) -}}
+    Snowflake does not support CREATE OR ALTER DYNAMIC ICEBERG TABLE,
+    so we fall back to individual ALTER statements for iceberg tables.
 
-    {% else %}
+    The requires_full_refresh check is handled by the caller
+    (snowflake__get_create_or_alter_dynamic_table_sql) before dispatching here.
+-#}
 
         {%- set target_lag = configuration_changes.target_lag -%}
         {%- if target_lag -%}{{- log('Applying UPDATE TARGET_LAG to: ' ~ existing_relation) -}}{%- endif -%}
@@ -65,7 +63,5 @@
         {% if has_prior_statements %};{% endif %}
         alter dynamic table {{ existing_relation }} drop clustering key
         {% endif %}
-
-    {%- endif -%}
 
 {%- endmacro %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create_or_alter.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create_or_alter.sql
@@ -1,0 +1,61 @@
+{% macro snowflake__get_create_or_alter_dynamic_table_sql(
+    existing_relation,
+    configuration_changes,
+    target_relation,
+    sql
+) -%}
+
+    {% if configuration_changes.requires_full_refresh %}
+        {{- log('Applying full refresh (CREATE OR REPLACE) to: ' ~ existing_relation ~ ' due to changes that require table recreation') -}}
+        {{- get_replace_sql(existing_relation, target_relation, sql) -}}
+
+    {% else %}
+
+        {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
+
+        {%- if catalog_relation.catalog_type == 'INFO_SCHEMA' -%}
+            {%- set dynamic_table = target_relation.from_config(config.model) -%}
+            {{- log('Applying CREATE OR ALTER to: ' ~ existing_relation) -}}
+            {{ snowflake__create_or_alter_dynamic_table_info_schema_sql(dynamic_table, target_relation, sql) }}
+        {%- elif catalog_relation.catalog_type == 'BUILT_IN' -%}
+            {{- log('Applying ALTER to: ' ~ existing_relation) -}}
+            {{ snowflake__alter_dynamic_table_built_in_sql(existing_relation, configuration_changes) }}
+        {%- else -%}
+            {% do exceptions.raise_compiler_error('Unexpected model config for: ' ~ target_relation) %}
+        {%- endif -%}
+
+    {%- endif -%}
+
+{%- endmacro %}
+
+
+{% macro snowflake__create_or_alter_dynamic_table_info_schema_sql(dynamic_table, relation, sql) -%}
+
+    {%- if dynamic_table.transient is not none -%}
+        {%- set is_transient = dynamic_table.transient -%}
+    {%- elif adapter.behavior.snowflake_default_transient_dynamic_tables.no_warn -%}
+        {%- set is_transient = true -%}
+    {%- else -%}
+        {%- set is_transient = false -%}
+    {%- endif -%}
+    {%- set transient_keyword = 'transient ' if is_transient else '' -%}
+create or alter {{ transient_keyword }}dynamic table {{ relation }}
+    {% if dynamic_table.target_lag is not none %}target_lag = '{{ dynamic_table.target_lag }}'{% endif %}
+    warehouse = {{ dynamic_table.warehouse_parameter }}
+    {{ optional('initialization_warehouse', dynamic_table.snowflake_initialization_warehouse) }}
+    {{ optional('refresh_mode', dynamic_table.refresh_mode) }}
+    {{ optional('initialize', dynamic_table.initialize) }}
+    {% if dynamic_table.scheduler is not none %}
+    scheduler = '{{ dynamic_table.scheduler }}'
+    {% elif dynamic_table.target_lag is none %}
+    scheduler = 'DISABLE'
+    {% endif %}
+    {{ optional('with row access policy', dynamic_table.row_access_policy, equals_char='') }}
+    {{ optional('with tag', dynamic_table.table_tag, quote_char='(', equals_char='') }}
+    {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
+    {{ optional('immutable where', dynamic_table.immutable_where, quote_char='(', equals_char='') }}
+    as (
+        {{ sql }}
+    )
+
+{%- endmacro %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create_or_alter.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create_or_alter.sql
@@ -50,8 +50,8 @@ create or alter {{ transient_keyword }}dynamic table {{ relation }}
     {% elif dynamic_table.target_lag is none %}
     scheduler = 'DISABLE'
     {% endif %}
-    {{ optional('with row access policy', dynamic_table.row_access_policy, equals_char='') }}
-    {{ optional('with tag', dynamic_table.table_tag, quote_char='(', equals_char='') }}
+    {#- Snowflake error 001506: CREATE OR ALTER does not support setting policies or tags.
+        row_access_policy and table_tag must be managed via separate ALTER TABLE statements. -#}
     {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
     {{ optional('immutable where', dynamic_table.immutable_where, quote_char='(', equals_char='') }}
     as (

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create_or_alter.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create_or_alter.sql
@@ -18,8 +18,14 @@
             {{- log('Applying CREATE OR ALTER to: ' ~ existing_relation) -}}
             {{ snowflake__create_or_alter_dynamic_table_info_schema_sql(dynamic_table, target_relation, sql) }}
         {%- elif catalog_relation.catalog_type == 'BUILT_IN' -%}
-            {{- log('Applying ALTER to: ' ~ existing_relation) -}}
-            {{ snowflake__alter_dynamic_table_built_in_sql(existing_relation, configuration_changes) }}
+            {%- if configuration_changes.refresh_mode -%}
+                {#- Snowflake's ALTER DYNAMIC TABLE ... SET does not support refresh_mode -#}
+                {{- log('Applying full refresh (CREATE OR REPLACE) to: ' ~ existing_relation ~ ' because refresh_mode cannot be altered on Iceberg tables') -}}
+                {{- get_replace_sql(existing_relation, target_relation, sql) -}}
+            {%- else -%}
+                {{- log('Applying ALTER to: ' ~ existing_relation) -}}
+                {{ snowflake__get_alter_dynamic_table_as_sql(existing_relation, configuration_changes) }}
+            {%- endif -%}
         {%- else -%}
             {% do exceptions.raise_compiler_error('Unexpected model config for: ' ~ target_relation) %}
         {%- endif -%}

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
@@ -607,3 +607,74 @@ DYNAMIC_ICEBERG_TABLE_SCHEDULER_ENABLED = """
 ) }}
 select * from {{ ref('my_seed') }}
 """
+
+
+# Row access policy / table tag fixtures (INFO_SCHEMA)
+DYNAMIC_TABLE_WITH_ROW_ACCESS_POLICY = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    row_access_policy='always_true on (id)',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_WITH_ROW_ACCESS_POLICY_ALTER = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='5 minutes',
+    refresh_mode='INCREMENTAL',
+    row_access_policy='always_true on (id)',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_WITHOUT_ROW_ACCESS_POLICY = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_WITH_TAG = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    table_tag="tag_name = 'tag_value'",
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_WITH_TAG_ALTER = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='5 minutes',
+    refresh_mode='INCREMENTAL',
+    table_tag="tag_name = 'tag_value'",
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_WITHOUT_TAG = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+) }}
+select * from {{ ref('my_seed') }}
+"""

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
@@ -716,3 +716,31 @@ DYNAMIC_TABLE_WITHOUT_TAG = """
 ) }}
 select * from {{ ref('my_seed') }}
 """
+
+
+# Warehouse change fixture (uses alt warehouse env var)
+DYNAMIC_TABLE_ALT_WAREHOUSE = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse=env_var('SNOWFLAKE_TEST_ALT_WAREHOUSE', 'DBT_TESTING'),
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+# Iceberg initialization_warehouse alter fixture (literal warehouse, like INFO_SCHEMA equivalent)
+DYNAMIC_ICEBERG_TABLE_WITH_INIT_WAREHOUSE_ALTER = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    snowflake_initialization_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+) }}
+select * from {{ ref('my_seed') }}
+"""

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
@@ -94,6 +94,67 @@ select * from {{ ref('my_seed') }}
 """
 
 
+DYNAMIC_TABLE_FULL_CONFIG = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='1 hour',
+    refresh_mode='AUTO',
+    initialize='ON_CREATE',
+    scheduler='ENABLE',
+    snowflake_initialization_warehouse=env_var('SNOWFLAKE_TEST_ALT_WAREHOUSE', 'DBT_TESTING'),
+    cluster_by=["HASH(id)", "id"],
+) }}
+select id, value from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_CLUSTER_BY_SINGLE = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='1 hour',
+    refresh_mode='AUTO',
+    cluster_by="id",
+) }}
+select id, value from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_CLUSTER_BY_TWO_COLUMNS = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='1 hour',
+    refresh_mode='AUTO',
+    cluster_by=["id", "value"],
+) }}
+select id, value from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_EXTRA_COLUMN = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+) }}
+select *, 1 as extra_col from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_EXTRA_COLUMN_TARGET_LAG_FIVE = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='5 minutes',
+    refresh_mode='INCREMENTAL',
+) }}
+select *, 1 as extra_col from {{ ref('my_seed') }}
+"""
+
+
 DYNAMIC_ICEBERG_TABLE_ALTER = """
 {{ config(
     materialized='dynamic_table',
@@ -397,6 +458,126 @@ DYNAMIC_TABLE_SCHEDULER_DISABLED_TO_ENABLED = """
     refresh_mode='INCREMENTAL',
 ) }}
 select * from {{ ref('my_seed') }}
+"""
+
+
+# Iceberg initialization_warehouse fixtures
+DYNAMIC_ICEBERG_TABLE_WITH_INIT_WAREHOUSE = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    snowflake_initialization_warehouse=env_var('SNOWFLAKE_TEST_ALT_WAREHOUSE', 'DBT_TESTING'),
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_ICEBERG_TABLE_WITHOUT_INIT_WAREHOUSE = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+# Iceberg immutable_where fixtures
+DYNAMIC_ICEBERG_TABLE_WITH_IMMUTABLE_WHERE = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    immutable_where="id < 100",
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_ICEBERG_TABLE_WITH_IMMUTABLE_WHERE_ALTER = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    immutable_where="id < 50",
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_ICEBERG_TABLE_WITHOUT_IMMUTABLE_WHERE = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+# Iceberg cluster_by fixtures
+DYNAMIC_ICEBERG_TABLE_WITH_CLUSTER_BY = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    cluster_by="id",
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+) }}
+select id, value from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_ICEBERG_TABLE_WITH_CLUSTER_BY_ALTER = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    cluster_by="value",
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+) }}
+select id, value from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_ICEBERG_TABLE_WITHOUT_CLUSTER_BY = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+) }}
+select id, value from {{ ref('my_seed') }}
 """
 
 

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_basic.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_basic.py
@@ -27,6 +27,7 @@ class TestBasic:
             "my_dynamic_table.sql": models.DYNAMIC_TABLE,
             "my_dynamic_table_downstream.sql": models.DYNAMIC_TABLE_DOWNSTREAM,
             "my_dynamic_iceberg_table.sql": models.DYNAMIC_ICEBERG_TABLE,
+            "my_dynamic_table_full_config.sql": models.DYNAMIC_TABLE_FULL_CONFIG,
         }
 
     @pytest.fixture(scope="class", autouse=True)
@@ -39,6 +40,7 @@ class TestBasic:
         assert query_relation_type(project, "my_dynamic_table") == "dynamic_table"
         assert query_relation_type(project, "my_dynamic_table_downstream") == "dynamic_table"
         assert query_relation_type(project, "my_dynamic_iceberg_table") == "dynamic_table"
+        assert query_relation_type(project, "my_dynamic_table_full_config") == "dynamic_table"
 
 
 class TestAutoConfigDoesntFullRefresh:
@@ -206,7 +208,7 @@ class TestSchedulerConfigChange:
         update_model(project, "dynamic_table_scheduler", models.DYNAMIC_TABLE_SCHEDULER_DISABLED)
         _, logs = run_dbt_and_capture(["--debug", "run"])
 
-        assert_message_in_logs("Applying UPDATE SCHEDULER to:", logs)
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs)
         assert_message_in_logs("scheduler = 'DISABLE'", logs)
         assert_message_in_logs("alter dynamic table", logs)
         assert_message_in_logs("Applying REFRESH to:", logs)
@@ -219,7 +221,7 @@ class TestSchedulerConfigChange:
         update_model(project, "dynamic_table_scheduler", models.DYNAMIC_TABLE_TARGET_LAG_ONLY)
         _, logs = run_dbt_and_capture(["--debug", "run"])
 
-        assert_message_in_logs("Applying UPDATE SCHEDULER to:", logs)
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs)
         assert_message_in_logs("scheduler = 'ENABLE'", logs)
         assert_message_in_logs("target_lag = '2 minutes'", logs)
         assert_message_not_in_logs("Applying REFRESH to:", logs)
@@ -234,7 +236,7 @@ class TestSchedulerConfigChange:
         )
         _, logs = run_dbt_and_capture(["--debug", "run"])
 
-        assert_message_in_logs("Applying UPDATE SCHEDULER to:", logs)
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs)
         assert_message_in_logs("scheduler = 'ENABLE'", logs)
         assert_message_in_logs("target_lag = '2 minutes'", logs)
         assert_message_not_in_logs("Applying REFRESH to:", logs)
@@ -249,7 +251,7 @@ class TestSchedulerConfigChange:
         update_model(project, "dynamic_table_scheduler", models.DYNAMIC_TABLE_SCHEDULER_DISABLED)
         _, logs = run_dbt_and_capture(["--debug", "run"])
 
-        assert_message_in_logs("Applying UPDATE SCHEDULER to:", logs)
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs)
         assert_message_in_logs("scheduler = 'DISABLE'", logs)
         assert_message_in_logs("alter dynamic table", logs)
         assert_message_in_logs("Applying REFRESH to:", logs)
@@ -427,7 +429,7 @@ class TestIcebergSchedulerConfigChange:
         )
         _, logs = run_dbt_and_capture(["--debug", "run"])
 
-        assert_message_in_logs("Applying UPDATE SCHEDULER to:", logs)
+        assert_message_in_logs("Applying ALTER to:", logs)
         assert_message_in_logs("scheduler = 'DISABLE'", logs)
         assert_message_in_logs("alter dynamic table", logs)
         assert_message_in_logs("Applying REFRESH to:", logs)
@@ -444,7 +446,7 @@ class TestIcebergSchedulerConfigChange:
         )
         _, logs = run_dbt_and_capture(["--debug", "run"])
 
-        assert_message_in_logs("Applying UPDATE SCHEDULER to:", logs)
+        assert_message_in_logs("Applying ALTER to:", logs)
         assert_message_in_logs("scheduler = 'ENABLE'", logs)
         assert_message_in_logs("target_lag = '2 minutes'", logs)
         assert_message_not_in_logs("Applying REFRESH to:", logs)

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_configuration_changes.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_configuration_changes.py
@@ -888,6 +888,162 @@ class TestIcebergImmutableWhereChanges:
         assert dt_after.immutable_where is None
 
 
+CREATE_ROW_ACCESS_POLICY = """
+create or replace row access policy always_true as (id integer) returns boolean ->
+  case
+      when id = 1 then true
+      else false
+  end
+;
+"""
+
+CREATE_TAG = """
+create or replace tag tag_name COMMENT = 'testing'
+"""
+
+
+class TestRowAccessPolicyWithCreateOrAlter:
+    """Tests that CREATE OR ALTER succeeds when row_access_policy is configured.
+
+    Validates that:
+    - A config change (target_lag) on a DT with row_access_policy triggers CREATE OR ALTER
+    - The CREATE OR ALTER DDL includes the policy and succeeds
+    - A policy-only change (no other config change) is a no-op (known limitation)
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_policy(self, project):
+        project.run_sql(CREATE_ROW_ACCESS_POLICY)
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "dt_with_policy.sql": models.DYNAMIC_TABLE_WITH_ROW_ACCESS_POLICY,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, project, setup_class):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        update_model(project, "dt_with_policy", models.DYNAMIC_TABLE_WITH_ROW_ACCESS_POLICY)
+
+    def test_config_change_with_policy_uses_create_or_alter(self, project):
+        """Changing target_lag on a DT with row_access_policy should use CREATE OR ALTER.
+
+        Snowflake error 001506: CREATE OR ALTER does not support setting policies or tags.
+        The CREATE OR ALTER DDL must omit row_access_policy/table_tag clauses.
+        The policy remains attached to the table from the initial CREATE.
+        """
+        dt_before = describe_dynamic_table(project, "dt_with_policy")
+        assert dt_before.target_lag == "2 minutes"
+
+        update_model(project, "dt_with_policy", models.DYNAMIC_TABLE_WITH_ROW_ACCESS_POLICY_ALTER)
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs)
+        assert_message_in_logs("create or alter dynamic table", logs)
+        assert_message_in_logs("with row access policy", logs, expected_pass=False)
+
+        dt_after = describe_dynamic_table(project, "dt_with_policy")
+        assert dt_after.target_lag == "5 minutes"
+
+    def test_policy_only_change_is_noop(self, project):
+        """Removing row_access_policy (with no other config change) does NOT trigger a rebuild.
+
+        TODO: row_access_policy is not tracked by SnowflakeDynamicTableConfigChangeset and
+        SHOW DYNAMIC TABLES does not return policy information, so dbt cannot detect
+        policy-only changes. Changing row_access_policy requires --full-refresh.
+        This limitation applies to all relation types (tables, views, dynamic tables).
+        """
+        update_model(project, "dt_with_policy", models.DYNAMIC_TABLE_WITHOUT_ROW_ACCESS_POLICY)
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("No configuration changes were identified on:", logs)
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs, expected_pass=False)
+
+
+class TestTableTagWithCreateOrAlter:
+    """Tests that CREATE OR ALTER succeeds when table_tag is configured."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_tag(self, project):
+        project.run_sql(CREATE_TAG)
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "dt_with_tag.sql": models.DYNAMIC_TABLE_WITH_TAG,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, project, setup_class):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        update_model(project, "dt_with_tag", models.DYNAMIC_TABLE_WITH_TAG)
+
+    def test_config_change_with_tag_uses_create_or_alter(self, project):
+        """Changing target_lag on a DT with table_tag should use CREATE OR ALTER.
+
+        Snowflake error 001506: CREATE OR ALTER does not support setting policies or tags.
+        The CREATE OR ALTER DDL must omit table_tag clauses.
+        The tag remains attached to the table from the initial CREATE.
+        """
+        dt_before = describe_dynamic_table(project, "dt_with_tag")
+        assert dt_before.target_lag == "2 minutes"
+
+        update_model(project, "dt_with_tag", models.DYNAMIC_TABLE_WITH_TAG_ALTER)
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs)
+        assert_message_in_logs("create or alter dynamic table", logs)
+        assert_message_in_logs("with tag", logs, expected_pass=False)
+
+        dt_after = describe_dynamic_table(project, "dt_with_tag")
+        assert dt_after.target_lag == "5 minutes"
+
+    def test_tag_only_change_is_noop(self, project):
+        """Removing table_tag (with no other config change) does NOT trigger a rebuild.
+
+        TODO: table_tag is not tracked by SnowflakeDynamicTableConfigChangeset and
+        SHOW DYNAMIC TABLES does not return tag information, so dbt cannot detect
+        tag-only changes. Changing table_tag requires --full-refresh.
+        This limitation applies to all relation types (tables, views, dynamic tables).
+        """
+        update_model(project, "dt_with_tag", models.DYNAMIC_TABLE_WITHOUT_TAG)
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("No configuration changes were identified on:", logs)
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs, expected_pass=False)
+
+
 class TestIcebergClusterByChanges:
     """Tests for cluster_by ALTER on dynamic iceberg tables."""
 

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_configuration_changes.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_configuration_changes.py
@@ -982,7 +982,7 @@ class TestRowAccessPolicyWithCreateOrAlter:
 
     Validates that:
     - A config change (target_lag) on a DT with row_access_policy triggers CREATE OR ALTER
-    - The CREATE OR ALTER DDL includes the policy and succeeds
+    - The CREATE OR ALTER DDL omits the policy (Snowflake error 001506) and succeeds
     - A policy-only change (no other config change) is a no-op (known limitation)
     """
 
@@ -1171,3 +1171,264 @@ class TestIcebergClusterByChanges:
         assert_message_in_logs("Applying ALTER to:", logs)
         dt_after = describe_dynamic_table(project, "iceberg_cluster")
         assert dt_after.cluster_by is None
+
+
+class TestIcebergRefreshModeChangeTriggersReplace:
+    """Tests that changing refresh_mode on an Iceberg DT triggers CREATE OR REPLACE.
+
+    Snowflake's ALTER DYNAMIC TABLE ... SET does not support refresh_mode,
+    so the Iceberg ALTER path falls back to CREATE OR REPLACE when refresh_mode changes.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "iceberg_refresh.sql": models.DYNAMIC_ICEBERG_TABLE,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, project, setup_class):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        update_model(project, "iceberg_refresh", models.DYNAMIC_ICEBERG_TABLE)
+
+    def test_refresh_mode_change_triggers_replace(self, project):
+        """Changing refresh_mode on an Iceberg DT should fall back to CREATE OR REPLACE."""
+        dt_before = describe_dynamic_table(project, "iceberg_refresh")
+        assert dt_before.refresh_mode == "INCREMENTAL"
+
+        update_model(project, "iceberg_refresh", models.DYNAMIC_ICEBERG_TABLE_REPLACE)
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("refresh_mode cannot be altered on Iceberg tables", logs)
+        assert_message_in_logs("create or replace dynamic iceberg table", logs)
+        assert_message_in_logs("Applying ALTER to:", logs, expected_pass=False)
+
+        dt_after = describe_dynamic_table(project, "iceberg_refresh")
+        assert dt_after.refresh_mode == "FULL"
+
+
+class TestSqlAndConfigChangeAppliesBoth:
+    """Tests that simultaneous SQL + config change applies both via CREATE OR ALTER.
+
+    Validates that when a dynamic table's SQL definition and a tracked
+    configuration field (target_lag) change in the same run, CREATE OR ALTER
+    is used and both the new SQL and the new config take effect.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "dt_sql_and_config.sql": models.DYNAMIC_TABLE,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, project, setup_class):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        update_model(project, "dt_sql_and_config", models.DYNAMIC_TABLE)
+
+    def test_sql_and_config_change_applies_both(self, project):
+        dt_before = describe_dynamic_table(project, "dt_sql_and_config")
+        assert dt_before.target_lag == "2 minutes"
+
+        update_model(
+            project, "dt_sql_and_config", models.DYNAMIC_TABLE_EXTRA_COLUMN_TARGET_LAG_FIVE
+        )
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs)
+        assert_message_in_logs("create or alter dynamic table", logs)
+
+        dt_after = describe_dynamic_table(project, "dt_sql_and_config")
+        assert dt_after.target_lag == "5 minutes"
+
+        columns = project.run_sql(
+            f"select column_name from information_schema.columns "
+            f"where table_schema = upper('{project.test_schema}') "
+            f"and table_name = upper('dt_sql_and_config')",
+            fetch="all",
+        )
+        column_names = {row[0].upper() for row in columns}
+        assert "EXTRA_COL" in column_names
+
+
+class TestIcebergTargetLagChangeUsesAlter:
+    """Tests that target_lag change on Iceberg DT uses ALTER SET (not REPLACE)."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "iceberg_lag.sql": models.DYNAMIC_ICEBERG_TABLE,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, project, setup_class):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        update_model(project, "iceberg_lag", models.DYNAMIC_ICEBERG_TABLE)
+
+    def test_iceberg_target_lag_change_uses_alter(self, project):
+        dt_before = describe_dynamic_table(project, "iceberg_lag")
+        assert dt_before.target_lag == "2 minutes"
+
+        update_model(project, "iceberg_lag", models.DYNAMIC_ICEBERG_TABLE_ALTER)
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying ALTER to:", logs)
+        assert_message_in_logs("alter dynamic table", logs)
+        assert_message_in_logs(
+            "create or replace dynamic iceberg table", logs, expected_pass=False
+        )
+
+        dt_after = describe_dynamic_table(project, "iceberg_lag")
+        assert dt_after.target_lag == "5 minutes"
+
+
+class TestWarehouseChangeAppliesAlter:
+    """Tests that snowflake_warehouse change is applied via CREATE OR ALTER (INFO_SCHEMA).
+
+    Skipped gracefully if SNOWFLAKE_TEST_ALT_WAREHOUSE is not distinct from DBT_TESTING.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "dt_warehouse.sql": models.DYNAMIC_TABLE,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, project, setup_class):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        update_model(project, "dt_warehouse", models.DYNAMIC_TABLE)
+
+    def test_warehouse_change_applies_alter(self, project):
+        if ALT_WAREHOUSE.upper() == "DBT_TESTING":
+            pytest.skip(
+                "SNOWFLAKE_TEST_ALT_WAREHOUSE is not distinct from DBT_TESTING; "
+                "cannot validate warehouse change."
+            )
+
+        dt_before = describe_dynamic_table(project, "dt_warehouse")
+        assert dt_before.snowflake_warehouse == "DBT_TESTING"
+
+        update_model(project, "dt_warehouse", models.DYNAMIC_TABLE_ALT_WAREHOUSE)
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs)
+        assert_message_in_logs("create or alter dynamic table", logs)
+
+        dt_after = describe_dynamic_table(project, "dt_warehouse")
+        assert dt_after.snowflake_warehouse.upper() == ALT_WAREHOUSE.upper()
+
+
+class TestIcebergInitWarehouseAlter:
+    """Tests that Iceberg initialization_warehouse value change uses ALTER SET."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "iceberg_init_wh_alter.sql": models.DYNAMIC_ICEBERG_TABLE_WITH_INIT_WAREHOUSE,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, project, setup_class):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        update_model(
+            project, "iceberg_init_wh_alter", models.DYNAMIC_ICEBERG_TABLE_WITH_INIT_WAREHOUSE
+        )
+
+    def test_iceberg_init_warehouse_value_change(self, project):
+        if ALT_WAREHOUSE.upper() == "DBT_TESTING":
+            pytest.skip(
+                "SNOWFLAKE_TEST_ALT_WAREHOUSE is not distinct from DBT_TESTING; "
+                "cannot validate initialization_warehouse value change."
+            )
+
+        dt_before = describe_dynamic_table(project, "iceberg_init_wh_alter")
+        assert dt_before.snowflake_initialization_warehouse == ALT_WAREHOUSE
+
+        update_model(
+            project,
+            "iceberg_init_wh_alter",
+            models.DYNAMIC_ICEBERG_TABLE_WITH_INIT_WAREHOUSE_ALTER,
+        )
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying ALTER to:", logs)
+        assert_message_in_logs("alter dynamic table", logs)
+
+        dt_after = describe_dynamic_table(project, "iceberg_init_wh_alter")
+        assert dt_after.snowflake_initialization_warehouse == "DBT_TESTING"

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_configuration_changes.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_configuration_changes.py
@@ -113,8 +113,10 @@ class Changes:
     def test_full_refresh_is_always_successful(self, project):
         # this always passes and always changes the configuration, regardless of on_configuration_change
         # and regardless of whether the changes require a replace versus an alter
-        run_dbt(["run", "--full-refresh"])
+        _, logs = run_dbt_and_capture(["--debug", "run", "--full-refresh"])
         self.assert_changes_are_applied(project)
+        assert_message_in_logs("create or replace dynamic table", logs)
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs, expected_pass=False)
 
 
 class TestChangesApply(Changes):
@@ -124,8 +126,11 @@ class TestChangesApply(Changes):
 
     def test_changes_are_applied(self, project):
         # this passes and changes the configuration
-        run_dbt(["run"])
+        _, logs = run_dbt_and_capture(["--debug", "run"])
         self.assert_changes_are_applied(project)
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs)
+        assert_message_in_logs("create or alter dynamic table", logs)
+        assert_message_in_logs("create or replace dynamic table", logs, expected_pass=False)
 
 
 class TestChangesContinue(Changes):
@@ -463,10 +468,12 @@ class TestTransientChanges:
 
         # Update to non-transient
         update_model(project, "dynamic_table_transient", models.DYNAMIC_TABLE_NON_TRANSIENT)
-        run_dbt(["run"])
+        _, logs = run_dbt_and_capture(["--debug", "run"])
 
-        # Verify transient was changed (requires full refresh/recreation)
+        # Verify transient was changed via CREATE OR REPLACE (not CREATE OR ALTER)
         assert query_transient_status(project, "dynamic_table_transient") is False
+        assert_message_in_logs("create or replace dynamic table", logs)
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs, expected_pass=False)
 
 
 class TestNonTransientChanges:
@@ -510,10 +517,12 @@ class TestNonTransientChanges:
 
         # Update to transient
         update_model(project, "dynamic_table_non_transient", models.DYNAMIC_TABLE_TRANSIENT)
-        run_dbt(["run"])
+        _, logs = run_dbt_and_capture(["--debug", "run"])
 
-        # Verify transient was changed (requires full refresh/recreation)
+        # Verify transient was changed via CREATE OR REPLACE (not CREATE OR ALTER)
         assert query_transient_status(project, "dynamic_table_non_transient") is True
+        assert_message_in_logs("create or replace transient dynamic table", logs)
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs, expected_pass=False)
 
 
 class TestTransientBehaviorFlagDisabled:
@@ -675,3 +684,259 @@ class TestNoTransientConfigDoesNotRecreateNonTransientTable:
 
         # Table should still be non-transient -- untouched despite flag=ON
         assert query_transient_status(project, "dynamic_table_default") is False
+
+
+class TestSqlOnlyChangeIsNoop:
+    """Changing only the SQL body (query) must NOT trigger CREATE OR ALTER
+    because configuration change detection does not compare the SQL definition."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_sql_only_change.sql": models.DYNAMIC_TABLE}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def test_sql_only_change_is_noop(self, project):
+        fqn = f"{project.database}.{project.test_schema}.dt_sql_only_change"
+        run_dbt(["run", "--full-refresh"])
+
+        # change only the SQL, not the config
+        update_model(project, "dt_sql_only_change", models.DYNAMIC_TABLE_EXTRA_COLUMN)
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("No configuration changes were identified on:", logs)
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs, expected_pass=False)
+        assert_message_in_logs(f"create or replace dynamic table {fqn}", logs, expected_pass=False)
+
+
+class _NoChangeIsNoopBase:
+    """Re-running with identical config must NOT trigger CREATE OR ALTER.
+
+    Subclasses set MODEL_SQL to exercise different cluster_by shapes and catch
+    format mismatches between dbt config and SHOW DYNAMIC TABLES output
+    (e.g. Snowflake wrapping simple columns with LINEAR(...)).
+    """
+
+    MODEL_SQL: str  # override in subclasses
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_no_change.sql": self.MODEL_SQL}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def _assert_no_change(self, dbt_command):
+        run_dbt(["run", "--full-refresh"])
+        _, logs = run_dbt_and_capture(["--debug"] + dbt_command)
+
+        assert_message_in_logs("No configuration changes were identified on:", logs)
+        assert_message_in_logs("Applying CREATE OR ALTER to:", logs, expected_pass=False)
+
+    def test_no_change_run_is_noop(self, project):
+        self._assert_no_change(["run"])
+
+    def test_no_change_build_is_noop(self, project):
+        self._assert_no_change(["build"])
+
+
+class TestNoChangeFullConfig(_NoChangeIsNoopBase):
+    """Full config with cluster_by=["HASH(id)", "id"], initialization_warehouse, scheduler."""
+
+    MODEL_SQL = models.DYNAMIC_TABLE_FULL_CONFIG
+
+
+class TestNoChangeClusterBySingleColumn(_NoChangeIsNoopBase):
+    """Single plain column cluster_by — Snowflake wraps it with LINEAR(...)."""
+
+    MODEL_SQL = models.DYNAMIC_TABLE_CLUSTER_BY_SINGLE
+
+
+class TestNoChangeClusterByTwoColumns(_NoChangeIsNoopBase):
+    """Two plain columns cluster_by — Snowflake wraps them with LINEAR(...)."""
+
+    MODEL_SQL = models.DYNAMIC_TABLE_CLUSTER_BY_TWO_COLUMNS
+
+
+class TestIcebergInitializationWarehouseChanges:
+    """Tests for initialization_warehouse ALTER on dynamic iceberg tables."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "iceberg_init_wh.sql": models.DYNAMIC_ICEBERG_TABLE_WITH_INIT_WAREHOUSE,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, project, setup_class):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        update_model(project, "iceberg_init_wh", models.DYNAMIC_ICEBERG_TABLE_WITH_INIT_WAREHOUSE)
+
+    def test_iceberg_create_with_initialization_warehouse(self, project):
+        dt = describe_dynamic_table(project, "iceberg_init_wh")
+        assert dt.snowflake_initialization_warehouse == ALT_WAREHOUSE
+
+    def test_iceberg_unset_initialization_warehouse(self, project):
+        dt_before = describe_dynamic_table(project, "iceberg_init_wh")
+        assert dt_before.snowflake_initialization_warehouse == ALT_WAREHOUSE
+
+        # Remove initialization_warehouse
+        update_model(
+            project, "iceberg_init_wh", models.DYNAMIC_ICEBERG_TABLE_WITHOUT_INIT_WAREHOUSE
+        )
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying ALTER to:", logs)
+        assert_message_in_logs("alter dynamic table", logs)
+        dt_after = describe_dynamic_table(project, "iceberg_init_wh")
+        assert dt_after.snowflake_initialization_warehouse is None
+
+
+class TestIcebergImmutableWhereChanges:
+    """Tests for immutable_where ALTER on dynamic iceberg tables."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "iceberg_immutable.sql": models.DYNAMIC_ICEBERG_TABLE_WITH_IMMUTABLE_WHERE,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, project, setup_class):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        update_model(
+            project, "iceberg_immutable", models.DYNAMIC_ICEBERG_TABLE_WITH_IMMUTABLE_WHERE
+        )
+
+    def test_iceberg_create_with_immutable_where(self, project):
+        dt = describe_dynamic_table(project, "iceberg_immutable")
+        assert dt.immutable_where == "id < 100"
+
+    def test_iceberg_alter_immutable_where(self, project):
+        # Change immutable_where from 'id < 100' to 'id < 50'
+        update_model(
+            project, "iceberg_immutable", models.DYNAMIC_ICEBERG_TABLE_WITH_IMMUTABLE_WHERE_ALTER
+        )
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying ALTER to:", logs)
+        dt_after = describe_dynamic_table(project, "iceberg_immutable")
+        assert dt_after.immutable_where == "id < 50"
+
+    def test_iceberg_unset_immutable_where(self, project):
+        # Remove immutable_where entirely
+        update_model(
+            project, "iceberg_immutable", models.DYNAMIC_ICEBERG_TABLE_WITHOUT_IMMUTABLE_WHERE
+        )
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying ALTER to:", logs)
+        dt_after = describe_dynamic_table(project, "iceberg_immutable")
+        assert dt_after.immutable_where is None
+
+
+class TestIcebergClusterByChanges:
+    """Tests for cluster_by ALTER on dynamic iceberg tables."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "iceberg_cluster.sql": models.DYNAMIC_ICEBERG_TABLE_WITH_CLUSTER_BY,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, project, setup_class):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        update_model(project, "iceberg_cluster", models.DYNAMIC_ICEBERG_TABLE_WITH_CLUSTER_BY)
+
+    def test_iceberg_create_with_cluster_by(self, project):
+        dt = describe_dynamic_table(project, "iceberg_cluster")
+        assert dt.cluster_by == "id"
+
+    def test_iceberg_alter_cluster_by(self, project):
+        # Change cluster_by from 'id' to 'value'
+        update_model(
+            project, "iceberg_cluster", models.DYNAMIC_ICEBERG_TABLE_WITH_CLUSTER_BY_ALTER
+        )
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying ALTER to:", logs)
+        dt_after = describe_dynamic_table(project, "iceberg_cluster")
+        assert dt_after.cluster_by == "value"
+
+    def test_iceberg_drop_cluster_by(self, project):
+        # Remove cluster_by entirely
+        update_model(project, "iceberg_cluster", models.DYNAMIC_ICEBERG_TABLE_WITHOUT_CLUSTER_BY)
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying ALTER to:", logs)
+        dt_after = describe_dynamic_table(project, "iceberg_cluster")
+        assert dt_after.cluster_by is None

--- a/dbt-snowflake/tests/unit/test_dynamic_table_config.py
+++ b/dbt-snowflake/tests/unit/test_dynamic_table_config.py
@@ -566,13 +566,35 @@ class TestSchedulerValidation:
         )
         return relation_config
 
-    def test_scheduler_enable_invalid_when_target_lag_none(self):
-        relation_config = self._make_relation_config(scheduler="ENABLE", target_lag=None)
+    def test_no_target_lag_no_scheduler_defaults_to_disable(self):
+        """Case 1: no target_lag, no scheduler -> scheduler inferred as DISABLE."""
+        relation_config = self._make_relation_config(scheduler=None, target_lag=None)
 
-        with pytest.raises(CompilationError, match="requires `target_lag`"):
-            SnowflakeDynamicTableConfig.from_relation_config(relation_config)
+        config = SnowflakeDynamicTableConfig.from_relation_config(relation_config)
 
-    def test_scheduler_disable_invalid_when_target_lag_set(self):
+        assert config.target_lag is None
+        assert config.scheduler == "DISABLE"
+
+    def test_target_lag_set_no_scheduler_defaults_to_enable(self):
+        """Case 2: target_lag set, no scheduler -> scheduler inferred as ENABLE."""
+        relation_config = self._make_relation_config(scheduler=None, target_lag="2 minutes")
+
+        config = SnowflakeDynamicTableConfig.from_relation_config(relation_config)
+
+        assert config.target_lag == "2 minutes"
+        assert config.scheduler == "ENABLE"
+
+    def test_no_target_lag_scheduler_disable_is_valid(self):
+        """Case 3: no target_lag, scheduler='DISABLE' -> valid."""
+        relation_config = self._make_relation_config(scheduler="DISABLE", target_lag=None)
+
+        config = SnowflakeDynamicTableConfig.from_relation_config(relation_config)
+
+        assert config.target_lag is None
+        assert config.scheduler == "DISABLE"
+
+    def test_target_lag_set_scheduler_disable_is_invalid(self):
+        """Case 4: target_lag set, scheduler='DISABLE' -> CompilationError."""
         relation_config = self._make_relation_config(scheduler="DISABLE", target_lag="1 hour")
 
         with pytest.raises(CompilationError, match="requires `target_lag` to be omitted"):
@@ -585,6 +607,12 @@ class TestSchedulerValidation:
 
         assert config.scheduler == "ENABLE"
         assert config.target_lag == "1 hour"
+
+    def test_scheduler_enable_invalid_when_target_lag_none(self):
+        relation_config = self._make_relation_config(scheduler="ENABLE", target_lag=None)
+
+        with pytest.raises(CompilationError, match="requires `target_lag`"):
+            SnowflakeDynamicTableConfig.from_relation_config(relation_config)
 
     def test_invalid_scheduler_literal_still_rejected(self):
         relation_config = self._make_relation_config(scheduler="ENABLED", target_lag="1 hour")


### PR DESCRIPTION
## Summary

- **Use `CREATE OR ALTER DYNAMIC TABLE` instead of `CREATE OR REPLACE`** when applying configuration changes (`on_configuration_change=apply`) to existing Snowflake dynamic tables. This preserves table state and avoids unnecessary recreation. It is expected to preserve and not reinit dynamic table in some scenario with SQL changes as well .
- **Iceberg dynamic tables continue to use `ALTER DYNAMIC TABLE`** because Snowflake does not yet support `CREATE OR ALTER DYNAMIC ICEBERG TABLE`.
- **Fix false-positive change detection** by stripping the `LINEAR(...)` wrapper Snowflake adds to `cluster_by` metadata, preventing spurious re-creation on identical re-runs.
- **`refresh_mode` changes no longer require full refresh** — they can be applied via `CREATE OR ALTER`.
- **Transient ↔ non-transient changes still require full refresh** (`CREATE OR REPLACE`), as expected.
- **Remove `row_access_policy` and `table_tag` from CREATE OR ALTER DDL** — Snowflake error 001506: `CREATE OR ALTER does not support setting policies or tags`. Including these clauses caused a hard SQL error. Policies/tags set during initial `CREATE` remain attached since Snowflake preserves them across `CREATE OR ALTER`.

Addresses: https://github.com/dbt-labs/dbt-adapters/issues/1825

## Changes

### Macros
- **`create_or_alter.sql` (new)**: Generates `CREATE OR ALTER DYNAMIC TABLE` DDL for native (non-Iceberg) dynamic tables with all supported attributes (target_lag, warehouse, refresh_mode, scheduler, initialization_warehouse, immutable_where, cluster_by). Explicitly omits `row_access_policy` and `table_tag` per Snowflake limitation (error 001506).
- **`alter.sql` (modified)**: Refactored to serve Iceberg tables only. Renamed macro to `snowflake__alter_dynamic_table_built_in_sql`. Removed the `requires_full_refresh` branch (handled by caller).
- **`dynamic_table.sql`**: Updated `apply` branch to call `snowflake__get_create_or_alter_dynamic_table_sql` instead of the old alter macro.

### Python
- **`dynamic_table.py`**: Strip `LINEAR(...)` wrapper from Snowflake's `cluster_by` metadata to prevent false-positive change detection. `refresh_mode` changes no longer require full refresh.

### Tests
- Verify `CREATE OR ALTER` DDL for apply path, `CREATE OR REPLACE` for full refresh
- No-op detection for identical configs across `dbt run` and `dbt build` (various `cluster_by` shapes: expression, single column, two columns)
- SQL-only model changes do not trigger `CREATE OR ALTER`
- Iceberg ALTER path for `initialization_warehouse`, `immutable_where`, `cluster_by`
- Transient changes trigger `CREATE OR REPLACE`, not `CREATE OR ALTER`
- Extended scheduler validation unit tests
- **NEW**: `CREATE OR ALTER` succeeds on DTs with `row_access_policy` or `table_tag` (policy/tag omitted from DDL, preserved by Snowflake)
- **NEW**: Policy/tag-only changes documented as no-ops (known limitation: dbt change detection does not track these fields)

## Test plan

- [x] All 237 Snowflake unit tests pass
- [x] All 65 dynamic table integration tests pass (native + Iceberg, including 4 new policy/tag tests)
- [x] Manual verification: `dbt run` and `dbt build` with no config changes produce no DDL
- [x] Manual verification: `dbt build --debug` no longer triggers spurious `CREATE OR ALTER`

Resolves #1825


Made with [Cursor](https://cursor.com)