### PR TITLE
bigquery: gate MicrobatchConcurrency on use_concurrent_microbatch behavior flag

### DIFF
--- a/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
@@ -143,6 +143,19 @@ BIGQUERY_USE_STANDARD_SQL_FOR_PARTITIONS = BehaviorFlag(
     ),
 )
 
+USE_CONCURRENT_MICROBATCH = BehaviorFlag(
+    name="use_concurrent_microbatch",
+    default=False,
+    description=(
+        "Enable concurrent execution of microbatch incremental batches on BigQuery. "
+        "When enabled, dbt will run microbatch batches in parallel threads instead "
+        "of sequentially. Safe when batches write to disjoint partitions (as implied "
+        "by a well-chosen `partition_by`) — BigQuery applies concurrent MERGE "
+        "statements atomically under snapshot isolation. Users are responsible for "
+        "ensuring batches do not overlap in partition_key range."
+    ),
+)  # type: ignore[typeddict-item]
+
 _dataset_lock = threading.Lock()
 
 
@@ -209,6 +222,12 @@ class BigQueryAdapter(BaseAdapter):
         }
     )
 
+    def supports(self, capability: Capability) -> bool:
+        # Gate MicrobatchConcurrency on the use_concurrent_microbatch behavior flag.
+        if capability == Capability.MicrobatchConcurrency:
+            return bool(self.behavior.use_concurrent_microbatch)
+        return super().supports(capability)
+
     def __init__(self, config, mp_context: SpawnContext) -> None:
         super().__init__(config, mp_context)
         self.connections: BigQueryConnectionManager = self.connections
@@ -226,6 +245,7 @@ class BigQueryAdapter(BaseAdapter):
             BIGQUERY_NOOP_ALTER_RELATION_COMMENT,
             BIGQUERY_REJECT_WILDCARD_METADATA_SOURCE_FRESHNESS,
             BIGQUERY_USE_STANDARD_SQL_FOR_PARTITIONS,
+            USE_CONCURRENT_MICROBATCH,
         ]
 
     def get_partitions_metadata(self, table):


### PR DESCRIPTION
## Resolves / relates to

Resolves [#766](https://github.com/dbt-labs/dbt-adapters/issues/766).

## Why

The BigQuery adapter currently does not declare `Capability.MicrobatchConcurrency`, so dbt-core runs microbatch batches sequentially and emits the warning:

> `Found N microbatch models with the concurrent_batches config set to true, but the bigquery adapter does not support running batches concurrently. Batches will be run sequentially.`

For models whose `partition_by` produces disjoint partition ranges per batch (the common case for hourly microbatches), sequential execution multiplies wall-clock by the batch count with no correctness benefit. Users in #766 and elsewhere report this makes microbatch on BigQuery prohibitively slow for high-cardinality hourly pipelines.

## What this PR does

Mirrors the [dbt-databricks concurrent-microbatch rollout pattern](https://github.com/databricks/dbt-databricks/) exactly:

1. Adds a `USE_CONCURRENT_MICROBATCH` `BehaviorFlag` (default `False`) with a description documenting the correctness contract.
2. Registers the flag in `BigQueryAdapter._behavior_flags`.
3. Overrides `supports()` to return `True` for `Capability.MicrobatchConcurrency` iff the flag is enabled. All other capability checks delegate to `super().supports()`.

Opt-in only. Default behavior for existing projects is unchanged.

## Why the correctness contract is safe on BigQuery

- BigQuery applies concurrent DML under **snapshot isolation** — `MERGE` statements writing to disjoint partitions can run concurrently and the final table state is deterministic.
- The 1,000 DML statements/day per-table quota was removed in 2020 ([DML without limits, now in BigQuery](https://cloud.google.com/blog/products/data-analytics/dml-without-limits-now-in-bigquery)).
- The microbatch materialization (`bq_generate_microbatch_build_sql`) has no serial-ordering assumptions — it delegates per batch to `bq_insert_overwrite_sql`.

The behavior flag documents that users are responsible for ensuring `partition_by` produces disjoint partitions across batches (true for `TIMESTAMP_TRUNC` expressions and similar; violated only by partitioning on non-batch-scoped expressions).

## Reviewer notes

- Single-file change, ~20 LoC.
- Pattern 1:1 with `dbt-databricks` — existing maintainer familiarity.
- No changes to existing capabilities or materialization macros.
- Default `False` → opt-in only → no behavior change for users who don't set the flag.
