### PR TITLE
Fix _dbt_max_partition false-positive detection in BigQuery incremental

### DIFF
--- a/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/incremental_strategy/common.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/incremental_strategy/common.sql
@@ -1,7 +1,20 @@
 {% macro declare_dbt_max_partition(relation, partition_by, compiled_code, language='sql') %}
 
   {#-- TODO: revisit partitioning with python models --#}
-  {%- if '_dbt_max_partition' in compiled_code and language == 'sql' -%}
+  {%- if language != 'sql' -%}
+    {{ return('') }}
+  {%- endif -%}
+
+  {#-
+    Ignore mentions in comments/quoted literals when deciding whether to declare
+    _dbt_max_partition.
+  -#}
+  {%- set compiled_code_without_comments = modules.re.sub("(?s)/\\*.*?\\*/|--[^\\n\\r]*", " ", compiled_code) -%}
+  {%- set compiled_code_without_comments_or_strings = modules.re.sub("'(?:''|[^'])*'", " ", compiled_code_without_comments) -%}
+  {%- set uses_dbt_max_partition = modules.re.search("(^|[^A-Za-z0-9_])_dbt_max_partition([^A-Za-z0-9_]|$)", compiled_code_without_comments_or_strings) is not none -%}
+  {%- set relation_exists = load_relation(relation) is not none -%}
+
+  {%- if uses_dbt_max_partition and relation_exists -%}
 
     declare _dbt_max_partition {{ partition_by.data_type_for_partition() }} default (
       select max({{ partition_by.field }}) from {{ this }}

--- a/dbt-bigquery/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
+++ b/dbt-bigquery/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
@@ -190,6 +190,28 @@ where date_day >= _dbt_max_partition
 {% endif %}
 """.lstrip()
 
+overwrite_comment_only_max_partition_token_sql = """
+{{
+    config(
+        materialized="incremental",
+        incremental_strategy='insert_overwrite',
+        on_schema_change='append_new_columns',
+        partition_by={
+            "field": "date_day",
+            "data_type": "date"
+        }
+    )
+}}
+
+with data as (
+    select 1 as id, cast('2020-01-01' as date) as date_day
+)
+
+-- _dbt_max_partition appears in a comment and must not trigger declaration.
+/* _dbt_max_partition in block comments should also be ignored. */
+select * from data
+""".lstrip()
+
 overwrite_day_sql = """
 {{
     config(

--- a/dbt-bigquery/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/dbt-bigquery/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -30,6 +30,7 @@ from tests.functional.adapter.incremental.incremental_strategy_fixtures import (
     overwrite_day_with_time_ingestion_sql,
     overwrite_day_with_time_partition_datetime_sql,
     overwrite_static_day_sql,
+    overwrite_comment_only_max_partition_token_sql,
 )
 
 
@@ -122,3 +123,20 @@ class TestBigQueryScripting(SeedConfigBase):
             project.adapter, "incremental_overwrite_day_with_time_partition_expected"
         )
         assert created == expected
+
+
+class TestBigQueryMaxPartitionCommentToken:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_overwrite_comment_token.sql": (
+                overwrite_comment_only_max_partition_token_sql
+            ),
+        }
+
+    def test_first_run_and_incremental_run_succeed(self):
+        first_run = run_dbt()
+        assert len(first_run) == 1
+
+        second_run = run_dbt()
+        assert len(second_run) == 1


### PR DESCRIPTION
## Summary
- fix `declare_dbt_max_partition` to avoid matching `_dbt_max_partition` mentions that only appear in SQL comments/quoted string literals
- only emit the declaration when the target relation exists
- add a functional regression test that runs an `insert_overwrite` incremental model where `_dbt_max_partition` appears only in comments and verifies first + second runs succeed

## Root Cause
`declare_dbt_max_partition` previously used a raw substring check:

```jinja
'_dbt_max_partition' in compiled_code
```

This matched comment text, causing declaration injection even when the model did not actually reference `_dbt_max_partition` in executable SQL.

On first run, that declaration queried the target table before it existed, producing a table-not-found error.

## Changes
- `dbt-bigquery/src/dbt/include/bigquery/macros/materializations/incremental_strategy/common.sql`
  - sanitize `compiled_code` by removing comments and single-quoted string literals before detection
  - use boundary-aware regex for token detection
  - guard declaration behind `load_relation(relation) is not none`
- `dbt-bigquery/tests/functional/adapter/incremental/incremental_strategy_fixtures.py`
  - add `overwrite_comment_only_max_partition_token_sql` fixture
- `dbt-bigquery/tests/functional/adapter/incremental/test_incremental_strategies.py`
  - add `TestBigQueryMaxPartitionCommentToken` regression test

## Issue
- Closes #1907
