### PR TITLE
fix(redshift): quote database name in list_schemas SHOW SCHEMAS

### DIFF
--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
@@ -312,8 +312,13 @@
 
 {% macro redshift__list_schemas(database) %}
   {% if redshift__use_show_apis() %}
+    {# dbt-core's create_schemas passes a pre-quoted identifier via str(relation);
+       other callers pass the raw database name. Normalize by stripping any surrounding
+       double-quotes before re-applying adapter.quote so the identifier is always quoted
+       exactly once — required for databases with hyphens. #}
+    {%- set _database = database | replace('"', '') -%}
     {% call statement('list_schemas', fetch_result=True) -%}
-      SHOW SCHEMAS FROM DATABASE {{ adapter.quote(database) }}
+      SHOW SCHEMAS FROM DATABASE {{ adapter.quote(_database) }}
     {% endcall %}
     {%- set table = load_result('list_schemas').table -%}
     {%- set schemas = [] -%}

--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
@@ -313,12 +313,16 @@
 {% macro redshift__list_schemas(database) %}
   {% if redshift__use_show_apis() %}
     {# dbt-core's create_schemas passes a pre-quoted identifier via str(relation);
-       other callers pass the raw database name. Normalize by stripping any surrounding
-       double-quotes before re-applying adapter.quote so the identifier is always quoted
-       exactly once — required for databases with hyphens. #}
-    {%- set _database = database | replace('"', '') -%}
+       other callers pass the raw database name. Only quote when the input is not
+       already wrapped in double-quotes, so the identifier is quoted exactly once —
+       required for databases with hyphens. #}
+    {%- if database.startswith('"') and database.endswith('"') -%}
+      {%- set _quoted_database = database -%}
+    {%- else -%}
+      {%- set _quoted_database = adapter.quote(database) -%}
+    {%- endif -%}
     {% call statement('list_schemas', fetch_result=True) -%}
-      SHOW SCHEMAS FROM DATABASE {{ adapter.quote(_database) }}
+      SHOW SCHEMAS FROM DATABASE {{ _quoted_database }}
     {% endcall %}
     {%- set table = load_result('list_schemas').table -%}
     {%- set schemas = [] -%}

--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
@@ -313,7 +313,7 @@
 {% macro redshift__list_schemas(database) %}
   {% if redshift__use_show_apis() %}
     {% call statement('list_schemas', fetch_result=True) -%}
-      SHOW SCHEMAS FROM DATABASE {{ database }}
+      SHOW SCHEMAS FROM DATABASE {{ adapter.quote(database) }}
     {% endcall %}
     {%- set table = load_result('list_schemas').table -%}
     {%- set schemas = [] -%}

--- a/dbt-redshift/tests/functional/adapter/hyphenated_database/test_hyphenated_database.py
+++ b/dbt-redshift/tests/functional/adapter/hyphenated_database/test_hyphenated_database.py
@@ -35,10 +35,15 @@ class TestHyphenatedDatabaseRun(HyphenatedDatabaseMixin):
             "simple_table.sql": _SIMPLE_TABLE,
         }
 
-    def test_run(self, project):
-        results = run_dbt(["run"])
-        assert len(results) == 1
+    @pytest.fixture(scope="class")
+    def dbt_run_results(self, project):
+        """Run dbt once per worker/class; other tests in this class use it as a prerequisite."""
+        return run_dbt(["run"])
 
+    def test_run(self, dbt_run_results):
+        assert len(dbt_run_results) == 1
+
+    @pytest.mark.usefixtures("dbt_run_results")
     def test_list_relations_uses_show_api(self, project):
         """list_relations_without_caching (SHOW TABLES) works with a hyphenated database."""
         with project.adapter.connection_named("_test"):
@@ -51,6 +56,7 @@ class TestHyphenatedDatabaseRun(HyphenatedDatabaseMixin):
         identifiers = {rel.identifier for rel in relations}
         assert "simple_table" in identifiers
 
+    @pytest.mark.usefixtures("dbt_run_results")
     def test_check_schema_exists(self, project):
         """check_schema_exists (SHOW SCHEMAS) works with a hyphenated database."""
         with project.adapter.connection_named("_test"):
@@ -59,6 +65,7 @@ class TestHyphenatedDatabaseRun(HyphenatedDatabaseMixin):
             )
         assert exists
 
+    @pytest.mark.usefixtures("dbt_run_results")
     def test_list_schemas(self, project):
         """list_schemas (SHOW SCHEMAS) works with a hyphenated database."""
         with project.adapter.connection_named("_test"):

--- a/dbt-redshift/tests/functional/adapter/hyphenated_database/test_hyphenated_database.py
+++ b/dbt-redshift/tests/functional/adapter/hyphenated_database/test_hyphenated_database.py
@@ -25,11 +25,6 @@ select 1 as id, 'hello' as label
 union all select 2, 'world'
 """
 
-_VIEW_FROM_TABLE = """
-{{ config(materialized='view', bind=false) }}
-select * from {{ ref('simple_table') }}
-"""
-
 
 class TestHyphenatedDatabaseRun(HyphenatedDatabaseMixin):
     """dbt run succeeds against a database whose name contains a hyphen."""
@@ -38,12 +33,11 @@ class TestHyphenatedDatabaseRun(HyphenatedDatabaseMixin):
     def models(self):
         return {
             "simple_table.sql": _SIMPLE_TABLE,
-            "view_from_table.sql": _VIEW_FROM_TABLE,
         }
 
     def test_run(self, project):
         results = run_dbt(["run"])
-        assert len(results) == 2
+        assert len(results) == 1
 
     def test_list_relations_uses_show_api(self, project):
         """list_relations_without_caching (SHOW TABLES) works with a hyphenated database."""
@@ -56,17 +50,13 @@ class TestHyphenatedDatabaseRun(HyphenatedDatabaseMixin):
 
         identifiers = {rel.identifier for rel in relations}
         assert "simple_table" in identifiers
-        assert "view_from_table" in identifiers
 
     def test_check_schema_exists(self, project):
         """check_schema_exists (SHOW SCHEMAS) works with a hyphenated database."""
         with project.adapter.connection_named("_test"):
-            information_schema = project.adapter.Relation.create(
-                database=REDSHIFT_TEST_DBNAME_W_HYPHEN,
-                schema=project.test_schema,
-                identifier="INFORMATION_SCHEMA",
-            ).information_schema()
-            exists = project.adapter.check_schema_exists(information_schema, project.test_schema)
+            exists = project.adapter.check_schema_exists(
+                REDSHIFT_TEST_DBNAME_W_HYPHEN, project.test_schema
+            )
         assert exists
 
     def test_list_schemas(self, project):


### PR DESCRIPTION
## Summary

Follow-up to #1885 which fixed quoting in `SHOW TABLES` and `SHOW COLUMNS` for hyphenated database names. Three gaps remained:

- **`redshift__list_schemas` did not quote the database identifier.** This caused `SHOW SCHEMAS FROM DATABASE db-with-hyphen` to fail with a syntax error whenever the database contained a hyphen. The fix is more nuanced than a straight `adapter.quote(database)` because `list_schemas` has two inconsistent calling conventions:
  - `dbt-core`'s `create_schemas` (`task/runnable.py`) passes `str(db_only)`, which is already quoted (e.g. `"db-with-hyphen"`).
  - Direct adapter calls (e.g. `adapter.list_schemas(project.database)`) pass the raw unquoted name.

  The macro now strips any surrounding `"` before re-applying `adapter.quote()`, so the identifier is always quoted exactly once regardless of caller. This mirrors the existing normalization in `RedshiftAdapter.verify_database`.

- **`TestHyphenatedDatabaseRun` was racy under pytest-xdist.** Tests that assert schema/table presence (`list_relations`, `check_schema_exists`, `list_schemas`) could be dispatched to a worker that never ran `test_run`, leaving the hyphenated database's schema empty. Added a class-scoped `dbt_run_results` fixture so every worker that receives one of these tests materializes the models first.

- **Two test bugs carried over from #1885:**
  - The late-binding view model (`bind=false`) cannot be atomically swapped via `__dbt_tmp` in a datasharing (consumer) database. Removed the view model from `TestHyphenatedDatabaseRun`; the SHOW TABLES quoting behaviour is already covered by the remaining table model.
  - `test_check_schema_exists` was passing an `InformationSchema` object where `BaseAdapter.check_schema_exists(database: str, schema: str)` expects a plain string. Pass `REDSHIFT_TEST_DBNAME_W_HYPHEN` directly instead.

## Test plan

- [ ] Set `REDSHIFT_TEST_DBNAME_W_HYPHEN` to a Redshift database whose name contains a hyphen, then run `hatch run integration-tests tests/functional/adapter/hyphenated_database`
- [ ] Verify all 7 tests pass: `test_run`, `test_list_relations_uses_show_api`, `test_check_schema_exists`, `test_list_schemas`, `test_get_columns_in_relation`, `test_catalog_by_relations`, `test_catalog_by_schemas`
- [ ] Confirm `REDSHIFT_TEST_DBNAME_W_HYPHEN` unset → all tests skipped (no failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)