### PR TITLE
Flip old behaviour flags 1.12

### DIFF
--- a/dbt-adapters/.changes/unreleased/Under the Hood-20260417-164454.yaml
+++ b/dbt-adapters/.changes/unreleased/Under the Hood-20260417-164454.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: enable_truthy_nulls_equals_macro is now enabled by default
+time: 2026-04-17T16:44:54.257701+05:30
+custom:
+    Author: sriramr98
+    Issue: "1875"

--- a/dbt-adapters/src/dbt/adapters/base/impl.py
+++ b/dbt-adapters/src/dbt/adapters/base/impl.py
@@ -127,7 +127,7 @@ DEFAULT_BASE_BEHAVIOR_FLAGS = [
     },
     {
         "name": "enable_truthy_nulls_equals_macro",
-        "default": False,
+        "default": True,
         "docs_url": "",
     },
 ]


### PR DESCRIPTION
resolves #1875
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

There are a lot of behaviour flags we introduced in 1.9 and 1.10 that have reached maturity. We need to flip these flags to default to true so that the intended behaviour takes effect from 1.12


<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Flipped `enable_truthy_nulls_equals_macro` to true by default

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
