### PR TITLE
mutate copy for TestQueryTimeout to avoid spilling query_timeout

### DIFF
--- a/dbt-spark/tests/functional/adapter/test_query_timeout.py
+++ b/dbt-spark/tests/functional/adapter/test_query_timeout.py
@@ -56,11 +56,17 @@ class TestQueryTimeout:
 
     @pytest.fixture(scope="class")
     def dbt_profile_target(self, dbt_profile_target):
-        """Override profile to add timeout configuration."""
-        dbt_profile_target["query_timeout"] = 1  # 1 second timeout
-        dbt_profile_target["poll_interval"] = 1  # Poll every second for faster test
-        dbt_profile_target["query_retries"] = 0  # Disable retries for clearer errors
-        return dbt_profile_target
+        """Override profile to add timeout configuration.
+
+        Copy before mutating — the parent fixture is session-scoped, so
+        in-place mutation leaks query_timeout=1 into every later test on
+        the same worker and makes their seeds/queries time out.
+        """
+        overrides = dict(dbt_profile_target)
+        overrides["query_timeout"] = 1  # 1 second timeout
+        overrides["poll_interval"] = 1  # Poll every second for faster test
+        overrides["query_retries"] = 0  # Disable retries for clearer errors
+        return overrides
 
     def test_query_timeout_exceeded(self, project):
         """Test that queries exceeding timeout raise appropriate error."""

--- a/dbt-spark/tests/functional/adapter/test_query_timeout.py
+++ b/dbt-spark/tests/functional/adapter/test_query_timeout.py
@@ -4,6 +4,7 @@ NOTE: These tests only work with PyHive-based connections (http/thrift methods).
 ODBC connections use PyodbcConnectionWrapper which doesn't have timeout/retry support yet.
 """
 
+import copy
 import pytest
 from dbt.tests.util import run_dbt, run_dbt_and_capture
 from dbt_common.exceptions import DbtRuntimeError
@@ -62,7 +63,7 @@ class TestQueryTimeout:
         in-place mutation leaks query_timeout=1 into every later test on
         the same worker and makes their seeds/queries time out.
         """
-        overrides = dict(dbt_profile_target)
+        overrides = copy.deepcopy(dbt_profile_target)
         overrides["query_timeout"] = 1  # 1 second timeout
         overrides["poll_interval"] = 1  # Poll every second for faster test
         overrides["query_retries"] = 0  # Disable retries for clearer errors


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
Spark integration tests are flaky due to test query timeout causing a side effect of mutating query_timeout to 1s for all followed tests.

### Solution
Mutate the copy of profile instead of mutating the original fixture.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
