### PR TITLE
Change bytes from 2048 to 1024

### DIFF
--- a/dbt-snowflake/tests/functional/adapter/test_basic.py
+++ b/dbt-snowflake/tests/functional/adapter/test_basic.py
@@ -89,7 +89,7 @@ class TestGetCatalogForSingleRelationSnowflake(BaseGetCatalogForSingleRelation):
                 "bytes": StatsItem(
                     id="bytes",
                     label="Approximate Size",
-                    value=2048,
+                    value=1024,
                     include=True,
                     description="Size of the table as reported by Snowflake",
                 ),


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#


### Problem
`test_get_catalog_for_single_relation` fails due stats.bytes mismatch.

### Solution
Change bytes from 2048 to 1024.

Verified that the bytes have changed by manually running this sql -
```sql
CREATE OR REPLACE TRANSIENT TABLE <db>.<schema>.MY_SEED (
      id          INTEGER,
      first_name  TEXT,
      email       TEXT,
      ip_address  TEXT,
      updated_at  TIMESTAMP_NTZ
  );

INSERT INTO <db>.<schema>.MY_SEED (id, first_name, email, ip_address, updated_at)
  VALUES (1, 'Larry', 'lking0@miitbeian.gov.cn', '69.135.206.194',
          '2008-09-12 19:08:31'::timestamp_ntz);
```

and verifying that following returns 1024 in bytes section-
```sql
SHOW OBJECTS IN SCHEMA <db>.<schema>STARTS WITH 'MY_SEED' LIMIT 1;
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
