### PR TITLE
Athena: Add failing integration test proving insert_overwrite duplication bug

### DIFF
--- a/dbt-athena/tests/functional/adapter/test_insert_overwrite_no_duplicates.py
+++ b/dbt-athena/tests/functional/adapter/test_insert_overwrite_no_duplicates.py
@@ -1,0 +1,70 @@
+"""
+Regression test for insert_overwrite data duplication caused by stale S3 files that have no
+corresponding Glue partition metadata.
+
+This state can arise when a previous run:
+  1. Called clean_up_partitions (removes Glue metadata + S3 files for a partition)
+  2. Started the INSERT INTO — writing new files to S3
+  3. Failed before the INSERT completed (so no Glue partition was registered)
+
+On the next run, clean_up_partitions queries Glue, finds nothing, and skips S3 cleanup. The new
+INSERT then writes files alongside the stale ones. When Glue finally registers the partition, it
+points to the directory containing both old and new files — causing duplicates.
+
+The test simulates this state directly using ALTER TABLE DROP PARTITION, which removes the Glue
+partition metadata without touching S3 files, exactly replicating the post-failure state.
+"""
+
+import pytest
+
+from dbt.contracts.results import RunStatus
+from dbt.tests.util import run_dbt
+
+insert_overwrite_model_sql = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partitioned_by=['date_column'],
+    s3_data_naming='table',
+    format='parquet'
+) }}
+select
+    1 as value,
+    cast(from_iso8601_date('{{ var("logical_date") }}') as date) as date_column
+"""
+
+
+class TestInsertOverwriteNoDuplicatesAfterStaleS3Files:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"insert_overwrite_no_dupes.sql": insert_overwrite_model_sql}
+
+    def test_no_duplicates_after_stale_s3_files(self, project):
+        relation_name = "insert_overwrite_no_dupes"
+        count_query = f"select count(*) as cnt from {project.test_schema}.{relation_name}"
+        date_filter_query = (
+            f"select count(*) as cnt from {project.test_schema}.{relation_name} "
+            f"where date_column = date '2024-01-01'"
+        )
+
+        first_run = run_dbt(
+            ["run", "--select", relation_name, "--vars", '{"logical_date": "2024-01-01"}']
+        )
+        assert first_run.results[0].status == RunStatus.Success
+        assert project.run_sql(count_query, fetch="all")[0][0] == 1
+
+        # Simulate a previous run's partial failure: drop the Glue partition metadata but leave
+        # the S3 files in place. This is exactly the state left when clean_up_partitions succeeds
+        # but the subsequent INSERT fails mid-execution.
+        project.run_sql(
+            f"alter table {project.test_schema}.{relation_name} "
+            f"drop partition (date_column='2024-01-01')"
+        )
+
+        # Without the fix, this run would find no Glue metadata for date_column=2024-01-01,
+        # skip S3 cleanup, then write new files alongside the stale ones — producing 2 rows.
+        second_run = run_dbt(
+            ["run", "--select", relation_name, "--vars", '{"logical_date": "2024-01-01"}']
+        )
+        assert second_run.results[0].status == RunStatus.Success
+        assert project.run_sql(date_filter_query, fetch="all")[0][0] == 1


### PR DESCRIPTION
This came up in https://github.com/dbt-labs/dbt-adapters/pull/1558#discussion_r3141756090.

Demonstrates that `insert_overwrite` can produce duplicate rows when a partition's Glue metadata is missing but S3 files still exist — the state left after a run that completed `clean_up_partitions` but failed before the `INSERT` finished.

The test uses `ALTER TABLE DROP PARTITION` to reproduce this state deterministically: it removes the Glue partition metadata without touching S3 files, then re-runs the model and asserts no duplicates. The assertion currently fails (count=2), confirming the bug.

Is Athena `INSERT` partition atomic? Most likely not for Hive-format tables. Athena (Trino engine) writes data files to S3 first, then registers the partition in Glue upon successful completion. A query failure can leave
orphaned S3 files without Glue registration. Iceberg tables are atomic (Iceberg's own commit protocol), but not regular Hive tables. I'm not aware of official AWS docs that spell this out explicitly, so this remains speculative, but it's consistent with how Presto/Trino work. **It would make sense to get explicit confirmation from AWS before proceeding to implement a workaround**.

## How could this be fixed?

1. Modify `helpers.sql` to also compute raw S3 path segments (key=value without SQL quoting) and pass them to `clean_up_partitions`
2. Modify `clean_up_partitions` in `impl.py`: delete Glue metadata first, ~~then best-effort delete S3 from Glue locations,~~ then delete S3 from the derived path (table base + partition path) — this last step is what
fixes the bug

I would argue that it's best to not try to delete S3 files based on glue metadata locations at all, because the behavior can't be guaranteed to have idempotent results.

## Test execution

```shell
hatch run integration-tests tests/functional/adapter/test_insert_overwrite_no_duplicates.py -v
```

```
----------------------------- Captured stdout call -----------------------------


Invoking dbt with ['run', '--select', 'insert_overwrite_no_dupes', '--vars', '{"logical_date": "2024-01-01"}']
16:35:55  Running with dbt=1.12.0-a1
16:35:55  Registered adapter: athena=1.10.0-rc2
16:35:55  Unable to do partial parsing because saved manifest not found. Starting full parse.
16:35:55  Found 1 model, 491 macros
16:35:55
16:35:55  Concurrency: 1 threads (target='default')
16:35:55
16:36:12  1 of 1 START sql incremental model test17771349500576746116_test_insert_overwrite_no_duplicates.insert_overwrite_no_dupes  [RUN]
16:36:25  1 of 1 OK created sql incremental model test17771349500576746116_test_insert_overwrite_no_duplicates.insert_overwrite_no_dupes  [OK 1 in 13.45s]
16:36:25
16:36:25  Finished running 1 incremental model in 0 hours 0 minutes and 30.61 seconds (30.61s).
16:36:26
16:36:26  Completed successfully
16:36:26
16:36:26  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1


Invoking dbt with ['run', '--select', 'insert_overwrite_no_dupes', '--vars', '{"logical_date": "2024-01-01"}']
16:36:33  Running with dbt=1.12.0-a1
16:36:33  Registered adapter: athena=1.10.0-rc2
16:36:33  Found 1 model, 491 macros
16:36:33
16:36:33  Concurrency: 1 threads (target='default')
16:36:33
16:36:54  1 of 1 START sql incremental model test17771349500576746116_test_insert_overwrite_no_duplicates.insert_overwrite_no_dupes  [RUN]
16:37:23  1 of 1 OK created sql incremental model test17771349500576746116_test_insert_overwrite_no_duplicates.insert_overwrite_no_dupes  [OK 1 in 28.98s]
16:37:23
16:37:23  Finished running 1 incremental model in 0 hours 0 minutes and 49.88 seconds (49.88s).
16:37:23
16:37:23  Completed successfully
16:37:23
16:37:23  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

```
=================================== FAILURES ===================================
_ TestInsertOverwriteNoDuplicatesAfterStaleS3Files.test_no_duplicates_after_stale_s3_files _
[gw0] darwin -- Python 3.12.10 /Users/juhoautio/code/dbt-adapters/dbt-athena/.hatch/dbt-athena/bin/python

self = &lt;test_insert_overwrite_no_duplicates.TestInsertOverwriteNoDuplicatesAfterStaleS3Files object at 0x10a847a70&gt;
project = &lt;dbt.tests.fixtures.project.TestProjInfo object at 0x10be0d070&gt;

   def test_no_duplicates_after_stale_s3_files(self, project):
       relation_name = "insert_overwrite_no_dupes"
       count_query = f"select count(*) as cnt from {project.test_schema}.{relation_name}"
       date_filter_query = (
           f"select count(*) as cnt from {project.test_schema}.{relation_name} "
           f"where date_column = date '2024-01-01'"
       )

       first_run = run_dbt(
           ["run", "--select", relation_name, "--vars", '{"logical_date": "2024-01-01"}']
       )
       assert first_run.results[0].status == RunStatus.Success
       assert project.run_sql(count_query, fetch="all")[0][0] == 1

       # Simulate a previous run's partial failure: drop the Glue partition metadata but leave
       # the S3 files in place. This is exactly the state left when clean_up_partitions succeeds
       # but the subsequent INSERT fails mid-execution.
       project.run_sql(
           f"alter table {project.test_schema}.{relation_name} "
           f"drop partition (date_column='2024-01-01')"
       )

       # Without the fix, this run would find no Glue metadata for date_column=2024-01-01,
       # skip S3 cleanup, then write new files alongside the stale ones — producing 2 rows.
       second_run = run_dbt(
           ["run", "--select", relation_name, "--vars", '{"logical_date": "2024-01-01"}']
       )
       assert second_run.results[0].status == RunStatus.Success
&gt;       assert project.run_sql(date_filter_query, fetch="all")[0][0] == 1
E       assert 2 == 1

/Users/juhoautio/code/dbt-adapters/dbt-athena/tests/functional/adapter/test_insert_overwrite_no_duplicates.py:70: AssertionError
```

----

TODO: template to be filled if this PR is extended to include the fix.

```
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
```