### PR TITLE
fix(snowflake): remove target_file_size from Iceberg REST catalog test fixtures

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Under the Hood-20260417-164156.yaml
+++ b/dbt-snowflake/.changes/unreleased/Under the Hood-20260417-164156.yaml
@@ -2,5 +2,5 @@ kind: Under the Hood
 body: Remove target_file_size from Iceberg REST catalog test fixtures to fix privilege errors caused by a Snowflake platform change
 time: 2026-04-17T16:41:56.525658+05:30
 custom:
-    Author: aahelguha
+    Author: aahel
     Issue: N/A

--- a/dbt-snowflake/.changes/unreleased/Under the Hood-20260417-164156.yaml
+++ b/dbt-snowflake/.changes/unreleased/Under the Hood-20260417-164156.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove target_file_size from Iceberg REST catalog test fixtures to fix privilege errors caused by a Snowflake platform change
+time: 2026-04-17T16:41:56.525658+05:30
+custom:
+    Author: aahelguha
+    Issue: N/A

--- a/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_iceberg_rest_catalog_integrations.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_iceberg_rest_catalog_integrations.py
@@ -13,7 +13,7 @@ MODEL__BASIC_ICEBERG_TABLE = """
 
 MODEL__ICEBERG_TABLE_WITH_CATALOG_CONFIG = """
                             {{ config(materialized='table', catalog_name='basic_iceberg_rest_catalog',
-                            target_file_size='16MB', max_data_extension_time_in_days=1, auto_refresh='true') }}
+                            max_data_extension_time_in_days=1, auto_refresh='true') }}
                             select 1 as id
                             """
 
@@ -70,7 +70,6 @@ class TestSnowflakeIcebergRestCatalogIntegration(BaseCatalogIntegrationValidatio
                                 ),
                                 # No catalog_linked_database_type means standard CTAS is used
                                 "max_data_extension_time_in_days": 1,
-                                "target_file_size": "AUTO",
                                 "auto_refresh": "true",
                             },
                         }
@@ -126,7 +125,6 @@ class TestSnowflakeIcebergRestGlueCatalogIntegration(BaseCatalogIntegrationValid
                                 ),
                                 "catalog_linked_database_type": "glue",  # Glue requires 4-step process
                                 "max_data_extension_time_in_days": 1,
-                                "target_file_size": "AUTO",
                                 "auto_refresh": "true",
                             },
                         }
@@ -188,7 +186,7 @@ class TestSnowflakeIcebergRestGlueCatalogIntegration(BaseCatalogIntegrationValid
                 """,
                 "glue_iceberg_table_with_catalog_config.sql": """
                     {{ config(materialized='table', catalog_name='glue_iceberg_rest_catalog',
-                    target_file_size='16MB', max_data_extension_time_in_days=1, auto_refresh='true') }}
+                    max_data_extension_time_in_days=1, auto_refresh='true') }}
                     select 1 as id
                 """,
             }

--- a/dbt-snowflake/tests/functional/iceberg/test_iceberg_partition_by.py
+++ b/dbt-snowflake/tests/functional/iceberg/test_iceberg_partition_by.py
@@ -153,7 +153,6 @@ class TestIcebergPartitionBy(BaseCatalogIntegrationValidation):
                                     "SNOWFLAKE_TEST_CATALOG_LINKED_DATABASE"
                                 ),
                                 "max_data_extension_time_in_days": 1,
-                                "target_file_size": "AUTO",
                                 "auto_refresh": "true",
                             },
                         }
@@ -173,7 +172,6 @@ class TestIcebergPartitionBy(BaseCatalogIntegrationValidation):
                                 ),
                                 "catalog_linked_database_type": "glue",  # Glue requires 4-step process
                                 "max_data_extension_time_in_days": 1,
-                                "target_file_size": "AUTO",
                                 "auto_refresh": "true",
                             },
                         }


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

### Problem

A Snowflake platform change causes `target_file_size` to fail with a privilege error during Iceberg table creation in Catalog Linked Databases (CLDs), regardless of the value (`AUTO`, `16MB`, etc.):

```
SQL access control error: Insufficient privileges to operate on schema '...'
```

### Solution

Remove `target_file_size` from Iceberg REST catalog test fixtures and model configs. The property is currently non-functional during `CREATE ICEBERG TABLE` in CLDs at the Snowflake platform level (likely a bug or undocumented restriction — worth a Snowflake support ticket). Removing it from these CLD-specific tests does not lose meaningful coverage since the feature itself is unavailable in this context.

Verified by testing both `AUTO` and `16MB` — both fail. A plain `CREATE ICEBERG TABLE ... AS SELECT` without `target_file_size` succeeds.

Affected test files:
- `tests/functional/adapter/catalog_integrations/test_iceberg_rest_catalog_integrations.py`
- `tests/functional/iceberg/test_iceberg_partition_by.py`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX