### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/dbt-adapters/src/dbt/adapters/relation_configs/config_validation.py
+++ b/dbt-adapters/src/dbt/adapters/relation_configs/config_validation.py
@@ -38,9 +38,7 @@ class RelationConfigValidationMixin:
 
     def run_validation_rules(self):
         for validation_rule in self.validation_rules:
-            try:
-                assert validation_rule.validation_check
-            except AssertionError:
+            if not validation_rule.validation_check:
                 if validation_rule.validation_error:
                     raise validation_rule.validation_error
                 else:

--- a/dbt-athena/src/dbt/adapters/athena/query_headers.py
+++ b/dbt-athena/src/dbt/adapters/athena/query_headers.py
@@ -32,7 +32,8 @@ class _AthenaQueryComment(_QueryComment):
         ):
             return sql
 
-        cleaned_query_comment = self.query_comment.strip().replace("\n", " ")
+        cleaned_query_comment = " ".join(self.query_comment.strip().splitlines())
+        cleaned_query_comment = cleaned_query_comment.replace("/*", "").replace("*/", "")
 
         if self.append:
             # replace last ';' with '<comment>;'


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `dbt-adapters/src/dbt/adapters/relation_configs/config_validation.py:L39`

Relation config validation relies on `assert validation_rule.validation_check` inside `run_validation_rules`. In optimized Python mode (`python -O`), assert statements are stripped, so invalid configs would not raise and child validation still proceeds. If adapters rely on these checks for safety constraints, this can permit unsafe relation config states.

## Solution

Replace `assert`-based checks with explicit conditionals, e.g. `if not validation_rule.validation_check: ... raise ...`. Avoid using `assert` for runtime validation logic.

## Changes

- `dbt-adapters/src/dbt/adapters/relation_configs/config_validation.py` (modified)
- `dbt-athena/src/dbt/adapters/athena/query_headers.py` (modified)