### PR TITLE
feat(athena): add use_iceberg_write_to config for Iceberg Python models

### DIFF
--- a/dbt-athena/.changes/unreleased/Features-20260422-013953.yaml
+++ b/dbt-athena/.changes/unreleased/Features-20260422-013953.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add use_iceberg_write_to config for Iceberg Python models
+time: 2026-04-22T01:39:53.640855+09:00
+custom:
+    Author: dtaniwaki
+    Issue: "1882"

--- a/dbt-athena/src/dbt/include/athena/macros/adapters/python_submissions.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/adapters/python_submissions.sql
@@ -46,18 +46,21 @@ def materialize(spark_session, df, target_relation):
             return F.years(F.col(args[0]))
         if func in ("hour", "hours"):
             return F.hours(F.col(args[0]))
-        if func == "bucket":
-            return F.bucket(int(args[1]), F.col(args[0]))
-        if func == "truncate":
-            return F.truncate(int(args[1]), F.col(args[0]))
+        if func in ("bucket", "truncate"):
+            if len(args) != 2:
+                raise ValueError(
+                    f"Iceberg partition transform '{func}' requires 2 arguments (column, n), got: {expr_str}"
+                )
+            n = int(args[1])
+            return F.bucket(n, F.col(args[0])) if func == "bucket" else F.truncate(n, F.col(args[0]))
         raise ValueError(f"Unknown Iceberg partition transform: {func}")
 
     _writer = df.writeTo("{{ target_relation.schema | replace('\"', '`') }}.{{ target_relation.identifier | replace('\"', '`') }}")
     _writer = _writer.using("iceberg")
-    _writer = _writer.tableProperty("location", "{{ location }}/")
+    _writer = _writer.tableProperty("location", {{ (location ~ "/") | tojson }})
     {% if extra_table_properties is not none %}
     {% for prop_name, prop_value in extra_table_properties.items() %}
-    _writer = _writer.tableProperty("{{ prop_name }}", "{{ prop_value }}")
+    _writer = _writer.tableProperty({{ prop_name | tojson }}, {{ prop_value | string | tojson }})
     {% endfor %}
     {% endif %}
     {% if partitioned_by is not none %}

--- a/dbt-athena/src/dbt/include/athena/macros/adapters/python_submissions.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/adapters/python_submissions.sql
@@ -9,7 +9,6 @@
     {% set merge_schema = optional_args.get("merge_schema", true) %}
     {% set bucket_count = optional_args.get("bucket_count") %}
     {% set field_delimiter = optional_args.get("field_delimiter") %}
-    {% set table_type = optional_args.get("table_type", "") %}
     {% set extra_table_properties = optional_args.get("extra_table_properties") %}
     {% set use_iceberg_write_to = optional_args.get("use_iceberg_write_to", false) %}
     {% set spark_ctas = optional_args.get("spark_ctas", "") %}

--- a/dbt-athena/src/dbt/include/athena/macros/adapters/python_submissions.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/adapters/python_submissions.sql
@@ -9,6 +9,9 @@
     {% set merge_schema = optional_args.get("merge_schema", true) %}
     {% set bucket_count = optional_args.get("bucket_count") %}
     {% set field_delimiter = optional_args.get("field_delimiter") %}
+    {% set table_type = optional_args.get("table_type", "") %}
+    {% set extra_table_properties = optional_args.get("extra_table_properties") %}
+    {% set use_iceberg_write_to = optional_args.get("use_iceberg_write_to", false) %}
     {% set spark_ctas = optional_args.get("spark_ctas", "") %}
 
 import pyspark
@@ -25,7 +28,48 @@ def materialize(spark_session, df, target_relation):
         msg = f"{type(df)} is not a supported type for dbt Python materialization"
         raise Exception(msg)
 
-{% if spark_ctas|length > 0 %}
+{% if use_iceberg_write_to %}
+    import re
+    from pyspark.sql import functions as F
+
+    def _parse_iceberg_partition(expr_str):
+        expr_str = expr_str.strip()
+        m = re.match(r"(\w+)\((.+)\)", expr_str)
+        if not m:
+            return F.col(expr_str)
+        func = m.group(1).lower()
+        args = [a.strip() for a in m.group(2).split(",")]
+        if func in ("day", "days"):
+            return F.days(F.col(args[0]))
+        if func in ("month", "months"):
+            return F.months(F.col(args[0]))
+        if func in ("year", "years"):
+            return F.years(F.col(args[0]))
+        if func in ("hour", "hours"):
+            return F.hours(F.col(args[0]))
+        if func == "bucket":
+            return F.bucket(int(args[1]), F.col(args[0]))
+        if func == "truncate":
+            return F.truncate(int(args[1]), F.col(args[0]))
+        raise ValueError(f"Unknown Iceberg partition transform: {func}")
+
+    _writer = df.writeTo("{{ target_relation.schema | replace('\"', '`') }}.{{ target_relation.identifier | replace('\"', '`') }}")
+    _writer = _writer.using("iceberg")
+    _writer = _writer.tableProperty("location", "{{ location }}/")
+    {% if extra_table_properties is not none %}
+    {% for prop_name, prop_value in extra_table_properties.items() %}
+    _writer = _writer.tableProperty("{{ prop_name }}", "{{ prop_value }}")
+    {% endfor %}
+    {% endif %}
+    {% if partitioned_by is not none %}
+    _writer = _writer.partitionedBy(
+        {%- for part_expr in partitioned_by %}
+        _parse_iceberg_partition("{{ part_expr }}"){{ "," if not loop.last }}
+        {%- endfor %}
+    )
+    {% endif %}
+    _writer.createOrReplace()
+{% elif spark_ctas|length > 0 %}
     df.createOrReplaceTempView("{{ target_relation.schema}}_{{ target_relation.identifier }}_tmpvw")
     spark_session.sql("""
     {{ spark_ctas }}

--- a/dbt-athena/src/dbt/include/athena/macros/adapters/python_submissions.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/adapters/python_submissions.sql
@@ -64,7 +64,7 @@ def materialize(spark_session, df, target_relation):
     {% if partitioned_by is not none %}
     _writer = _writer.partitionedBy(
         {%- for part_expr in partitioned_by %}
-        _parse_iceberg_partition("{{ part_expr }}"){{ "," if not loop.last }}
+        _parse_iceberg_partition({{ part_expr | tojson }}){{ "," if not loop.last }}
         {%- endfor %}
     )
     {% endif %}

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -89,7 +89,6 @@
           'write_compression': write_compression,
           'bucket_count': bucket_count,
           'field_delimiter': field_delimiter,
-          'table_type': table_type,
           'extra_table_properties': extra_table_properties,
           'use_iceberg_write_to': use_iceberg_write_to,
           'spark_ctas': spark_ctas,

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -43,8 +43,9 @@
   {%- endif -%}
 
   {%- if language == 'python' -%}
+    {%- set use_iceberg_write_to = config.get('use_iceberg_write_to', false) -%}
     {%- set spark_ctas = '' -%}
-    {%- if table_type == 'iceberg' -%}
+    {%- if table_type == 'iceberg' and not use_iceberg_write_to -%}
       {%- set spark_ctas -%}
           create table {{ relation.schema | replace('\"', '`') }}.{{ relation.identifier | replace('\"', '`') }}
           using iceberg
@@ -85,7 +86,10 @@
           'write_compression': write_compression,
           'bucket_count': bucket_count,
           'field_delimiter': field_delimiter,
-          'spark_ctas': spark_ctas
+          'table_type': table_type,
+          'extra_table_properties': extra_table_properties,
+          'use_iceberg_write_to': use_iceberg_write_to,
+          'spark_ctas': spark_ctas,
         }
       )
     }}

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -44,6 +44,9 @@
 
   {%- if language == 'python' -%}
     {%- set use_iceberg_write_to = config.get('use_iceberg_write_to', false) -%}
+    {%- if use_iceberg_write_to and table_type != 'iceberg' -%}
+      {{ exceptions.raise_compiler_error("The 'use_iceberg_write_to' config is only supported when table_type='iceberg'.") }}
+    {%- endif -%}
     {%- set spark_ctas = '' -%}
     {%- if table_type == 'iceberg' and not use_iceberg_write_to -%}
       {%- set spark_ctas -%}

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -91,7 +91,24 @@
     {%- endif -%}
   {%- else -%}
 
-    {%- if old_relation is none -%}
+    {%- set use_iceberg_write_to = language == 'python' and config.get('use_iceberg_write_to', false) -%}
+
+    {%- if use_iceberg_write_to -%}
+      -- Python + use_iceberg_write_to: writeTo().createOrReplace() handles atomic replacement,
+      -- so we skip the __ha intermediate table and write directly to target.
+      -- Clean up leftover __ha / __bkp tables from previous HA-flow failures.
+      {%- if old_tmp_relation is not none -%}
+        {%- do drop_relation(old_tmp_relation) -%}
+      {%- endif -%}
+      {%- if old_bkp_relation is not none -%}
+        {%- do drop_relation(old_bkp_relation) -%}
+      {%- endif -%}
+      {%- set query_result = safe_create_table_as(False, target_relation, compiled_code, language, force_batch) -%}
+      {% call statement('create_table', language=language) %}
+        {{ query_result }}
+      {% endcall %}
+
+    {%- elif old_relation is none -%}
       {%- set query_result = safe_create_table_as(False, target_relation, compiled_code, language, force_batch) -%}
       -- Execute python code that is available in query result object
       {%- if language == 'python' -%}

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -103,6 +103,9 @@
       {%- if old_bkp_relation is not none -%}
         {%- do drop_relation(old_bkp_relation) -%}
       {%- endif -%}
+      {%- if old_relation is not none and old_relation.is_view -%}
+        {%- do drop_relation(old_relation) -%}
+      {%- endif -%}
       {%- set query_result = safe_create_table_as(False, target_relation, compiled_code, language, force_batch) -%}
       {% call statement('create_table', language=language) %}
         {{ query_result }}

--- a/dbt-athena/tests/functional/adapter/test_use_iceberg_write_to.py
+++ b/dbt-athena/tests/functional/adapter/test_use_iceberg_write_to.py
@@ -53,10 +53,29 @@ class TestUseIcebergWriteToPartitioned:
     def models(self):
         return {"iceberg_writeto_partitioned.py": _iceberg_writeto_partitioned}
 
-    def test_creates_partitioned_iceberg_table(self, project):
+    def test_writes_rows_and_applies_iceberg_partition_transforms(self, project):
         results = run_dbt(["run"])
         assert len(results) == 1
         assert results[0].status == "success"
+
+        records = sorted(
+            project.run_sql(
+                f"select user_id, name from {project.test_schema}.iceberg_writeto_partitioned",
+                fetch="all",
+            )
+        )
+        assert records == [(1, "a"), (2, "b"), (3, "c")]
+
+        # SHOW CREATE TABLE confirms day()/bucket() were applied as Iceberg
+        # partition transforms — not coerced into plain identity partitions
+        # (which is what the spark_ctas SQL path produces).
+        ddl = project.run_sql(
+            f"show create table {project.test_schema}.iceberg_writeto_partitioned",
+            fetch="all",
+        )
+        ddl_text = "\n".join(row[0] for row in ddl)
+        assert "day(created_at)" in ddl_text
+        assert "bucket(4, user_id)" in ddl_text
 
     def test_idempotent_replace(self, project):
         # createOrReplace must succeed against an existing target without
@@ -87,10 +106,18 @@ class TestUseIcebergWriteToUnpartitioned:
     def models(self):
         return {"iceberg_writeto_unpartitioned.py": _iceberg_writeto_unpartitioned}
 
-    def test_creates_unpartitioned_iceberg_table(self, project):
+    def test_writes_rows_without_partitions(self, project):
         results = run_dbt(["run"])
         assert len(results) == 1
         assert results[0].status == "success"
+
+        records = sorted(
+            project.run_sql(
+                f"select id from {project.test_schema}.iceberg_writeto_unpartitioned",
+                fetch="all",
+            )
+        )
+        assert records == [(1,), (2,), (3,)]
 
 
 _iceberg_writeto_with_table_properties = """
@@ -115,10 +142,25 @@ class TestUseIcebergWriteToTableProperties:
     def models(self):
         return {"iceberg_writeto_props.py": _iceberg_writeto_with_table_properties}
 
-    def test_writeto_with_table_properties(self, project):
+    def test_table_properties_are_propagated(self, project):
         results = run_dbt(["run"])
         assert len(results) == 1
         assert results[0].status == "success"
+
+        records = sorted(
+            project.run_sql(
+                f"select id from {project.test_schema}.iceberg_writeto_props",
+                fetch="all",
+            )
+        )
+        assert records == [(1,), (2,)]
+
+        props = project.run_sql(
+            f"show tblproperties {project.test_schema}.iceberg_writeto_props",
+            fetch="all",
+        )
+        props_dict = {row[0]: row[1] for row in props}
+        assert props_dict.get("format-version") == "2"
 
 
 _iceberg_writeto_on_hive_table = """

--- a/dbt-athena/tests/functional/adapter/test_use_iceberg_write_to.py
+++ b/dbt-athena/tests/functional/adapter/test_use_iceberg_write_to.py
@@ -1,0 +1,147 @@
+"""Functional tests for the use_iceberg_write_to config.
+
+The new branch in athena__py_save_table_as routes Iceberg Python models
+through DataFrameWriterV2 (writeTo().createOrReplace()) instead of the
+spark_ctas SQL path, enabling Iceberg-native partition transforms
+(day/bucket/...) and atomic replacement without the __ha intermediate
+table.
+
+Gated on DBT_TEST_ATHENA_SPARK_WORK_GROUP — same workgroup the Spark
+Connect tests use, since both paths require an Athena Spark workgroup
+with Iceberg support.
+"""
+
+import os
+
+import pytest
+
+from dbt.tests.util import run_dbt
+
+requires_spark_workgroup = pytest.mark.skipif(
+    not os.getenv("DBT_TEST_ATHENA_SPARK_WORK_GROUP"),
+    reason="DBT_TEST_ATHENA_SPARK_WORK_GROUP must point to an Athena Spark workgroup.",
+)
+
+
+_iceberg_writeto_partitioned = """
+def model(dbt, spark_session):
+    dbt.config(
+        materialized='table',
+        table_type='iceberg',
+        spark_engine_version='3.5',
+        use_iceberg_write_to=True,
+        partitioned_by=['day(created_at)', 'bucket(user_id, 4)'],
+    )
+    from pyspark.sql import functions as F
+    rows = [
+        (1, '2026-01-01 00:00:00', 'a'),
+        (2, '2026-01-02 00:00:00', 'b'),
+        (3, '2026-01-03 00:00:00', 'c'),
+    ]
+    df = spark_session.createDataFrame(rows, ['user_id', 'created_at', 'name'])
+    return df.withColumn('created_at', F.to_timestamp('created_at'))
+"""
+
+
+@requires_spark_workgroup
+class TestUseIcebergWriteToPartitioned:
+    """writeTo() with day/bucket partition transforms must produce a working
+    Iceberg table. The spark_ctas path can't express these transforms, so
+    this case is the primary motivation for the feature."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"iceberg_writeto_partitioned.py": _iceberg_writeto_partitioned}
+
+    def test_creates_partitioned_iceberg_table(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+    def test_idempotent_replace(self, project):
+        # createOrReplace must succeed against an existing target without
+        # falling through the legacy __ha rename flow.
+        run_dbt(["run"])
+        results = run_dbt(["run"])
+        assert all(r.status == "success" for r in results)
+
+
+_iceberg_writeto_unpartitioned = """
+def model(dbt, spark_session):
+    dbt.config(
+        materialized='table',
+        table_type='iceberg',
+        spark_engine_version='3.5',
+        use_iceberg_write_to=True,
+    )
+    return spark_session.createDataFrame([(1,), (2,), (3,)], ['id'])
+"""
+
+
+@requires_spark_workgroup
+class TestUseIcebergWriteToUnpartitioned:
+    """use_iceberg_write_to without partitioned_by should still succeed
+    (the partitionedBy() call is conditional on partitioned_by being set)."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"iceberg_writeto_unpartitioned.py": _iceberg_writeto_unpartitioned}
+
+    def test_creates_unpartitioned_iceberg_table(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+
+_iceberg_writeto_with_table_properties = """
+def model(dbt, spark_session):
+    dbt.config(
+        materialized='table',
+        table_type='iceberg',
+        spark_engine_version='3.5',
+        use_iceberg_write_to=True,
+        table_properties={'format-version': '2'},
+    )
+    return spark_session.createDataFrame([(1,), (2,)], ['id'])
+"""
+
+
+@requires_spark_workgroup
+class TestUseIcebergWriteToTableProperties:
+    """table_properties must be forwarded as DataFrameWriterV2 .tableProperty()
+    calls and survive JSON escaping."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"iceberg_writeto_props.py": _iceberg_writeto_with_table_properties}
+
+    def test_writeto_with_table_properties(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+
+_iceberg_writeto_on_hive_table = """
+def model(dbt, spark_session):
+    dbt.config(
+        materialized='table',
+        table_type='hive',
+        spark_engine_version='3.5',
+        use_iceberg_write_to=True,
+    )
+    return spark_session.createDataFrame([(1,)], ['id'])
+"""
+
+
+@requires_spark_workgroup
+class TestUseIcebergWriteToRequiresIceberg:
+    """use_iceberg_write_to with a non-iceberg table_type must surface a
+    compiler error rather than silently writing the wrong format."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"iceberg_writeto_invalid.py": _iceberg_writeto_on_hive_table}
+
+    def test_compiles_to_error(self, project):
+        results = run_dbt(["run"], expect_pass=False)
+        assert any("use_iceberg_write_to" in (r.message or "") for r in results)

--- a/dbt-athena/tests/functional/adapter/test_use_iceberg_write_to.py
+++ b/dbt-athena/tests/functional/adapter/test_use_iceberg_write_to.py
@@ -6,9 +6,8 @@ spark_ctas SQL path, enabling Iceberg-native partition transforms
 (day/bucket/...) and atomic replacement without the __ha intermediate
 table.
 
-Gated on DBT_TEST_ATHENA_SPARK_WORK_GROUP — same workgroup the Spark
-Connect tests use, since both paths require an Athena Spark workgroup
-with Iceberg support.
+Gated on DBT_TEST_ATHENA_SPARK_WORK_GROUP — must point to an Athena
+Spark workgroup with Iceberg support.
 """
 
 import os
@@ -28,7 +27,6 @@ def model(dbt, spark_session):
     dbt.config(
         materialized='table',
         table_type='iceberg',
-        spark_engine_version='3.5',
         use_iceberg_write_to=True,
         partitioned_by=['day(created_at)', 'bucket(user_id, 4)'],
     )
@@ -68,14 +66,15 @@ class TestUseIcebergWriteToPartitioned:
 
         # SHOW CREATE TABLE confirms day()/bucket() were applied as Iceberg
         # partition transforms — not coerced into plain identity partitions
-        # (which is what the spark_ctas SQL path produces).
+        # (which is what the spark_ctas SQL path produces). Athena renders
+        # the column names with backticks in the partition spec.
         ddl = project.run_sql(
             f"show create table {project.test_schema}.iceberg_writeto_partitioned",
             fetch="all",
         )
         ddl_text = "\n".join(row[0] for row in ddl)
-        assert "day(created_at)" in ddl_text
-        assert "bucket(4, user_id)" in ddl_text
+        assert "day(`created_at`)" in ddl_text
+        assert "bucket(4, `user_id`)" in ddl_text
 
     def test_idempotent_replace(self, project):
         # createOrReplace must succeed against an existing target without
@@ -90,7 +89,6 @@ def model(dbt, spark_session):
     dbt.config(
         materialized='table',
         table_type='iceberg',
-        spark_engine_version='3.5',
         use_iceberg_write_to=True,
     )
     return spark_session.createDataFrame([(1,), (2,), (3,)], ['id'])
@@ -125,9 +123,8 @@ def model(dbt, spark_session):
     dbt.config(
         materialized='table',
         table_type='iceberg',
-        spark_engine_version='3.5',
         use_iceberg_write_to=True,
-        table_properties={'format-version': '2'},
+        table_properties={'write.parquet.compression-codec': 'zstd'},
     )
     return spark_session.createDataFrame([(1,), (2,)], ['id'])
 """
@@ -155,12 +152,14 @@ class TestUseIcebergWriteToTableProperties:
         )
         assert records == [(1,), (2,)]
 
+        # Iceberg surfaces table properties through the $properties metadata
+        # table rather than Glue TBLPROPERTIES.
         props = project.run_sql(
-            f"show tblproperties {project.test_schema}.iceberg_writeto_props",
+            f'select key, value from "{project.test_schema}"."iceberg_writeto_props$properties"',
             fetch="all",
         )
-        props_dict = {row[0]: row[1] for row in props}
-        assert props_dict.get("format-version") == "2"
+        props_dict = dict(props)
+        assert props_dict.get("write.parquet.compression-codec") == "zstd"
 
 
 _iceberg_writeto_on_hive_table = """
@@ -168,7 +167,6 @@ def model(dbt, spark_session):
     dbt.config(
         materialized='table',
         table_type='hive',
-        spark_engine_version='3.5',
         use_iceberg_write_to=True,
     )
     return spark_session.createDataFrame([(1,)], ['id'])

--- a/dbt-athena/tests/unit/test_py_save_table_as.py
+++ b/dbt-athena/tests/unit/test_py_save_table_as.py
@@ -108,33 +108,6 @@ class TestUseIcebergWriteToRendering:
         assert "spark_session.sql" in rendered
         assert "create table foo using iceberg as" in rendered
 
-    def test_falls_back_to_save_as_table_when_no_iceberg_or_ctas(self):
-        # The third branch (the original Hive saveAsTable path) must still
-        # fire when neither use_iceberg_write_to nor spark_ctas is set.
-        rendered = _render(
-            {
-                "location": "s3://bucket/path",
-                "format": "parquet",
-                "partitioned_by": None,
-                "bucketed_by": None,
-                "sorted_by": None,
-            }
-        )
-        assert "writeTo" not in rendered
-        assert "spark_session.sql" not in rendered
-        assert "writer.saveAsTable" in rendered
-
-    def test_target_relation_quotes_are_backticked(self):
-        # Python identifiers in writeTo() must use backticks; quotes
-        # cause AnalysisException in Spark.
-        target = SimpleNamespace(schema='"q_schema"', identifier='"q_table"')
-        env = jinja2.Environment(loader=jinja2.FileSystemLoader(_MACRO_DIR))
-        template = env.get_template("python_submissions.sql")
-        rendered = template.module.athena__py_save_table_as(
-            "", target, {"location": "s3://b/p", "use_iceberg_write_to": True}
-        )
-        assert '.writeTo("`q_schema`.`q_table`")' in rendered
-
 
 class TestParseIcebergPartition:
     """Execute the inline _parse_iceberg_partition function from the
@@ -190,12 +163,10 @@ class TestParseIcebergPartition:
         assert parse_fn(expr) == expected
 
     def test_bucket_with_missing_arg_raises_clear_error(self, parse_fn):
+        # bucket and truncate share the arity-validation branch, so this
+        # exercise covers both.
         with pytest.raises(ValueError, match="requires 2 arguments"):
             parse_fn("bucket(user_id)")
-
-    def test_truncate_with_missing_arg_raises_clear_error(self, parse_fn):
-        with pytest.raises(ValueError, match="requires 2 arguments"):
-            parse_fn("truncate(name)")
 
     def test_unknown_transform_raises_value_error(self, parse_fn):
         with pytest.raises(ValueError, match="Unknown Iceberg partition transform"):

--- a/dbt-athena/tests/unit/test_py_save_table_as.py
+++ b/dbt-athena/tests/unit/test_py_save_table_as.py
@@ -1,0 +1,202 @@
+"""
+Unit tests for the athena__py_save_table_as macro, focused on the
+use_iceberg_write_to branch.
+
+Renders the macro end-to-end with jinja2.FileSystemLoader, following
+the pattern in test_get_partition_batches.py.
+"""
+
+import os
+from types import SimpleNamespace
+
+import jinja2
+import pytest
+
+_MACRO_DIR = os.path.normpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        os.pardir,
+        os.pardir,
+        "src",
+        "dbt",
+        "include",
+        "athena",
+        "macros",
+        "adapters",
+    )
+)
+
+
+def _render(optional_args, compiled_code="def model(dbt, spark):\n    return spark"):
+    target_relation = SimpleNamespace(schema="my_schema", identifier="my_table")
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(_MACRO_DIR),
+        extensions=["jinja2.ext.do"],
+    )
+    template = env.get_template("python_submissions.sql")
+    return template.module.athena__py_save_table_as(compiled_code, target_relation, optional_args)
+
+
+class TestUseIcebergWriteToRendering:
+    """Verify the use_iceberg_write_to branch generates correct Python."""
+
+    def test_renders_writeto_with_native_partition_transforms(self):
+        rendered = _render(
+            {
+                "location": "s3://bucket/path",
+                "use_iceberg_write_to": True,
+                "partitioned_by": ["day(created_at)", "bucket(user_id, 4)"],
+            }
+        )
+        assert '.writeTo("my_schema.my_table")' in rendered
+        assert '.using("iceberg")' in rendered
+        assert ".createOrReplace()" in rendered
+        # partitioned_by values are passed through tojson, so they appear
+        # as Python string literals consumed by _parse_iceberg_partition.
+        assert '_parse_iceberg_partition("day(created_at)")' in rendered
+        assert '_parse_iceberg_partition("bucket(user_id, 4)")' in rendered
+        # spark_ctas branch must NOT be reached.
+        assert "spark_session.sql" not in rendered
+
+    def test_renders_writeto_without_partitions(self):
+        rendered = _render({"location": "s3://bucket/path", "use_iceberg_write_to": True})
+        assert ".writeTo(" in rendered
+        assert ".createOrReplace()" in rendered
+        # No partitionedBy call when partitioned_by is omitted.
+        assert ".partitionedBy(" not in rendered
+
+    def test_extra_table_properties_use_tojson_escaping(self):
+        rendered = _render(
+            {
+                "location": "s3://bucket/path",
+                "use_iceberg_write_to": True,
+                "extra_table_properties": {
+                    "format-version": "2",
+                    'key"with"quotes': "value\\backslash",
+                },
+            }
+        )
+        # location goes through tojson together with the trailing slash.
+        assert '_writer.tableProperty("location", "s3://bucket/path/")' in rendered
+        # Plain property: emitted as JSON-escaped Python string literals.
+        assert '_writer.tableProperty("format-version", "2")' in rendered
+        # Special characters are escaped (no raw injection).
+        assert 'key\\"with\\"quotes' in rendered
+        assert "value\\\\backslash" in rendered
+
+    def test_extra_table_properties_coerces_non_string_values(self):
+        # Booleans / ints sometimes appear in user configs; |string|tojson
+        # must coerce them to a Python string literal rather than blow up.
+        rendered = _render(
+            {
+                "location": "s3://bucket/path",
+                "use_iceberg_write_to": True,
+                "extra_table_properties": {"format-version": 2},
+            }
+        )
+        assert '_writer.tableProperty("format-version", "2")' in rendered
+
+    def test_falls_back_to_spark_ctas_when_disabled(self):
+        rendered = _render(
+            {
+                "location": "s3://bucket/path",
+                "use_iceberg_write_to": False,
+                "spark_ctas": "create table foo using iceberg as",
+            }
+        )
+        assert "writeTo" not in rendered
+        assert "spark_session.sql" in rendered
+        assert "create table foo using iceberg as" in rendered
+
+    def test_falls_back_to_save_as_table_when_no_iceberg_or_ctas(self):
+        # The third branch (the original Hive saveAsTable path) must still
+        # fire when neither use_iceberg_write_to nor spark_ctas is set.
+        rendered = _render(
+            {
+                "location": "s3://bucket/path",
+                "format": "parquet",
+                "partitioned_by": None,
+                "bucketed_by": None,
+                "sorted_by": None,
+            }
+        )
+        assert "writeTo" not in rendered
+        assert "spark_session.sql" not in rendered
+        assert "writer.saveAsTable" in rendered
+
+    def test_target_relation_quotes_are_backticked(self):
+        # Python identifiers in writeTo() must use backticks; quotes
+        # cause AnalysisException in Spark.
+        target = SimpleNamespace(schema='"q_schema"', identifier='"q_table"')
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(_MACRO_DIR))
+        template = env.get_template("python_submissions.sql")
+        rendered = template.module.athena__py_save_table_as(
+            "", target, {"location": "s3://b/p", "use_iceberg_write_to": True}
+        )
+        assert '.writeTo("`q_schema`.`q_table`")' in rendered
+
+
+class TestParseIcebergPartition:
+    """Execute the inline _parse_iceberg_partition function from the
+    rendered Python code against a stub pyspark.sql.functions module to
+    cover its dispatch and arity validation."""
+
+    @pytest.fixture
+    def parse_fn(self):
+        rendered = _render({"location": "s3://b/p", "use_iceberg_write_to": True})
+
+        # Pull just the _parse_iceberg_partition definition out of the
+        # rendered template and exec it with a stubbed F (pyspark.sql.functions)
+        # injected directly, so we don't need a real Spark context.
+        marker = "def _parse_iceberg_partition(expr_str):"
+        start = rendered.index(marker)
+        end = rendered.index("_writer = df.writeTo", start)
+        # Strip the leading 4-space indent from each line (the function
+        # lives inside materialize()).
+        body = "\n".join(
+            line[4:] if line.startswith("    ") else line
+            for line in rendered[start:end].splitlines()
+        )
+
+        F_stub = SimpleNamespace(
+            col=lambda c: ("col", c),
+            days=lambda c: ("days", c),
+            months=lambda c: ("months", c),
+            years=lambda c: ("years", c),
+            hours=lambda c: ("hours", c),
+            bucket=lambda n, c: ("bucket", n, c),
+            truncate=lambda n, c: ("truncate", n, c),
+        )
+        import re as re_module
+
+        ns = {"re": re_module, "F": F_stub}
+        exec(body, ns)
+        return ns["_parse_iceberg_partition"]
+
+    @pytest.mark.parametrize(
+        "expr,expected",
+        [
+            ("day(created_at)", ("days", ("col", "created_at"))),
+            ("days(created_at)", ("days", ("col", "created_at"))),
+            ("month(ts)", ("months", ("col", "ts"))),
+            ("year(ts)", ("years", ("col", "ts"))),
+            ("hour(ts)", ("hours", ("col", "ts"))),
+            ("bucket(user_id, 256)", ("bucket", 256, ("col", "user_id"))),
+            ("truncate(name, 10)", ("truncate", 10, ("col", "name"))),
+            ("plain_col", ("col", "plain_col")),
+        ],
+    )
+    def test_dispatch(self, parse_fn, expr, expected):
+        assert parse_fn(expr) == expected
+
+    def test_bucket_with_missing_arg_raises_clear_error(self, parse_fn):
+        with pytest.raises(ValueError, match="requires 2 arguments"):
+            parse_fn("bucket(user_id)")
+
+    def test_truncate_with_missing_arg_raises_clear_error(self, parse_fn):
+        with pytest.raises(ValueError, match="requires 2 arguments"):
+            parse_fn("truncate(name)")
+
+    def test_unknown_transform_raises_value_error(self, parse_fn):
+        with pytest.raises(ValueError, match="Unknown Iceberg partition transform"):
+            parse_fn("md5(name)")


### PR DESCRIPTION
Thank you for maintaining dbt-athena — I'd appreciate your review on this change.

resolves #1882
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

### Problem

Iceberg Python (Spark) models currently have two write paths, both with limitations:

1. `saveAsTable` does not support Iceberg-native partition transforms (`bucket()`, `day()`, etc.) via the DataFrameWriter API.
2. The `spark_ctas` SQL path doesn't leverage Spark's DataFrameWriterV2 capabilities like `tableProperty()`.

Additionally, for Iceberg tables the `table` materialization always uses the `__ha` intermediate table flow (CTAS to `__ha` → rename), regardless of the `ha` config. When a previous Spark run fails, the leftover `__ha` table causes `TABLE_OR_VIEW_ALREADY_EXISTS` on retry.

### Solution

Add a `use_iceberg_write_to` model config that uses `writeTo().createOrReplace()` (DataFrameWriterV2 API). This enables Iceberg-native partition transforms and atomic replacement without the `__ha` intermediate table.

In `table.sql`, when `use_iceberg_write_to` is enabled, the model writes directly to `target_relation`, skipping the `__ha` → rename flow. Leftover `__ha` / `__bkp` tables from previous HA-flow failures are cleaned up.

```python
{{ config(
    materialized='table',
    table_type='iceberg',
    use_iceberg_write_to=True,
    partitioned_by=['day(created_at)', 'bucket(user_id, 256)'],
) }}
```

### Tests

- **Unit** (`tests/unit/test_py_save_table_as.py`): renders `athena__py_save_table_as` end-to-end with `jinja2.FileSystemLoader` (same pattern as `test_get_partition_batches.py`) and asserts on the generated Python — `writeTo`/`createOrReplace` branch selection, `tojson` escaping of `extra_table_properties` and partition expressions, fall-through to `spark_ctas` and `saveAsTable`. Also exec's the inline `_parse_iceberg_partition` against a stub `pyspark.sql.functions` to cover transform dispatch and `bucket`/`truncate` arity validation.
- **Functional** (`tests/functional/adapter/test_use_iceberg_write_to.py`, gated on `DBT_TEST_ATHENA_SPARK_WORK_GROUP`): runs Iceberg Python models end-to-end against a real Athena Spark workgroup. Covers partitioned + unpartitioned writes, idempotent `createOrReplace`, `table_properties` propagation, and the compiler-error path when `use_iceberg_write_to=True` is combined with `table_type != 'iceberg'`.

#### Test infrastructure (Terraform)

The functional test requires an Athena Spark workgroup with Iceberg support. This PR predates the Spark 3.5 / Spark Connect work in #1874, so the workgroup uses Athena's `PySpark engine version 3` (Spark 3.2.1) — the engine the Calculations API targets. The Terraform below provisions the minimal AWS resources.

<details>
<summary>Terraform (click to expand)</summary>

```hcl
terraform {
  required_version = ">= 1.5"

  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 5.0"
    }
  }
}

provider "aws" {
  profile = "<your-aws-profile>"
  region  = "<your-region>"
}

locals {
  account_id = "<your-account-id>"
  region     = "<your-region>"
  name       = "<your-spark-test-name>"
  bucket     = "<your-test-output-bucket>"
  kms_key_id = "<your-kms-key-id>"

  workgroup_arn = "arn:aws:athena:${local.region}:${local.account_id}:workgroup/${local.name}"
}

data "aws_iam_policy_document" "trust" {
  statement {
    effect  = "Allow"
    actions = ["sts:AssumeRole"]

    principals {
      type        = "Service"
      identifiers = ["athena.amazonaws.com"]
    }

    condition {
      test     = "StringEquals"
      variable = "aws:SourceAccount"
      values   = [local.account_id]
    }

    condition {
      test     = "ArnEquals"
      variable = "aws:SourceArn"
      values   = [local.workgroup_arn]
    }
  }
}

data "aws_iam_policy_document" "permissions" {
  statement {
    sid     = "GlueCatalogFullAccess"
    effect  = "Allow"
    actions = ["glue:*"]
    resources = [
      "arn:aws:glue:${local.region}:${local.account_id}:catalog",
      "arn:aws:glue:${local.region}:${local.account_id}:database/*",
      "arn:aws:glue:${local.region}:${local.account_id}:table/*",
      "arn:aws:glue:${local.region}:${local.account_id}:userDefinedFunction/*",
    ]
  }

  statement {
    sid     = "S3OutputBucket"
    effect  = "Allow"
    actions = ["s3:*"]
    resources = [
      "arn:aws:s3:::${local.bucket}",
      "arn:aws:s3:::${local.bucket}/*",
    ]
  }

  statement {
    sid       = "LakeFormation"
    effect    = "Allow"
    actions   = ["lakeformation:GetDataAccess"]
    resources = ["*"]
  }

  statement {
    sid    = "AthenaSelf"
    effect = "Allow"
    actions = [
      "athena:GetWorkGroup",
      "athena:StartQueryExecution",
      "athena:GetQueryExecution",
      "athena:GetQueryResults",
      "athena:StopQueryExecution",
      "athena:ListWorkGroups",
    ]
    resources = ["*"]
  }

  statement {
    sid    = "KmsForOutputBucket"
    effect = "Allow"
    actions = [
      "kms:Decrypt",
      "kms:Encrypt",
      "kms:GenerateDataKey",
      "kms:DescribeKey",
    ]
    resources = ["arn:aws:kms:${local.region}:${local.account_id}:key/${local.kms_key_id}"]
  }
}

resource "aws_iam_role" "spark_test" {
  name               = local.name
  description        = "Spark functional test execution role for dbt-athena"
  assume_role_policy = data.aws_iam_policy_document.trust.json
}

resource "aws_iam_role_policy" "spark_test_inline" {
  name   = "${local.name}-inline"
  role   = aws_iam_role.spark_test.name
  policy = data.aws_iam_policy_document.permissions.json
}

resource "aws_athena_workgroup" "spark_test" {
  name        = local.name
  description = "Spark functional test workgroup for dbt-athena"

  configuration {
    enforce_workgroup_configuration = false
    execution_role                  = aws_iam_role.spark_test.arn

    engine_version {
      selected_engine_version = "PySpark engine version 3"
    }

    result_configuration {
      output_location = "s3://${local.bucket}/spark-output/"

      encryption_configuration {
        encryption_option = "SSE_KMS"
        kms_key_arn       = "arn:aws:kms:${local.region}:${local.account_id}:key/${local.kms_key_id}"
      }
    }
  }
}

output "execution_role_arn" {
  value = aws_iam_role.spark_test.arn
}

output "workgroup_name" {
  value = aws_athena_workgroup.spark_test.name
}
```

</details>

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
