### PR TITLE
fix(bigquery): qualify column refs in test_unique / test_not_null to avoid row-struct resolution

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fixes-20260427-083810.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20260427-083810.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Alias the source relation in `bigquery__test_unique` and add a `bigquery__test_not_null`
+  override so that columns sharing a name with their model resolve to the column
+  value instead of BigQuery's row STRUCT, fixing dbt-core#11067.
+time: 2026-04-27T08:38:10.000000+00:00
+custom:
+  Author: "1fanwang"
+  Issue: "11067"

--- a/dbt-bigquery/.changes/unreleased/Fixes-20260427-083810.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20260427-083810.yaml
@@ -1,7 +1,9 @@
 kind: Fixes
 body: Alias the source relation in `bigquery__test_unique` and add a `bigquery__test_not_null`
   override so that columns sharing a name with their model resolve to the column
-  value instead of BigQuery's row STRUCT, fixing dbt-core#11067.
+  value instead of BigQuery's row STRUCT. The relation is wrapped in a subquery
+  before aliasing so `where:`-filtered tests, where `get_where_subquery` already
+  emits a `dbt_subquery` alias, still produce valid SQL. Fixes dbt-core#11067.
 time: 2026-04-27T08:38:10.000000+00:00
 custom:
   Author: "1fanwang"

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/adapters.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/adapters.sql
@@ -209,13 +209,16 @@
 {% endmacro %}
 
 
+{# When a column has the same name as its table, BigQuery resolves an unqualified
+   column reference to the row STRUCT instead of the column value. Aliasing the
+   relation and qualifying the column reference forces resolution to the column. #}
 {% macro bigquery__test_unique(model, column_name) %}
 
 with dbt_test__target as (
 
-  select {{ column_name }} as unique_field
-  from {{ model }}
-  where {{ column_name }} is not null
+  select dbt_test__source.{{ column_name }} as unique_field
+  from {{ model }} dbt_test__source
+  where dbt_test__source.{{ column_name }} is not null
 
 )
 
@@ -226,6 +229,18 @@ select
 from dbt_test__target
 group by unique_field
 having count(*) > 1
+
+{% endmacro %}
+
+{# Same row-vs-column resolution issue as bigquery__test_unique: alias the
+   relation and qualify the column reference. #}
+{% macro bigquery__test_not_null(model, column_name) %}
+
+{% set column_list = '*' if should_store_failures() else 'dbt_test__source.' ~ column_name %}
+
+select {{ column_list }}
+from {{ model }} dbt_test__source
+where dbt_test__source.{{ column_name }} is null
 
 {% endmacro %}
 

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/adapters.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/adapters.sql
@@ -211,13 +211,17 @@
 
 {# When a column has the same name as its table, BigQuery resolves an unqualified
    column reference to the row STRUCT instead of the column value. Aliasing the
-   relation and qualifying the column reference forces resolution to the column. #}
+   relation and qualifying the column reference forces resolution to the column.
+   `model` is wrapped in a subquery before aliasing because `get_where_subquery`
+   may already render it as `(...) dbt_subquery` for `where:`-filtered tests; a
+   bare `{{ model }} dbt_test__source` would then produce an invalid double
+   alias. #}
 {% macro bigquery__test_unique(model, column_name) %}
 
 with dbt_test__target as (
 
   select dbt_test__source.{{ column_name }} as unique_field
-  from {{ model }} dbt_test__source
+  from (select * from {{ model }}) dbt_test__source
   where dbt_test__source.{{ column_name }} is not null
 
 )
@@ -232,14 +236,16 @@ having count(*) > 1
 
 {% endmacro %}
 
-{# Same row-vs-column resolution issue as bigquery__test_unique: alias the
-   relation and qualify the column reference. #}
+{# Same row-vs-column resolution issue as bigquery__test_unique. `model` is
+   wrapped in a subquery before aliasing so `where:`-filtered tests, where
+   `get_where_subquery` already adds a `dbt_subquery` alias, do not produce an
+   invalid double alias. #}
 {% macro bigquery__test_not_null(model, column_name) %}
 
 {% set column_list = '*' if should_store_failures() else 'dbt_test__source.' ~ column_name %}
 
 select {{ column_list }}
-from {{ model }} dbt_test__source
+from (select * from {{ model }}) dbt_test__source
 where dbt_test__source.{{ column_name }} is null
 
 {% endmacro %}

--- a/dbt-bigquery/tests/functional/adapter/generic_tests/test_column_table_name_collision.py
+++ b/dbt-bigquery/tests/functional/adapter/generic_tests/test_column_table_name_collision.py
@@ -1,0 +1,67 @@
+"""
+Regression test for dbt-core#11067.
+
+When a column has the same name as its table, BigQuery resolves an unqualified
+column reference to the row STRUCT (containing all of the row's columns) rather
+than to the column value. The default `unique` and `not_null` generic tests
+emit unqualified column references, which means the resulting SQL filters and
+groups against the row struct instead of the column. After the fix in
+`bigquery__test_unique` and `bigquery__test_not_null`, the source relation is
+aliased and column references are qualified, so the tests evaluate against the
+column as expected.
+"""
+
+import pytest
+
+from dbt.tests.util import run_dbt
+
+
+_MODEL_SQL = """
+select 1 as orders union all
+select 1 as orders union all
+select 2 as orders union all
+select cast(null as int64) as orders
+""".lstrip()
+
+
+_SCHEMA_YML = """
+version: 2
+models:
+  - name: orders
+    columns:
+      - name: orders
+        data_tests:
+          - unique
+          - not_null
+""".lstrip()
+
+
+class TestBigQueryGenericTestsColumnTableNameCollision:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "orders.sql": _MODEL_SQL,
+            "schema.yml": _SCHEMA_YML,
+        }
+
+    def test_unique_and_not_null_detect_failures(self, project):
+        run_dbt(["run"])
+        results = run_dbt(["test"], expect_pass=False)
+
+        assert len(results) == 2
+
+        statuses = {r.node.name: (r.status, r.failures) for r in results}
+
+        unique_status, unique_failures = statuses["unique_orders_orders"]
+        assert unique_status == "fail", (
+            f"unique test passed unexpectedly (status={unique_status}); "
+            "with the bug, the row-struct grouping can mask duplicates"
+        )
+        assert unique_failures >= 1
+
+        not_null_status, not_null_failures = statuses["not_null_orders_orders"]
+        assert not_null_status == "fail", (
+            f"not_null test passed unexpectedly (status={not_null_status}); "
+            "with the bug, the row-struct nullness check masks the null column value"
+        )
+        assert not_null_failures >= 1

--- a/dbt-bigquery/tests/functional/adapter/generic_tests/test_column_table_name_collision.py
+++ b/dbt-bigquery/tests/functional/adapter/generic_tests/test_column_table_name_collision.py
@@ -36,6 +36,46 @@ models:
 """.lstrip()
 
 
+# Same column/table name collision but with a `where:` filter on each test.
+# `get_where_subquery` renders `model` as `(select * from <rel> where ...)
+# dbt_subquery`; the BigQuery overrides must still compile and execute against
+# that already-aliased subquery.
+_SCHEMA_WHERE_YML = """
+version: 2
+models:
+  - name: orders
+    columns:
+      - name: orders
+        data_tests:
+          - unique:
+              config:
+                where: "orders is not null"
+          - not_null:
+              config:
+                where: "orders is not null or orders is null"
+""".lstrip()
+
+
+def _result_for_prefix(results, prefix):
+    """Look up a test result by node-name prefix.
+
+    Generic test node names (`unique_<model>_<column>` etc.) are stable today
+    but tying assertions to the literal name makes the test brittle across dbt
+    versions if naming gains suffixes. Match on prefix and surface a clear
+    error if the expected result is missing.
+    """
+    matches = [r for r in results if r.node.name.startswith(prefix)]
+    assert matches, (
+        f"expected a test result whose node name starts with {prefix!r}; "
+        f"found: {sorted(r.node.name for r in results)}"
+    )
+    assert len(matches) == 1, (
+        f"expected exactly one result for prefix {prefix!r}; "
+        f"got: {[r.node.name for r in matches]}"
+    )
+    return matches[0]
+
+
 class TestBigQueryGenericTestsColumnTableNameCollision:
     @pytest.fixture(scope="class")
     def models(self):
@@ -50,18 +90,53 @@ class TestBigQueryGenericTestsColumnTableNameCollision:
 
         assert len(results) == 2
 
-        statuses = {r.node.name: (r.status, r.failures) for r in results}
-
-        unique_status, unique_failures = statuses["unique_orders_orders"]
-        assert unique_status == "fail", (
-            f"unique test passed unexpectedly (status={unique_status}); "
+        unique_result = _result_for_prefix(results, "unique_")
+        assert unique_result.status == "fail", (
+            f"unique test passed unexpectedly (status={unique_result.status}); "
             "with the bug, the row-struct grouping can mask duplicates"
         )
-        assert unique_failures >= 1
+        assert unique_result.failures >= 1
 
-        not_null_status, not_null_failures = statuses["not_null_orders_orders"]
-        assert not_null_status == "fail", (
-            f"not_null test passed unexpectedly (status={not_null_status}); "
+        not_null_result = _result_for_prefix(results, "not_null_")
+        assert not_null_result.status == "fail", (
+            f"not_null test passed unexpectedly (status={not_null_result.status}); "
             "with the bug, the row-struct nullness check masks the null column value"
         )
-        assert not_null_failures >= 1
+        assert not_null_result.failures >= 1
+
+
+class TestBigQueryGenericTestsColumnTableNameCollisionWithWhere:
+    """`where:`-filtered tests render `model` as `(select * from <rel> where ...)
+    dbt_subquery`. The BigQuery overrides wrap `model` in another subquery
+    before aliasing so this case still produces valid SQL."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "orders.sql": _MODEL_SQL,
+            "schema.yml": _SCHEMA_WHERE_YML,
+        }
+
+    def test_unique_and_not_null_compile_with_where_filter(self, project):
+        run_dbt(["run"])
+        # `expect_pass=False` because the `not_null` test still observes the
+        # null row (its `where:` keeps null values); the `unique` test still
+        # sees duplicates of `orders=1`. The important assertion is that the
+        # SQL compiles and runs at all when `model` is an aliased subquery.
+        results = run_dbt(["test"], expect_pass=False)
+
+        assert len(results) == 2
+
+        unique_result = _result_for_prefix(results, "unique_")
+        assert unique_result.status == "fail", (
+            f"unique test status was {unique_result.status}; "
+            "expected fail because duplicate non-null orders remain after the where filter"
+        )
+        assert unique_result.failures >= 1
+
+        not_null_result = _result_for_prefix(results, "not_null_")
+        assert not_null_result.status == "fail", (
+            f"not_null test status was {not_null_result.status}; "
+            "expected fail because the where filter retains the null row"
+        )
+        assert not_null_result.failures >= 1


### PR DESCRIPTION
resolves dbt-labs/dbt-core#11067
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

### Problem

When a column shares its name with the model, BigQuery's `unique` and `not_null` generic tests can incorrectly pass even with duplicate or null column values. Reproducer per dbt-core#11067:

```yaml
# models/orders.sql
select 1 as orders union all
select 1 as orders union all
select cast(null as int64) as orders

# models/_models.yml
models:
  - name: orders
    columns:
      - name: orders
        data_tests:
          - unique
          - not_null
```

Root cause: BigQuery's identifier-resolution rule. When a column's name matches its containing relation's name and the relation is referenced without an alias, an unqualified reference like `orders` resolves to the row STRUCT containing all of the row's columns, not to the column value itself.

The current `bigquery__test_unique` and the inherited `default__test_not_null` emit unqualified column references:

```jinja
{# bigquery__test_unique today #}
with dbt_test__target as (
  select {{ column_name }} as unique_field
  from {{ model }}
  where {{ column_name }} is not null
)
...
```

so the WHERE / GROUP BY apply against the row struct rather than the column, masking the violations the tests are meant to catch.

### Solution

Alias the source relation as ``dbt_test__source`` and qualify column references in `bigquery__test_unique`. Add a `bigquery__test_not_null` override that does the same.

```jinja
{% macro bigquery__test_unique(model, column_name) %}
with dbt_test__target as (
  select dbt_test__source.{{ column_name }} as unique_field
  from {{ model }} dbt_test__source
  where dbt_test__source.{{ column_name }} is not null
)
...
{% endmacro %}

{% macro bigquery__test_not_null(model, column_name) %}
{% set column_list = '*' if should_store_failures() else 'dbt_test__source.' ~ column_name %}
select {{ column_list }}
from {{ model }} dbt_test__source
where dbt_test__source.{{ column_name }} is null
{% endmacro %}
```

Same shape suggested in the review of the original stale attempt at dbt-core#2061 / PR dbt-core#2075. Limited the change to BigQuery because Postgres / Snowflake / Redshift / Spark resolve unqualified column references column-first, so the bug does not manifest there and changing the default macro would have a wider blast radius.

Tradeoffs considered:
- **Updating `default__test_unique` / `default__test_not_null` instead.** Cleaner long-term, but riskier for adapters that override those defaults or user macros that shim them. BigQuery-only is safer; the default macros can still be changed if reviewers want the broader fix.
- **Different alias name.** `dbt_test__source` mirrors the existing `dbt_test__target` CTE. A column literally named `dbt_test__source` would still resolve correctly because `dbt_test__source.{{ column_name }}` is alias-dot-column syntax. This can be renamed if reviewers prefer something less collision-prone.

### Tests

Added `dbt-bigquery/tests/functional/adapter/generic_tests/test_column_table_name_collision.py`. It builds the reproducer model from the issue, runs `dbt test`, and asserts that both the `unique` and `not_null` tests fail with at least one failure each.

I have not been able to run the BigQuery integration tests locally because this environment has no project credentials. CI will need to validate the fixture shape.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue (BQ integration tests not run locally; relying on CI)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
