### PR TITLE
fix(functions): drop existing function on --full-refresh to handle signature changes

### DIFF
--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/functions/function.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/functions/function.sql
@@ -4,6 +4,12 @@
 
     {{ run_hooks(pre_hooks) }}
 
+    {# Drop the existing function when --full-refresh is requested to handle signature changes
+       (e.g. renamed parameters or changed return types) that CREATE OR REPLACE cannot apply. #}
+    {% if should_full_refresh() %}
+        {{ drop_relation_if_exists(existing_relation) }}
+    {% endif %}
+
     {% set function_config = this.get_function_config(model) %}
     {% set macro_name = this.get_function_macro_name(function_config) %}
 


### PR DESCRIPTION

Fixes dbt-labs/dbt-core #12708

PostgreSQL's `CREATE OR REPLACE FUNCTION` cannot rename parameters or change return types on an existing function — it raises errors like:
- `cannot change name of input parameter`  
- `cannot change return type of existing function`

When `--full-refresh` is set, users expect the function to be fully rebuilt. This fix drops the existing function first so the subsequent `CREATE OR REPLACE FUNCTION` succeeds regardless of signature changes.

## Changes

- In the global `function` materialization (`function.sql`), call `drop_relation_if_exists` on the existing relation when `should_full_refresh()` is true — mirroring how `incremental` and `table` materializations handle full-refresh.
- The generated SQL uses the existing `default__get_drop_sql` fallback: `DROP FUNCTION IF EXISTS <name> CASCADE`, which is safe for all adapters.

## Behavior

| Scenario | Before | After |
|---|---|---|
| `dbt run` (no full-refresh) | Works | Works (unchanged) |
| `dbt run --full-refresh`, same signature | Works | Works |
| `dbt run --full-refresh`, **changed signature** | Fails with Postgres error | **Fixed** |