### PR TITLE
feat(dbt-adapters): enforce model contract on materialized view create

### DIFF
--- a/dbt-adapters/.changes/unreleased/Features-20260504-211110.yaml
+++ b/dbt-adapters/.changes/unreleased/Features-20260504-211110.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Enforce model contract column-equivalence on materialized view create/full-refresh, and add reusable `get_columns_and_constraints_clause` macro so adapters whose DB supports MV constraint DDL can opt into rendering them
+time: 2026-05-04T21:11:10.000000+00:00
+custom:
+  Author: colin-rogers-dbt
+  Issue: "0"

--- a/dbt-adapters/.changes/unreleased/Features-20260504-211110.yaml
+++ b/dbt-adapters/.changes/unreleased/Features-20260504-211110.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Enforce model contract column-equivalence on materialized view create/full-refresh, and add reusable `get_columns_and_constraints_clause` macro so adapters whose DB supports MV constraint DDL can opt into rendering them
+body: Enforce model contract column-equivalence on materialized view create/full-refresh (gated by new `enforce_contract_on_materialized_view` behavior flag, default `True`), and add reusable `get_columns_and_constraints_clause` macro so adapters whose DB supports MV constraint DDL can opt into rendering them
 time: 2026-05-04T21:11:10.000000+00:00
 custom:
   Author: colin-rogers-dbt

--- a/dbt-adapters/src/dbt/adapters/base/impl.py
+++ b/dbt-adapters/src/dbt/adapters/base/impl.py
@@ -130,6 +130,15 @@ DEFAULT_BASE_BEHAVIOR_FLAGS = [
         "default": False,
         "docs_url": "",
     },
+    {
+        # When True (default), enforces the model contract on materialized
+        # view create / full-refresh by running the same column-equivalence
+        # check used for tables. Users can opt out by setting this flag to
+        # False in their project's `flags:` block.
+        "name": "enforce_contract_on_materialized_view",
+        "default": True,
+        "docs_url": "",
+    },
 ]
 
 

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/materialized_view.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/materialized_view.sql
@@ -56,7 +56,7 @@
 
     -- determine the scenario we're in: create, full_refresh, alter, refresh data
     {% if existing_relation is none %}
-        {% if contract_config and contract_config.enforced %}
+        {% if contract_config and contract_config.enforced and adapter.behavior.enforce_contract_on_materialized_view.no_warn %}
             {#-
               Enforce the model contract on initial creation. Most warehouses
               (postgres, redshift, bigquery, snowflake dynamic tables) do not
@@ -70,7 +70,7 @@
         {% endif %}
         {% set build_sql = get_create_materialized_view_as_sql(target_relation, sql) %}
     {% elif full_refresh_mode or not existing_relation.is_materialized_view %}
-        {% if contract_config and contract_config.enforced %}
+        {% if contract_config and contract_config.enforced and adapter.behavior.enforce_contract_on_materialized_view.no_warn %}
             {{ get_assert_columns_equivalent(sql) }}
         {% endif %}
         {% set build_sql = get_replace_sql(existing_relation, target_relation, sql) %}

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/materialized_view.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/materialized_view.sql
@@ -52,11 +52,27 @@
 {% macro materialized_view_get_build_sql(existing_relation, target_relation, backup_relation, intermediate_relation) %}
 
     {% set full_refresh_mode = should_full_refresh() %}
+    {% set contract_config = config.get('contract') %}
 
     -- determine the scenario we're in: create, full_refresh, alter, refresh data
     {% if existing_relation is none %}
+        {% if contract_config and contract_config.enforced %}
+            {#-
+              Enforce the model contract on initial creation. Most warehouses
+              (postgres, redshift, bigquery, snowflake dynamic tables) do not
+              accept inline constraint clauses on materialized view DDL, so the
+              base materialization only verifies column-shape equivalence here.
+              Adapters whose DB does support MV constraints can render them by
+              overriding `<adapter>__get_create_materialized_view_as_sql` and
+              calling `get_columns_and_constraints_clause(sql)`.
+            -#}
+            {{ get_assert_columns_equivalent(sql) }}
+        {% endif %}
         {% set build_sql = get_create_materialized_view_as_sql(target_relation, sql) %}
     {% elif full_refresh_mode or not existing_relation.is_materialized_view %}
+        {% if contract_config and contract_config.enforced %}
+            {{ get_assert_columns_equivalent(sql) }}
+        {% endif %}
         {% set build_sql = get_replace_sql(existing_relation, target_relation, sql) %}
     {% else %}
 

--- a/dbt-adapters/src/dbt/include/global_project/macros/relations/column/columns_spec_ddl.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/relations/column/columns_spec_ddl.sql
@@ -6,6 +6,29 @@
   {{ return(table_columns_and_constraints()) }}
 {%- endmacro %}
 
+{#
+  Reusable wrapper around the contract-enforcement DDL block.
+
+  Emits a `(col type CONSTRAINT ..., ...)` clause for relations whose contract
+  is enforced, after asserting that the SQL columns match the YAML schema.
+  Callers are still responsible for rewriting the SELECT via
+  `get_select_subquery(sql)` when they need the projection order to match the
+  rendered DDL (e.g. `create table ... as (select ...)`).
+
+  Intended to be reused by any relation-create macro that wants the same
+  contract semantics as `default__create_table_as` — including materialized
+  view / dynamic table / streaming table create macros for adapters whose
+  underlying DB accepts constraint clauses on those relation types.
+#}
+{%- macro get_columns_and_constraints_clause(sql) -%}
+  {{ adapter.dispatch('get_columns_and_constraints_clause', 'dbt')(sql) }}
+{%- endmacro -%}
+
+{% macro default__get_columns_and_constraints_clause(sql) -%}
+  {{ get_assert_columns_equivalent(sql) }}
+  {{ get_table_columns_and_constraints() }}
+{%- endmacro %}
+
 {% macro table_columns_and_constraints() %}
   {# loop through user_provided_columns to create DDL with data types and constraints #}
     {%- set raw_column_constraints = adapter.render_raw_columns_constraints(raw_columns=model['columns']) -%}

--- a/dbt-adapters/src/dbt/include/global_project/macros/relations/table/create.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/relations/table/create.sql
@@ -27,8 +27,7 @@
     {{ relation.include(database=(not temporary), schema=(not temporary)) }}
   {% set contract_config = config.get('contract') %}
   {% if contract_config.enforced and (not temporary) %}
-    {{ get_assert_columns_equivalent(sql) }}
-    {{ get_table_columns_and_constraints() }}
+    {{ get_columns_and_constraints_clause(sql) }}
     {%- set sql = get_select_subquery(sql) %}
   {% endif %}
   as (


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/# N/A

### Problem

When a user sets `contract.enforced: true` on a materialized view, dbt today silently skips contract verification. The yaml-vs-sql column-equivalence check that runs for table materializations is never invoked from `materialized_view.sql`, so a drift between the SQL output columns and the YAML contract goes undetected on MVs.

Separately, the contract-DDL block inside `default__create_table_as` (`get_assert_columns_equivalent` + `get_table_columns_and_constraints` + `get_select_subquery`) is hard-coded to the table-create path. Adapters that want the same semantics on a different relation type (e.g. dbt-databricks for MV / streaming-table DDL, which does accept inline constraints) have no reusable hook — they'd have to duplicate the trio inline.

### Solution

Two small base-framework changes:

1. **Reusable contract clause helper.** New dispatched macro `get_columns_and_constraints_clause(sql)` in `columns_spec_ddl.sql` that emits the assert-equivalence + columns-and-constraints DDL pair. `default__create_table_as` now uses it (no behavior change). Adapter-specific `<adapter>__create_table_as` overrides are intentionally left alone — they continue to call the underlying macros directly and can opt into the helper later.

2. **Contract enforcement in the shared MV materialization.** `materialized_view_get_build_sql` now calls `get_assert_columns_equivalent(sql)` on initial create and on full-refresh / type-mismatch replace when `contract.enforced` is true.

   Most warehouses (postgres, redshift, bigquery, snowflake dynamic tables) do not accept inline constraint clauses on MV DDL, so the base materialization stops at the column-equivalence assert. Adapters whose DB does support MV constraints (e.g. dbt-databricks Delta MVs, future Databricks streaming tables) can opt in by overriding `<adapter>__get_create_materialized_view_as_sql(relation, sql)` and calling `get_columns_and_constraints_clause(sql)` from inside their DDL — they get the same contract semantics as table create with no further framework changes.

### What this enables

- All adapters now get the contract column-shape check on MV create/full-refresh for free.
- A clean opt-in path for adapters whose target DB accepts constraint DDL on MV-like relations, without forcing a parallel constraint-rendering codepath.

### What this intentionally does **not** do

- Does not introduce relation-type-aware `CONSTRAINT_SUPPORT` (different MV vs table capabilities). That's a larger framework change tracked separately.
- Does not migrate per-adapter `<adapter>__create_table_as` overrides to the new helper. Backwards-compatible refactor for a follow-up.
- Does not add a `BaseMaterializedViewContract` test class to `dbt-tests-adapter`. Recommend pairing that with the relation-type-aware constraint matrix work.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue — *local hatch envs were broken on Python 3.14 (`ddtrace` build / `pkg_resources`); please verify in CI. Edited Jinja parses cleanly against `jinja2 + ext.do + ext.loopcontrols`.*
- [ ] This PR includes tests, or tests are not required/relevant for this PR — *no new tests; existing contract-on-table tests cover the refactor of `default__create_table_as`. A `BaseMaterializedViewContract` base class belongs with the broader MV-constraints framework work.*
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX — **adds a new dispatched macro** (`get_columns_and_constraints_clause`) and changes when contract enforcement raises on MVs (previously: never; now: on create / full-refresh). Flagging for DX review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)