### PR TITLE
backport: Snowflake dynamic table features to stable

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Breaking Changes-20260209-113822.yaml
+++ b/dbt-snowflake/.changes/unreleased/Breaking Changes-20260209-113822.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Add transient support for Snowflake dynamic tables via `transient` config option and `snowflake_default_transient_dynamic_tables` behavior flag.
+time: 2026-02-09T11:38:22.629597-08:00
+custom:
+    Author: igorbelianski-cyber
+    Issue: "716"

--- a/dbt-snowflake/.changes/unreleased/Features-20250707-131918.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20250707-131918.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add COPY GRANTS support for dynamic tables to inherit object-level privileges during table creation and replacement
+time: 2025-07-07T13:19:18.6N+1000
+custom:
+  Author: shaariqch
+  Issue: "1154"

--- a/dbt-snowflake/.changes/unreleased/Features-20260312-150724.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260312-150724.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add scheduler configuration support for Snowflake dynamic tables, enabling dbt-managed refresh scheduling that is decoupled from upstream and downstream dynamic table dependencies.
+time: 2026-03-12T15:07:24-07:00
+custom:
+    Author: ibelianski
+    Issue: none

--- a/dbt-snowflake/.changes/unreleased/Features-20260323-000000.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260323-000000.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add refresh_warehouse config for Snowflake dynamic tables, allowing a separate warehouse for self-refresh independent of the DDL execution warehouse
+time: 2026-03-23T00:00:00.000000-00:00
+custom:
+    Author: colinrogers
+    Issue: "1193"

--- a/dbt-snowflake/.changes/unreleased/Features-20260424-transient-tmp-relation.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260424-transient-tmp-relation.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add `tmp_relation_type=transient` support for incremental models, enabling Snowflake lineage tracking; add `snowflake__resolve_incremental_tmp_relation` dispatch macro for controlling tmp relation destination
+time: 2026-04-24T00:00:00.000000-00:00
+custom:
+    Author: b-per
+    Issue: "1893"

--- a/dbt-snowflake/.changes/unreleased/Fixes-20260406-161354.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260406-161354.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix ALTER DYNAMIC TABLE with immutable where sometimes causing a syntax error
+time: 2026-04-06T16:13:54.700633-07:00
+custom:
+    Author: ajhlee-dbt
+    Issue: "1836"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
@@ -63,6 +63,7 @@ class SnowflakeConfig(AdapterConfig):
     copy_grants: Optional[bool] = None
     snowflake_warehouse: Optional[str] = None
     snowflake_initialization_warehouse: Optional[str] = None
+    refresh_warehouse: Optional[str] = None
     query_tag: Optional[str] = None
     tmp_relation_type: Optional[str] = None
     merge_update_columns: Optional[str] = None
@@ -175,12 +176,14 @@ class SnowflakeAdapter(SQLAdapter):
     def _strip_quotes(self, identifier: str) -> str:
         return identifier.strip(self.Relation.quote_character)
 
-    def _get_warehouse(self) -> str:
+    def _get_warehouse(self) -> Optional[str]:
         _, table = self.execute("select current_warehouse() as warehouse", fetch=True)
         if len(table) == 0 or len(table[0]) == 0:
-            # can this happen?
-            raise DbtRuntimeError("Could not get current warehouse: no results")
-        return str(table[0][0])
+            return None
+        value = table[0][0]
+        if value is None or str(value).upper() == "NULL":
+            return None
+        return str(value)
 
     def _use_warehouse(self, warehouse: str):
         """Use the given warehouse. Quotes are never applied."""

--- a/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
@@ -67,6 +67,7 @@ class SnowflakeConfig(AdapterConfig):
     tmp_relation_type: Optional[str] = None
     merge_update_columns: Optional[str] = None
     target_lag: Optional[str] = None
+    scheduler: Optional[str] = None
     row_access_policy: Optional[str] = None
     table_tag: Optional[str] = None
     immutable_where: Optional[str] = None
@@ -562,6 +563,8 @@ CALL {proc_name}();
         available_columns = [c.lower() for c in dt_table.column_names]
         if "initialization_warehouse" in available_columns:
             base_columns.insert(base_columns.index("warehouse") + 1, "initialization_warehouse")
+        if "scheduler" in available_columns:
+            base_columns.append("scheduler")
 
         selected = dt_table.select(base_columns)
 

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
@@ -26,6 +26,7 @@ from dbt.adapters.snowflake.relation_configs import (
     SnowflakeDynamicTableWarehouseConfigChange,
     SnowflakeDynamicTableImmutableWhereConfigChange,
     SnowflakeDynamicTableClusterByConfigChange,
+    SnowflakeDynamicTableTransientConfigChange,
     SnowflakeQuotePolicy,
     SnowflakeRelationType,
 )
@@ -93,7 +94,9 @@ class SnowflakeRelation(BaseRelation):
 
     @classmethod
     def dynamic_table_config_changeset(
-        cls, relation_results: RelationResults, relation_config: RelationConfig
+        cls,
+        relation_results: RelationResults,
+        relation_config: RelationConfig,
     ) -> Optional[SnowflakeDynamicTableConfigChangeset]:
         existing_dynamic_table = SnowflakeDynamicTableConfig.from_relation_results(
             relation_results
@@ -148,6 +151,19 @@ class SnowflakeRelation(BaseRelation):
             config_change_collection.cluster_by = SnowflakeDynamicTableClusterByConfigChange(
                 action=RelationConfigChangeAction.alter,  # type:ignore
                 context=new_dynamic_table.cluster_by,
+            )
+
+        # Transient is only compared when both sides are explicitly known:
+        # - new is None when the user omitted transient from their config ("don't care")
+        # - existing is None when describe_dynamic_table was called without include_transient
+        if (
+            new_dynamic_table.transient is not None
+            and existing_dynamic_table.transient is not None
+            and new_dynamic_table.transient != existing_dynamic_table.transient
+        ):
+            config_change_collection.transient = SnowflakeDynamicTableTransientConfigChange(
+                action=RelationConfigChangeAction.create,  # type: ignore
+                context=new_dynamic_table.transient,
             )
 
         if config_change_collection.has_changes:

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
@@ -115,11 +115,11 @@ class SnowflakeRelation(BaseRelation):
                 context=new_dynamic_table.target_lag,
             )
 
-        if new_dynamic_table.snowflake_warehouse != existing_dynamic_table.snowflake_warehouse:
+        if new_dynamic_table.warehouse_parameter != existing_dynamic_table.warehouse_parameter:
             config_change_collection.snowflake_warehouse = (
                 SnowflakeDynamicTableWarehouseConfigChange(
                     action=RelationConfigChangeAction.alter,  # type:ignore
-                    context=new_dynamic_table.snowflake_warehouse,
+                    context=new_dynamic_table.warehouse_parameter,
                 )
             )
 

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
@@ -22,6 +22,7 @@ from dbt.adapters.snowflake.relation_configs import (
     SnowflakeDynamicTableConfigChangeset,
     SnowflakeDynamicTableInitializationWarehouseConfigChange,
     SnowflakeDynamicTableRefreshModeConfigChange,
+    SnowflakeDynamicTableSchedulerConfigChange,
     SnowflakeDynamicTableTargetLagConfigChange,
     SnowflakeDynamicTableWarehouseConfigChange,
     SnowflakeDynamicTableImmutableWhereConfigChange,
@@ -105,7 +106,10 @@ class SnowflakeRelation(BaseRelation):
 
         config_change_collection = SnowflakeDynamicTableConfigChangeset()
 
-        if new_dynamic_table.target_lag != existing_dynamic_table.target_lag:
+        if (
+            new_dynamic_table.target_lag != existing_dynamic_table.target_lag
+            and new_dynamic_table.target_lag is not None
+        ):
             config_change_collection.target_lag = SnowflakeDynamicTableTargetLagConfigChange(
                 action=RelationConfigChangeAction.alter,  # type:ignore
                 context=new_dynamic_table.target_lag,
@@ -137,6 +141,12 @@ class SnowflakeRelation(BaseRelation):
             config_change_collection.refresh_mode = SnowflakeDynamicTableRefreshModeConfigChange(
                 action=RelationConfigChangeAction.create,  # type:ignore
                 context=new_dynamic_table.refresh_mode,
+            )
+
+        if new_dynamic_table.scheduler != existing_dynamic_table.scheduler:
+            config_change_collection.scheduler = SnowflakeDynamicTableSchedulerConfigChange(
+                action=RelationConfigChangeAction.alter,  # type:ignore
+                context=new_dynamic_table.scheduler,
             )
 
         if new_dynamic_table.immutable_where != existing_dynamic_table.immutable_where:

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/__init__.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/__init__.py
@@ -8,6 +8,7 @@ from dbt.adapters.snowflake.relation_configs.dynamic_table import (
     SnowflakeDynamicTableTargetLagConfigChange,
     SnowflakeDynamicTableImmutableWhereConfigChange,
     SnowflakeDynamicTableClusterByConfigChange,
+    SnowflakeDynamicTableTransientConfigChange,
 )
 from dbt.adapters.snowflake.relation_configs.policies import (
     SnowflakeIncludePolicy,

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/__init__.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/__init__.py
@@ -1,9 +1,11 @@
 from dbt.adapters.snowflake.relation_configs.dynamic_table import (
     RefreshMode,
+    Scheduler,
     SnowflakeDynamicTableConfig,
     SnowflakeDynamicTableConfigChangeset,
     SnowflakeDynamicTableInitializationWarehouseConfigChange,
     SnowflakeDynamicTableRefreshModeConfigChange,
+    SnowflakeDynamicTableSchedulerConfigChange,
     SnowflakeDynamicTableWarehouseConfigChange,
     SnowflakeDynamicTableTargetLagConfigChange,
     SnowflakeDynamicTableImmutableWhereConfigChange,

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
@@ -49,6 +49,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
     - initialize: specifies the behavior of the initial refresh of the dynamic table
     - cluster_by: specifies the columns to cluster on
     - immutable_where: specifies an immutability constraint expression
+    - transient: specifies whether the dynamic table is transient (no fail-safe). snowflake_default_transient_dynamic_tables determines the default value
 
     There are currently no non-configurable parameters.
     """
@@ -66,6 +67,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
     table_tag: Optional[str] = None
     cluster_by: Optional[Union[str, list[str]]] = None
     immutable_where: Optional[str] = None
+    transient: Optional[bool] = None
 
     @classmethod
     def from_dict(cls, config_dict: Dict[str, Any]) -> Self:
@@ -91,6 +93,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
             "table_tag": config_dict.get("table_tag"),
             "cluster_by": config_dict.get("cluster_by"),
             "immutable_where": config_dict.get("immutable_where"),
+            "transient": config_dict.get("transient"),
         }
 
         return super().from_dict(kwargs_dict)  # type:ignore
@@ -117,6 +120,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
             "immutable_where": relation_config.config.extra.get(  # type:ignore
                 "immutable_where"
             ),
+            "transient": relation_config.config.extra.get("transient"),  # type:ignore
         }
 
         if refresh_mode := relation_config.config.extra.get("refresh_mode"):  # type:ignore
@@ -172,6 +176,9 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
             "table_tag": dynamic_table.get("table_tag"),
             "cluster_by": cluster_by,
             "immutable_where": immutable_where,
+            # agate.Row.get() returns None when the column is absent, which is the
+            # correct default -- it means "not queried" and skips transient comparison.
+            "transient": dynamic_table.get("transient"),
             # we don't get initialize since that's a one-time scheduler attribute, not a DT attribute
         }
 
@@ -232,6 +239,16 @@ class SnowflakeDynamicTableClusterByConfigChange(RelationConfigChange):
         return False
 
 
+@dataclass(frozen=True, eq=True, unsafe_hash=True)
+class SnowflakeDynamicTableTransientConfigChange(RelationConfigChange):
+    context: Optional[bool] = None
+
+    @property
+    def requires_full_refresh(self) -> bool:
+        # Transient cannot be changed via ALTER, requires full table recreation
+        return True
+
+
 @dataclass
 class SnowflakeDynamicTableConfigChangeset:
     target_lag: Optional[SnowflakeDynamicTableTargetLagConfigChange] = None
@@ -242,6 +259,7 @@ class SnowflakeDynamicTableConfigChangeset:
     refresh_mode: Optional[SnowflakeDynamicTableRefreshModeConfigChange] = None
     immutable_where: Optional[SnowflakeDynamicTableImmutableWhereConfigChange] = None
     cluster_by: Optional[SnowflakeDynamicTableClusterByConfigChange] = None
+    transient: Optional[SnowflakeDynamicTableTransientConfigChange] = None
 
     @property
     def requires_full_refresh(self) -> bool:
@@ -261,6 +279,7 @@ class SnowflakeDynamicTableConfigChangeset:
                 self.refresh_mode.requires_full_refresh if self.refresh_mode else False,
                 self.immutable_where.requires_full_refresh if self.immutable_where else False,
                 self.cluster_by.requires_full_refresh if self.cluster_by else False,
+                self.transient.requires_full_refresh if self.transient else False,
             ]
         )
 
@@ -274,5 +293,6 @@ class SnowflakeDynamicTableConfigChangeset:
                 self.refresh_mode,
                 self.immutable_where,
                 self.cluster_by,
+                self.transient,
             ]
         )

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
@@ -76,6 +76,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
     row_access_policy: Optional[str] = None
     table_tag: Optional[str] = None
     cluster_by: Optional[Union[str, list[str]]] = None
+    copy_grants: Optional[bool] = None
     immutable_where: Optional[str] = None
     transient: Optional[bool] = None
 
@@ -114,6 +115,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
             "row_access_policy": config_dict.get("row_access_policy"),
             "table_tag": config_dict.get("table_tag"),
             "cluster_by": config_dict.get("cluster_by"),
+            "copy_grants": config_dict.get("copy_grants"),
             "immutable_where": config_dict.get("immutable_where"),
             "transient": config_dict.get("transient"),
         }
@@ -142,6 +144,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
             ),
             "table_tag": relation_config.config.extra.get("table_tag"),  # type:ignore
             "cluster_by": cluster_by(relation_config),
+            "copy_grants": relation_config.config.extra.get("copy_grants"),  # type:ignore
             "immutable_where": relation_config.config.extra.get(  # type:ignore
                 "immutable_where"
             ),

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
@@ -5,6 +5,7 @@ from dbt.adapters.relation_configs import RelationConfigChange, RelationResults
 from dbt.adapters.contracts.relation import RelationConfig
 from dbt.adapters.contracts.relation import ComponentName
 from dbt_common.dataclass_schema import StrEnum  # doesn't exist in standard library until py3.11
+from dbt_common.exceptions import CompilationError
 from typing_extensions import Self
 
 from dbt.adapters.snowflake.parse_model import cluster_by
@@ -33,6 +34,11 @@ class Initialize(StrEnum):
         return cls("ON_CREATE")
 
 
+class Scheduler(StrEnum):
+    ENABLE = "ENABLE"
+    DISABLE = "DISABLE"
+
+
 @dataclass(frozen=True, eq=True, unsafe_hash=True)
 class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
     """
@@ -47,6 +53,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
     - snowflake_initialization_warehouse: the name of the warehouse used for the initializations and reinitializations of the dynamic table
     - refresh_mode: specifies the refresh type for the dynamic table
     - initialize: specifies the behavior of the initial refresh of the dynamic table
+    - scheduler: specifies whether to ENABLE or DISABLE the dynamic table's scheduler
     - cluster_by: specifies the columns to cluster on
     - immutable_where: specifies an immutability constraint expression
     - transient: specifies whether the dynamic table is transient (no fail-safe). snowflake_default_transient_dynamic_tables determines the default value
@@ -58,11 +65,12 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
     schema_name: str
     database_name: str
     query: str
-    target_lag: str
     snowflake_warehouse: str
+    target_lag: Optional[str] = None
     snowflake_initialization_warehouse: Optional[str] = None
     refresh_mode: Optional[RefreshMode] = RefreshMode.default()
     initialize: Optional[Initialize] = Initialize.default()
+    scheduler: Optional[Scheduler] = None
     row_access_policy: Optional[str] = None
     table_tag: Optional[str] = None
     cluster_by: Optional[Union[str, list[str]]] = None
@@ -89,6 +97,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
             ),
             "refresh_mode": config_dict.get("refresh_mode"),
             "initialize": config_dict.get("initialize"),
+            "scheduler": config_dict.get("scheduler"),
             "row_access_policy": config_dict.get("row_access_policy"),
             "table_tag": config_dict.get("table_tag"),
             "cluster_by": config_dict.get("cluster_by"),
@@ -129,6 +138,32 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
         if initialize := relation_config.config.extra.get("initialize"):  # type:ignore
             config_dict["initialize"] = initialize.upper()
 
+        target_lag = config_dict.get("target_lag")
+        if scheduler := relation_config.config.extra.get("scheduler"):  # type:ignore
+            normalized_scheduler = scheduler.upper()
+            if normalized_scheduler not in (Scheduler.ENABLE, Scheduler.DISABLE):
+                raise CompilationError(
+                    "Invalid value for `scheduler`: "
+                    f"'{scheduler}'. Expected one of: "
+                    f"{Scheduler.ENABLE}, {Scheduler.DISABLE}."
+                )
+
+            if normalized_scheduler == Scheduler.ENABLE and target_lag is None:
+                raise CompilationError(
+                    "Invalid dynamic table config: `scheduler='ENABLE'` requires `target_lag`."
+                )
+
+            if normalized_scheduler == Scheduler.DISABLE and target_lag is not None:
+                raise CompilationError(
+                    "Invalid dynamic table config: `scheduler='DISABLE'` requires `target_lag` "
+                    "to be omitted."
+                )
+            config_dict["scheduler"] = normalized_scheduler
+        elif target_lag:
+            config_dict["scheduler"] = Scheduler.ENABLE
+        else:
+            config_dict["scheduler"] = Scheduler.DISABLE
+
         return config_dict
 
     @classmethod
@@ -163,15 +198,21 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
         else:
             cluster_by = None
 
+        scheduler = dynamic_table.get("scheduler")
+        target_lag = dynamic_table.get("target_lag")
+        if scheduler is None:
+            scheduler = Scheduler.ENABLE if target_lag else Scheduler.DISABLE
+
         config_dict = {
             "name": dynamic_table.get("name"),
             "schema_name": dynamic_table.get("schema_name"),
             "database_name": dynamic_table.get("database_name"),
             "query": dynamic_table.get("text"),
-            "target_lag": dynamic_table.get("target_lag"),
+            "target_lag": target_lag,
             "snowflake_warehouse": dynamic_table.get("warehouse"),
             "snowflake_initialization_warehouse": init_warehouse,
             "refresh_mode": dynamic_table.get("refresh_mode"),
+            "scheduler": scheduler,
             "row_access_policy": dynamic_table.get("row_access_policy"),
             "table_tag": dynamic_table.get("table_tag"),
             "cluster_by": cluster_by,
@@ -240,6 +281,15 @@ class SnowflakeDynamicTableClusterByConfigChange(RelationConfigChange):
 
 
 @dataclass(frozen=True, eq=True, unsafe_hash=True)
+class SnowflakeDynamicTableSchedulerConfigChange(RelationConfigChange):
+    context: Optional[str] = None
+
+    @property
+    def requires_full_refresh(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True, eq=True, unsafe_hash=True)
 class SnowflakeDynamicTableTransientConfigChange(RelationConfigChange):
     context: Optional[bool] = None
 
@@ -257,6 +307,7 @@ class SnowflakeDynamicTableConfigChangeset:
         SnowflakeDynamicTableInitializationWarehouseConfigChange
     ] = None
     refresh_mode: Optional[SnowflakeDynamicTableRefreshModeConfigChange] = None
+    scheduler: Optional[SnowflakeDynamicTableSchedulerConfigChange] = None
     immutable_where: Optional[SnowflakeDynamicTableImmutableWhereConfigChange] = None
     cluster_by: Optional[SnowflakeDynamicTableClusterByConfigChange] = None
     transient: Optional[SnowflakeDynamicTableTransientConfigChange] = None
@@ -277,6 +328,7 @@ class SnowflakeDynamicTableConfigChangeset:
                     else False
                 ),
                 self.refresh_mode.requires_full_refresh if self.refresh_mode else False,
+                self.scheduler.requires_full_refresh if self.scheduler else False,
                 self.immutable_where.requires_full_refresh if self.immutable_where else False,
                 self.cluster_by.requires_full_refresh if self.cluster_by else False,
                 self.transient.requires_full_refresh if self.transient else False,
@@ -291,6 +343,7 @@ class SnowflakeDynamicTableConfigChangeset:
                 self.snowflake_warehouse,
                 self.snowflake_initialization_warehouse,
                 self.refresh_mode,
+                self.scheduler,
                 self.immutable_where,
                 self.cluster_by,
                 self.transient,

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
@@ -49,7 +49,8 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
     - name: name of the dynamic table
     - query: the query behind the table
     - target_lag: the maximum amount of time that the dynamic table’s content should lag behind updates to the base tables
-    - snowflake_warehouse: the name of the warehouse that provides the compute resources for refreshing the dynamic table
+    - snowflake_warehouse: the name of the warehouse used to execute DDL (CREATE/ALTER); also used as the dynamic table's refresh warehouse when refresh_warehouse is not set
+    - refresh_warehouse: when set, used as the WAREHOUSE = parameter in the DDL (the table's self-refresh warehouse); snowflake_warehouse still executes the DDL
     - snowflake_initialization_warehouse: the name of the warehouse used for the initializations and reinitializations of the dynamic table
     - refresh_mode: specifies the refresh type for the dynamic table
     - initialize: specifies the behavior of the initial refresh of the dynamic table
@@ -68,6 +69,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
     snowflake_warehouse: str
     target_lag: Optional[str] = None
     snowflake_initialization_warehouse: Optional[str] = None
+    refresh_warehouse: Optional[str] = None
     refresh_mode: Optional[RefreshMode] = RefreshMode.default()
     initialize: Optional[Initialize] = Initialize.default()
     scheduler: Optional[Scheduler] = None
@@ -76,6 +78,16 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
     cluster_by: Optional[Union[str, list[str]]] = None
     immutable_where: Optional[str] = None
     transient: Optional[bool] = None
+
+    @property
+    def warehouse_parameter(self) -> str:
+        """The value used for the WAREHOUSE = parameter in CREATE/REPLACE DYNAMIC TABLE DDL.
+
+        When refresh_warehouse is set it is used here, so the dynamic table's self-refresh
+        runs on a different warehouse than the one executing the DDL (snowflake_warehouse).
+        When only snowflake_warehouse is set it serves both roles, preserving existing behaviour.
+        """
+        return self.refresh_warehouse or self.snowflake_warehouse
 
     @classmethod
     def from_dict(cls, config_dict: Dict[str, Any]) -> Self:
@@ -95,6 +107,7 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
             "snowflake_initialization_warehouse": config_dict.get(
                 "snowflake_initialization_warehouse"
             ),
+            "refresh_warehouse": config_dict.get("refresh_warehouse"),
             "refresh_mode": config_dict.get("refresh_mode"),
             "initialize": config_dict.get("initialize"),
             "scheduler": config_dict.get("scheduler"),
@@ -120,6 +133,9 @@ class SnowflakeDynamicTableConfig(SnowflakeRelationConfigBase):
             ),
             "snowflake_initialization_warehouse": relation_config.config.extra.get(  # type:ignore
                 "snowflake_initialization_warehouse"
+            ),
+            "refresh_warehouse": relation_config.config.extra.get(  # type:ignore
+                "refresh_warehouse"
             ),
             "row_access_policy": relation_config.config.extra.get(  # type:ignore
                 "row_access_policy"

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/dynamic_table.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/dynamic_table.sql
@@ -91,7 +91,8 @@
 
 
 {% macro snowflake__get_dynamic_table_configuration_changes(existing_relation, new_config) -%}
-    {% set _existing_dynamic_table = snowflake__describe_dynamic_table(existing_relation) %}
+    {% set _include_transient = new_config.get("transient") is not none %}
+    {% set _existing_dynamic_table = adapter.describe_dynamic_table(existing_relation, _include_transient) %}
     {% set _configuration_changes = existing_relation.dynamic_table_config_changeset(_existing_dynamic_table, new_config.model) %}
     {% do return(_configuration_changes) %}
 {%- endmacro %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/dynamic_table.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/dynamic_table.sql
@@ -15,6 +15,13 @@
         {{ dynamic_table_execute_build_sql(build_sql, existing_relation, target_relation) }}
     {% endif %}
 
+    {%- set dynamic_table = target_relation.from_config(config.model) -%}
+    {% if dynamic_table.scheduler | upper == 'DISABLE' %}
+        {% call statement(name="refresh") %}
+            {{ snowflake__refresh_dynamic_table(target_relation) }}
+        {% endcall %}
+    {% endif %}
+
     {{ run_hooks(post_hooks) }}
 
     {% do unset_query_tag(query_tag) %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/incremental.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/incremental.sql
@@ -12,25 +12,31 @@
 
        Low-level specifics:
        If an invalid option is specified, then we will raise an
-       excpetion with corresponding message.
+       exception with a corresponding message.
 
        Languages other than SQL (like Python) will use a temporary table.
-       With the default strategy of merge, the user may choose between a temporary
-       table and view (defaulting to view).
+       With the default strategy of merge, the user may choose between a
+       temporary table and view (defaulting to view).
 
-       The append strategy can use a view because it will run a single INSERT statement.
+       The append strategy can use a view because it will run a single INSERT
+       statement.
 
-       When unique_key is none, the delete+insert and microbatch strategies can use a view beacuse a
-       single INSERT statement is run with no DELETES as part of the statement.
-       Otherwise, play it safe by using a temporary table.
+       When unique_key is none, the delete+insert and microbatch strategies
+       can use a view because a single INSERT statement is run with no DELETES
+       as part of the statement. Otherwise, play it safe by using a table.
 
-       Catalog-linked databases (Iceberg tables) does not support using temporary relations.
+       Catalog-linked databases (Iceberg tables) do not support temporary
+       relations or transient tables — only Iceberg tables are allowed. A
+       permanent table is used as the tmp relation for CLD models.
+
+       'transient' is also available as a user-facing tmp_relation_type for
+       non-Iceberg models. Unlike session-scoped temporary tables, transient
+       tables are visible to Snowflake's lineage tracking. Note that transient
+       tables share the regular schema namespace; use the
+       snowflake__resolve_incremental_tmp_relation dispatch macro to redirect
+       tmp relations to a dedicated schema to avoid name collisions when
+       multiple runs share the same target schema.
   #} */
-
-  {#-- Always use table for catalog-linked databases (Iceberg) --#}
-  {% if snowflake__is_catalog_linked_database(relation=config.model) %}
-    {{ return("table") }}
-  {% endif %}
 
   {% if language == "python" and tmp_relation_type is not none %}
     {% do exceptions.raise_compiler_error(
@@ -39,21 +45,31 @@
     ) %}
   {% endif %}
 
-  {% if strategy in ["delete+insert", "microbatch"] and tmp_relation_type is not none and tmp_relation_type != "table" and unique_key is not none %}
+  {#-- Python always uses a temporary table, regardless of other conditions --#}
+  {% if language != "sql" %}
+    {{ return("table") }}
+  {% endif %}
+
+  {#-- CLD schemas only support Iceberg tables; use table (not transient) --#}
+  {% if snowflake__is_catalog_linked_database(relation=config.model) %}
+    {{ return("table") }}
+  {% endif %}
+
+  {% if strategy in ["delete+insert", "microbatch"] and tmp_relation_type is not none and tmp_relation_type not in ("table", "transient") and unique_key is not none %}
     {% do exceptions.raise_compiler_error(
       "In order to maintain consistent results when `unique_key` is not none,
-      the `" ~ strategy ~ "` strategy only supports `table` for `tmp_relation_type` but "
+      the `" ~ strategy ~ "` strategy only supports `table` or `transient` for `tmp_relation_type` but "
       ~ tmp_relation_type ~ " was specified."
       )
   %}
   {% endif %}
 
-  {% if language != "sql" %}
-    {{ return("table") }}
-  {% elif tmp_relation_type == "table" %}
+  {% if tmp_relation_type == "table" %}
     {{ return("table") }}
   {% elif tmp_relation_type == "view" %}
     {{ return("view") }}
+  {% elif tmp_relation_type == "transient" %}
+    {{ return("transient") }}
   {% elif strategy in ("default", "merge", "append", "insert_overwrite") %}
     {{ return("view") }}
   {% elif strategy in ["delete+insert", "microbatch"] and unique_key is none %}
@@ -61,6 +77,27 @@
   {% else %}
     {{ return("table") }}
   {% endif %}
+{% endmacro %}
+
+
+{% macro resolve_incremental_tmp_relation(tmp_relation) %}
+  {{ return(adapter.dispatch('resolve_incremental_tmp_relation', 'dbt')(tmp_relation)) }}
+{% endmacro %}
+
+
+{% macro snowflake__resolve_incremental_tmp_relation(tmp_relation) %}
+  {#--
+    Override this macro in your project to control where the incremental
+    tmp relation is created. Useful for redirecting to a dedicated scratch
+    schema to avoid name collisions when multiple runs share the same
+    target schema.
+
+    Example:
+      {% macro snowflake__resolve_incremental_tmp_relation(tmp_relation) %}
+        {{ return(tmp_relation.incorporate(schema='scratch')) }}
+      {% endmacro %}
+  --#}
+  {{ return(tmp_relation) }}
 {% endmacro %}
 
 {% materialization incremental, adapter='snowflake', supported_languages=['sql', 'python'] -%}
@@ -94,8 +131,11 @@
   {% if is_catalog_linked_db %}
     {% set tmp_relation = make_temp_relation(this).incorporate(type=tmp_relation_type, catalog=catalog_relation.catalog_name, is_table=true) %}
   {% else %}
-    {% set tmp_relation = make_temp_relation(this).incorporate(type=tmp_relation_type) %}
+    {#-- Transient tables are dropped with DROP TABLE, so the relation type must be 'table' --#}
+    {% set tmp_relation_object_type = 'table' if tmp_relation_type == 'transient' else tmp_relation_type %}
+    {% set tmp_relation = make_temp_relation(this).incorporate(type=tmp_relation_object_type) %}
   {% endif %}
+  {% set tmp_relation = resolve_incremental_tmp_relation(tmp_relation) %}
 
   {% set grant_config = config.get('grants') %}
 
@@ -131,7 +171,7 @@
     %}
 
   {% else %}
-    {#-- Create the temp relation, either as a view or as a temp table --#}
+    {#-- Create the temp relation as a view, temp table, or transient table --#}
     {% if is_catalog_linked_db %}
         {%- call statement('create_tmp_relation', language=language) -%}
           {{ create_table_as(False, tmp_relation, compiled_code, language) }}
@@ -139,6 +179,10 @@
     {% elif tmp_relation_type == 'view' %}
         {%- call statement('create_tmp_relation') -%}
           {{ snowflake__create_view_as_with_temp_flag(tmp_relation, compiled_code, True) }}
+        {%- endcall -%}
+    {% elif tmp_relation_type == 'transient' %}
+        {%- call statement('create_tmp_relation', language=language) -%}
+          {{ snowflake__create_table_transient_sql(tmp_relation, compiled_code) }}
         {%- endcall -%}
     {% else %}
         {%- call statement('create_tmp_relation', language=language) -%}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/alter.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/alter.sql
@@ -25,7 +25,7 @@
         {%- if cluster_by and cluster_by.context -%}{{- log('Applying UPDATE CLUSTER BY to: ' ~ existing_relation) -}}{%- endif -%}
 
         {#- Determine what SET changes we have -#}
-        {%- set has_set_changes = target_lag or snowflake_warehouse or (snowflake_initialization_warehouse and snowflake_initialization_warehouse.context) or scheduler or (immutable_where and immutable_where.context) -%}
+        {%- set has_set_changes = target_lag or snowflake_warehouse or (snowflake_initialization_warehouse and snowflake_initialization_warehouse.context) or scheduler -%}
 
         {#- Handle SET operations -#}
         {% if has_set_changes %}
@@ -34,7 +34,6 @@
             {% if snowflake_warehouse %}warehouse = {{ snowflake_warehouse.context }}{% endif %}
             {% if snowflake_initialization_warehouse and snowflake_initialization_warehouse.context %}initialization_warehouse = {{ snowflake_initialization_warehouse.context }}{% endif %}
             {% if scheduler %}scheduler = '{{ scheduler.context }}'{% endif %}
-            {% if immutable_where and immutable_where.context %}immutable where ({{ immutable_where.context }}){% endif %}
         {% endif %}
 
         {#- Handle unsetting initialization_warehouse when changed to None/empty -#}
@@ -43,15 +42,19 @@
         alter dynamic table {{ existing_relation }} unset initialization_warehouse
         {% endif %}
 
-        {#- Handle unsetting immutable_where when changed to None/empty -#}
-        {% if immutable_where and not immutable_where.context %}
+        {#- Handle setting or unsetting immutable_where -#}
+        {% if immutable_where %}
         {%- set needs_semicolon = has_set_changes or (snowflake_initialization_warehouse and not snowflake_initialization_warehouse.context) -%}
         {% if needs_semicolon %};{% endif %}
+        {% if immutable_where.context %}
+        alter dynamic table {{ existing_relation }} set immutable where ({{ immutable_where.context }})
+        {% else %}
         alter dynamic table {{ existing_relation }} unset immutable where
+        {% endif %}
         {% endif %}
 
         {#- Track if we've had any previous ALTER statements for semicolon placement -#}
-        {%- set has_prior_statements = has_set_changes or (snowflake_initialization_warehouse and not snowflake_initialization_warehouse.context) or (immutable_where and not immutable_where.context) -%}
+        {%- set has_prior_statements = has_set_changes or (snowflake_initialization_warehouse and not snowflake_initialization_warehouse.context) or immutable_where -%}
 
         {#- Handle CLUSTER BY changes (add/modify) -#}
         {% if cluster_by and cluster_by.context %}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/alter.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/alter.sql
@@ -17,20 +17,23 @@
         {%- if snowflake_warehouse -%}{{- log('Applying UPDATE WAREHOUSE to: ' ~ existing_relation) -}}{%- endif -%}
         {%- set snowflake_initialization_warehouse = configuration_changes.snowflake_initialization_warehouse -%}
         {%- if snowflake_initialization_warehouse and snowflake_initialization_warehouse.context -%}{{- log('Applying UPDATE INITIALIZATION_WAREHOUSE to: ' ~ existing_relation) -}}{%- endif -%}
+        {%- set scheduler = configuration_changes.scheduler -%}
+        {%- if scheduler -%}{{- log('Applying UPDATE SCHEDULER to: ' ~ existing_relation) -}}{%- endif -%}
         {%- set immutable_where = configuration_changes.immutable_where -%}
         {%- if immutable_where and immutable_where.context -%}{{- log('Applying UPDATE IMMUTABLE WHERE to: ' ~ existing_relation) -}}{%- endif -%}
         {%- set cluster_by = configuration_changes.cluster_by -%}
         {%- if cluster_by and cluster_by.context -%}{{- log('Applying UPDATE CLUSTER BY to: ' ~ existing_relation) -}}{%- endif -%}
 
         {#- Determine what SET changes we have -#}
-        {%- set has_set_changes = target_lag or snowflake_warehouse or (snowflake_initialization_warehouse and snowflake_initialization_warehouse.context) or (immutable_where and immutable_where.context) -%}
+        {%- set has_set_changes = target_lag or snowflake_warehouse or (snowflake_initialization_warehouse and snowflake_initialization_warehouse.context) or scheduler or (immutable_where and immutable_where.context) -%}
 
         {#- Handle SET operations -#}
         {% if has_set_changes %}
         alter dynamic table {{ existing_relation }} set
-            {% if target_lag %}target_lag = '{{ target_lag.context }}'{% endif %}
+            {% if target_lag and target_lag.context %}target_lag = '{{ target_lag.context }}'{% endif %}
             {% if snowflake_warehouse %}warehouse = {{ snowflake_warehouse.context }}{% endif %}
             {% if snowflake_initialization_warehouse and snowflake_initialization_warehouse.context %}initialization_warehouse = {{ snowflake_initialization_warehouse.context }}{% endif %}
+            {% if scheduler %}scheduler = '{{ scheduler.context }}'{% endif %}
             {% if immutable_where and immutable_where.context %}immutable where ({{ immutable_where.context }}){% endif %}
         {% endif %}
 

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
@@ -31,7 +31,16 @@
         A valid DDL statement which will result in a new dynamic info schema table.
 -#}
 
-    create dynamic table {{ relation }}
+    {#- Determine transient: explicit config takes precedence, otherwise use behavior flag default -#}
+    {%- if dynamic_table.transient is not none -%}
+        {%- set is_transient = dynamic_table.transient -%}
+    {%- elif adapter.behavior.snowflake_default_transient_dynamic_tables.no_warn -%}
+        {%- set is_transient = true -%}
+    {%- else -%}
+        {%- set is_transient = false -%}
+    {%- endif -%}
+    {%- set transient_keyword = 'transient ' if is_transient else '' -%}
+    create {{ transient_keyword }}dynamic table {{ relation }}
         target_lag = '{{ dynamic_table.target_lag }}'
         warehouse = {{ dynamic_table.snowflake_warehouse }}
         {{ optional('initialization_warehouse', dynamic_table.snowflake_initialization_warehouse) }}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
@@ -42,7 +42,7 @@
     {%- set transient_keyword = 'transient ' if is_transient else '' -%}
     create {{ transient_keyword }}dynamic table {{ relation }}
         {% if dynamic_table.target_lag is not none %}target_lag = '{{ dynamic_table.target_lag }}'{% endif %}
-        warehouse = {{ dynamic_table.snowflake_warehouse }}
+        warehouse = {{ dynamic_table.warehouse_parameter }}
         {{ optional('initialization_warehouse', dynamic_table.snowflake_initialization_warehouse) }}
         {{ optional('refresh_mode', dynamic_table.refresh_mode) }}
         {{ optional('initialize', dynamic_table.initialize) }}
@@ -83,7 +83,7 @@
 
     create dynamic iceberg table {{ relation }}
         {% if dynamic_table.target_lag is not none %}target_lag = '{{ dynamic_table.target_lag }}'{% endif %}
-        warehouse = {{ dynamic_table.snowflake_warehouse }}
+        warehouse = {{ dynamic_table.warehouse_parameter }}
         {{ optional('initialization_warehouse', dynamic_table.snowflake_initialization_warehouse) }}
         {{ optional('external_volume', catalog_relation.external_volume, "'") }}
         catalog = 'SNOWFLAKE'  -- required, and always SNOWFLAKE for built-in Iceberg tables

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
@@ -41,11 +41,16 @@
     {%- endif -%}
     {%- set transient_keyword = 'transient ' if is_transient else '' -%}
     create {{ transient_keyword }}dynamic table {{ relation }}
-        target_lag = '{{ dynamic_table.target_lag }}'
+        {% if dynamic_table.target_lag is not none %}target_lag = '{{ dynamic_table.target_lag }}'{% endif %}
         warehouse = {{ dynamic_table.snowflake_warehouse }}
         {{ optional('initialization_warehouse', dynamic_table.snowflake_initialization_warehouse) }}
         {{ optional('refresh_mode', dynamic_table.refresh_mode) }}
         {{ optional('initialize', dynamic_table.initialize) }}
+        {% if dynamic_table.scheduler is not none %}
+        scheduler = '{{ dynamic_table.scheduler }}'
+        {% elif dynamic_table.target_lag is none %}
+        scheduler = 'DISABLE'
+        {% endif %}
         {{ optional('with row access policy', dynamic_table.row_access_policy, equals_char='') }}
         {{ optional('with tag', dynamic_table.table_tag, quote_char='(', equals_char='') }}
         {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
@@ -77,7 +82,7 @@
 {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
 
     create dynamic iceberg table {{ relation }}
-        target_lag = '{{ dynamic_table.target_lag }}'
+        {% if dynamic_table.target_lag is not none %}target_lag = '{{ dynamic_table.target_lag }}'{% endif %}
         warehouse = {{ dynamic_table.snowflake_warehouse }}
         {{ optional('initialization_warehouse', dynamic_table.snowflake_initialization_warehouse) }}
         {{ optional('external_volume', catalog_relation.external_volume, "'") }}
@@ -85,6 +90,11 @@
         base_location = '{{ catalog_relation.base_location }}'
         {{ optional('refresh_mode', dynamic_table.refresh_mode) }}
         {{ optional('initialize', dynamic_table.initialize) }}
+        {% if dynamic_table.scheduler is not none %}
+        scheduler = '{{ dynamic_table.scheduler }}'
+        {% elif dynamic_table.target_lag is none %}
+        scheduler = 'DISABLE'
+        {% endif %}
         {{ optional('row_access_policy', dynamic_table.row_access_policy) }}
         {{ optional('table_tag', dynamic_table.table_tag) }}
         {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
@@ -44,7 +44,16 @@
         A valid DDL statement which will result in a new dynamic info schema table.
 -#}
 
-create or replace dynamic table {{ relation }}
+    {#- Determine transient: explicit config takes precedence, otherwise use behavior flag default -#}
+    {%- if dynamic_table.transient is not none -%}
+        {%- set is_transient = dynamic_table.transient -%}
+    {%- elif adapter.behavior.snowflake_default_transient_dynamic_tables.no_warn -%}
+        {%- set is_transient = true -%}
+    {%- else -%}
+        {%- set is_transient = false -%}
+    {%- endif -%}
+    {%- set transient_keyword = 'transient ' if is_transient else '' -%}
+create or replace {{ transient_keyword }}dynamic table {{ relation }}
     target_lag = '{{ dynamic_table.target_lag }}'
     warehouse = {{ dynamic_table.snowflake_warehouse }}
     {{ optional('initialization_warehouse', dynamic_table.snowflake_initialization_warehouse) }}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
@@ -54,11 +54,16 @@
     {%- endif -%}
     {%- set transient_keyword = 'transient ' if is_transient else '' -%}
 create or replace {{ transient_keyword }}dynamic table {{ relation }}
-    target_lag = '{{ dynamic_table.target_lag }}'
+    {% if dynamic_table.target_lag is not none %}target_lag = '{{ dynamic_table.target_lag }}'{% endif %}
     warehouse = {{ dynamic_table.snowflake_warehouse }}
     {{ optional('initialization_warehouse', dynamic_table.snowflake_initialization_warehouse) }}
     {{ optional('refresh_mode', dynamic_table.refresh_mode) }}
     {{ optional('initialize', dynamic_table.initialize) }}
+    {% if dynamic_table.scheduler is not none %}
+    scheduler = '{{ dynamic_table.scheduler }}'
+    {% elif dynamic_table.target_lag is none %}
+    scheduler = 'DISABLE'
+    {% endif %}
     {{ optional('with row access policy', dynamic_table.row_access_policy, equals_char='') }}
     {{ optional('with tag', dynamic_table.table_tag, quote_char='(', equals_char='') }}
     {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
@@ -90,7 +95,7 @@ create or replace {{ transient_keyword }}dynamic table {{ relation }}
 {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
 
 create or replace dynamic iceberg table {{ relation }}
-    target_lag = '{{ dynamic_table.target_lag }}'
+    {% if dynamic_table.target_lag is not none %}target_lag = '{{ dynamic_table.target_lag }}'{% endif %}
     warehouse = {{ dynamic_table.snowflake_warehouse }}
     {{ optional('initialization_warehouse', dynamic_table.snowflake_initialization_warehouse) }}
     {{ optional('external_volume', catalog_relation.external_volume, "'") }}
@@ -98,6 +103,11 @@ create or replace dynamic iceberg table {{ relation }}
     base_location = '{{ catalog_relation.base_location }}'
     {{ optional('refresh_mode', dynamic_table.refresh_mode) }}
     {{ optional('initialize', dynamic_table.initialize) }}
+    {% if dynamic_table.scheduler is not none %}
+    scheduler = '{{ dynamic_table.scheduler }}'
+    {% elif dynamic_table.target_lag is none %}
+    scheduler = 'DISABLE'
+    {% endif %}
     {{ optional('row_access_policy', dynamic_table.row_access_policy) }}
     {{ optional('table_tag', dynamic_table.table_tag) }}
     {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
@@ -55,7 +55,7 @@
     {%- set transient_keyword = 'transient ' if is_transient else '' -%}
 create or replace {{ transient_keyword }}dynamic table {{ relation }}
     {% if dynamic_table.target_lag is not none %}target_lag = '{{ dynamic_table.target_lag }}'{% endif %}
-    warehouse = {{ dynamic_table.snowflake_warehouse }}
+    warehouse = {{ dynamic_table.warehouse_parameter }}
     {{ optional('initialization_warehouse', dynamic_table.snowflake_initialization_warehouse) }}
     {{ optional('refresh_mode', dynamic_table.refresh_mode) }}
     {{ optional('initialize', dynamic_table.initialize) }}
@@ -96,7 +96,7 @@ create or replace {{ transient_keyword }}dynamic table {{ relation }}
 
 create or replace dynamic iceberg table {{ relation }}
     {% if dynamic_table.target_lag is not none %}target_lag = '{{ dynamic_table.target_lag }}'{% endif %}
-    warehouse = {{ dynamic_table.snowflake_warehouse }}
+    warehouse = {{ dynamic_table.warehouse_parameter }}
     {{ optional('initialization_warehouse', dynamic_table.snowflake_initialization_warehouse) }}
     {{ optional('external_volume', catalog_relation.external_volume, "'") }}
     catalog = 'snowflake'

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/replace.sql
@@ -67,6 +67,7 @@ create or replace {{ transient_keyword }}dynamic table {{ relation }}
     {{ optional('with row access policy', dynamic_table.row_access_policy, equals_char='') }}
     {{ optional('with tag', dynamic_table.table_tag, quote_char='(', equals_char='') }}
     {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
+    {% if dynamic_table.copy_grants -%} copy grants {%- endif %}
     {{ optional('immutable where', dynamic_table.immutable_where, quote_char='(', equals_char='') }}
     as (
         {{ sql }}
@@ -111,6 +112,7 @@ create or replace dynamic iceberg table {{ relation }}
     {{ optional('row_access_policy', dynamic_table.row_access_policy) }}
     {{ optional('table_tag', dynamic_table.table_tag) }}
     {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
+    {% if dynamic_table.copy_grants -%} copy grants {%- endif %}
     {{ optional('immutable where', dynamic_table.immutable_where, quote_char='(', equals_char='') }}
     as (
         {{ sql }}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
@@ -35,6 +35,36 @@
 {% endmacro %}
 
 
+{% macro snowflake__create_table_transient_sql(relation, compiled_code) -%}
+{#-
+    Implements CREATE TRANSIENT TABLE ... AS SELECT for use as an incremental
+    tmp relation. Unlike session-scoped temporary tables, transient tables
+    persist in the catalog (enabling Snowflake lineage tracking) but have no
+    fail-safe period, avoiding the storage costs of permanent tables.
+    https://docs.snowflake.com/en/sql-reference/sql/create-table
+-#}
+
+{%- set contract_config = config.get('contract') -%}
+{%- if contract_config.enforced -%}
+    {{- get_assert_columns_equivalent(compiled_code) -}}
+    {%- set compiled_code = get_select_subquery(compiled_code) -%}
+{%- endif -%}
+
+{%- set sql_header = config.get('sql_header', none) -%}
+{{ sql_header if sql_header is not none }}
+
+create or replace transient table {{ relation }}
+    {%- if contract_config.enforced %}
+    {{ get_table_columns_and_constraints() }}
+    {%- endif %}
+as (
+    {{ compiled_code }}
+    )
+;
+
+{%- endmacro %}
+
+
 {% macro snowflake__create_table_temporary_sql(relation, compiled_code) -%}
 {#-
     Implements CREATE TEMPORARY TABLE and CREATE TEMPORARY TABLE ... AS SELECT:

--- a/dbt-snowflake/tests/functional/adapter/incremental/test_incremental_transient.py
+++ b/dbt-snowflake/tests/functional/adapter/incremental/test_incremental_transient.py
@@ -1,0 +1,78 @@
+import pytest
+from dbt.tests.util import run_dbt, run_dbt_and_capture
+
+
+_MODEL_TRANSIENT_TMP = """
+{{ config(
+    materialized='incremental',
+    unique_key='id',
+    tmp_relation_type='transient',
+) }}
+
+select 1 as id, 'alice' as name
+{% if is_incremental() %}
+union all
+select 2 as id, 'bob' as name
+{% endif %}
+"""
+
+_MODEL_TRANSIENT_TMP_DELETE_INSERT = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='delete+insert',
+    unique_key='id',
+    tmp_relation_type='transient',
+) }}
+
+select 1 as id, 'alice' as name
+{% if is_incremental() %}
+union all
+select 2 as id, 'bob' as name
+{% endif %}
+"""
+
+
+class TestIncrementalTransientTmpRelation:
+    """tmp_relation_type='transient' creates a transient (not session-scoped) staging
+    table, enabling Snowflake lineage tracking while avoiding permanent-table
+    fail-safe storage costs."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"transient_incremental.sql": _MODEL_TRANSIENT_TMP}
+
+    def test_incremental_transient(self, project):
+        run_dbt(["run"])
+        result = project.run_sql(
+            "select count(*) as cnt from {database}.{schema}.transient_incremental",
+            fetch="one",
+        )
+        assert result[0] == 1
+
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+        assert "create or replace transient table" in logs.lower()
+
+        result = project.run_sql(
+            "select count(*) as cnt from {database}.{schema}.transient_incremental",
+            fetch="one",
+        )
+        assert result[0] == 2
+
+        run_dbt(["test"])
+
+
+class TestIncrementalTransientTmpRelationDeleteInsert:
+    """transient tmp_relation_type is allowed for delete+insert strategy since
+    transient tables are stable across multiple statements, unlike views."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"transient_delete_insert.sql": _MODEL_TRANSIENT_TMP_DELETE_INSERT}
+
+    def test_incremental_transient_delete_insert_runs(self, project):
+        run_dbt(["run"])
+
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+        assert "create or replace transient table" in logs.lower()
+
+        run_dbt(["test"])

--- a/dbt-snowflake/tests/functional/adapter/test_grants.py
+++ b/dbt-snowflake/tests/functional/adapter/test_grants.py
@@ -62,3 +62,18 @@ class TestSnapshotGrants(BaseSnapshotGrants):
 
 class TestSnapshotCopyGrantsSnowflake(BaseCopyGrantsSnowflake, BaseSnapshotGrants):
     pass
+
+
+class TestDynamicTableCopyGrantsSnowflake(BaseCopyGrantsSnowflake):
+    """Test copy_grants functionality for dynamic tables"""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+copy_grants": True,
+                "+materialized": "dynamic_table",
+                "+target_lag": "1 minute",
+                "+snowflake_warehouse": "DBT_TESTING_ALT",
+            },
+        }

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
@@ -308,3 +308,40 @@ DYNAMIC_TABLE_WITH_CLUSTER_BY_NONE_COLUMN = """
 ) }}
 select id, "NONE" from {{ ref('my_seed_none') }}
 """
+
+
+# Transient dynamic table fixtures
+DYNAMIC_TABLE_TRANSIENT = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    transient=True,
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_NON_TRANSIENT = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    transient=False,
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+# For testing default behavior (no explicit transient config)
+DYNAMIC_TABLE_DEFAULT_TRANSIENT = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+) }}
+select * from {{ ref('my_seed') }}
+"""

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
@@ -196,6 +196,44 @@ select * from {{ ref('my_seed') }}
 """
 
 
+DYNAMIC_TABLE_WITH_IMMUTABLE_WHERE_AND_LAG_ALTER = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='5 minutes',
+    refresh_mode='INCREMENTAL',
+    immutable_where="id < 50",
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+# Fixtures for testing that the immutable_where and cluster_by ALTER statements can both be applied simultaneously.
+DYNAMIC_TABLE_WITH_IMMUTABLE_WHERE_NO_CLUSTER = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    immutable_where="id < 100",
+) }}
+select id, value from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_WITH_IMMUTABLE_WHERE_AND_CLUSTER_ALTER = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    refresh_mode='INCREMENTAL',
+    immutable_where="id < 50",
+    cluster_by="id",
+) }}
+select id, value from {{ ref('my_seed') }}
+"""
+
+
 # Immutable Where with Jinja variable substitution
 DYNAMIC_TABLE_WITH_IMMUTABLE_WHERE_JINJA = """
 {%- set cutoff_value = var('immutable_cutoff', 100) -%}

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/models.py
@@ -345,3 +345,84 @@ DYNAMIC_TABLE_DEFAULT_TRANSIENT = """
 ) }}
 select * from {{ ref('my_seed') }}
 """
+
+
+# Scheduler fixtures
+DYNAMIC_TABLE_SCHEDULER_DISABLED = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    scheduler='DISABLE',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_SCHEDULER_ENABLED = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    scheduler='ENABLE',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_NO_TARGET_LAG = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_TARGET_LAG_ONLY = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_TABLE_SCHEDULER_DISABLED_TO_ENABLED = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    scheduler='ENABLE',
+    refresh_mode='INCREMENTAL',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+# Iceberg Scheduler fixtures
+DYNAMIC_ICEBERG_TABLE_SCHEDULER_DISABLED = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    scheduler='DISABLE',
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+DYNAMIC_ICEBERG_TABLE_SCHEDULER_ENABLED = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    target_lag='2 minutes',
+    scheduler='ENABLE',
+    table_format="iceberg",
+    external_volume="s3_iceberg_snow",
+    base_location_subpath="subpath",
+) }}
+select * from {{ ref('my_seed') }}
+"""

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_basic.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_basic.py
@@ -448,3 +448,36 @@ class TestIcebergSchedulerConfigChange:
         assert_message_in_logs("scheduler = 'ENABLE'", logs)
         assert_message_in_logs("target_lag = '2 minutes'", logs)
         assert_message_not_in_logs("Applying REFRESH to:", logs)
+
+
+class TestDynamicTableCopyGrants:
+    """Test copy_grants functionality specifically for dynamic tables"""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        copy_grants_model = """
+{{ config(
+    materialized='dynamic_table',
+    target_lag='1 minute',
+    snowflake_warehouse='DBT_TESTING_ALT',
+    copy_grants=true
+) }}
+
+select * from {{ ref('my_seed') }}
+"""
+        yield {
+            "my_dynamic_table_copy_grants.sql": copy_grants_model,
+        }
+
+    def test_dynamic_table_copy_grants_in_sql(self, project):
+        """Test that copy_grants appears in the generated SQL on replace (full-refresh)"""
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        _, logs = run_dbt_and_capture(["--debug", "run", "--full-refresh"])
+
+        assert_message_in_logs("copy grants", logs)
+        assert query_relation_type(project, "my_dynamic_table_copy_grants") == "dynamic_table"

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_basic.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_basic.py
@@ -3,7 +3,16 @@ import pytest
 from dbt.tests.util import assert_message_in_logs, run_dbt, run_dbt_and_capture
 
 from tests.functional.relation_tests.dynamic_table_tests import models
-from tests.functional.utils import query_relation_type
+from tests.functional.utils import (
+    insert_record,
+    query_relation_type,
+    query_row_count,
+    update_model,
+)
+
+
+def assert_message_not_in_logs(message: str, logs: str):
+    assert_message_in_logs(message, logs, expected_pass=False)
 
 
 class TestBasic:
@@ -62,12 +71,380 @@ class TestAutoConfigDoesntFullRefresh:
 
         _, logs = run_dbt_and_capture(["--debug", "run", "--select", f"{test_dt}.sql"])
 
-        assert_message_in_logs(f"create dynamic table {model_qualified_name}", logs, False)
-        assert_message_in_logs(
-            f"create or replace dynamic table {model_qualified_name}", logs, False
-        )
-        assert_message_in_logs("refresh_mode = AUTO", logs, False)
+        assert_message_not_in_logs(f"create dynamic table {model_qualified_name}", logs)
+        assert_message_not_in_logs(f"create or replace dynamic table {model_qualified_name}", logs)
+        assert_message_not_in_logs("refresh_mode = AUTO", logs)
         assert_message_in_logs(
             f"No configuration changes were identified on: `{model_qualified_name}`. Continuing.",
             logs,
         )
+
+
+class TestSchedulerDisabled:
+    """Verify SCHEDULER=DISABLE appears in DDL and REFRESH is called."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "my_dt_scheduler_disabled.sql": models.DYNAMIC_TABLE_SCHEDULER_DISABLED,
+        }
+
+    def test_scheduler_disabled_in_create_ddl(self, project):
+        run_dbt(["seed"])
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("scheduler = 'DISABLE'", logs)
+        assert_message_in_logs("alter dynamic table", logs)
+        assert_message_in_logs("Applying REFRESH to:", logs)
+        assert query_relation_type(project, "my_dt_scheduler_disabled") == "dynamic_table"
+
+
+class TestSchedulerEnabled:
+    """Verify SCHEDULER=ENABLE with target_lag works."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "my_dt_scheduler_enabled.sql": models.DYNAMIC_TABLE_SCHEDULER_ENABLED,
+        }
+
+    def test_scheduler_enabled_in_create_ddl(self, project):
+        run_dbt(["seed"])
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("scheduler = 'ENABLE'", logs)
+        assert_message_in_logs("target_lag = '2 minutes'", logs)
+        assert_message_not_in_logs("Applying REFRESH to:", logs)
+        assert query_relation_type(project, "my_dt_scheduler_enabled") == "dynamic_table"
+
+
+class TestNoTargetLagDefaultsSchedulerDisabled:
+    """Verify missing target_lag defaults scheduler to DISABLE and REFRESH is called."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "my_dt_no_target_lag.sql": models.DYNAMIC_TABLE_NO_TARGET_LAG,
+        }
+
+    def test_no_target_lag_defaults_scheduler_disabled(self, project):
+        run_dbt(["seed"])
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("scheduler = 'DISABLE'", logs)
+        assert_message_in_logs("alter dynamic table", logs)
+        assert_message_in_logs("Applying REFRESH to:", logs)
+        assert query_relation_type(project, "my_dt_no_target_lag") == "dynamic_table"
+
+
+class TestSchedulerInReplaceDDL:
+    """Verify scheduler is preserved in CREATE OR REPLACE."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "my_dt_scheduler_replace.sql": models.DYNAMIC_TABLE_SCHEDULER_DISABLED,
+        }
+
+    def test_scheduler_in_replace_ddl(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+
+        _, logs = run_dbt_and_capture(["--debug", "run", "--full-refresh"])
+
+        assert_message_in_logs("scheduler = 'DISABLE'", logs)
+        assert query_relation_type(project, "my_dt_scheduler_replace") == "dynamic_table"
+
+
+class TestSchedulerConfigChange:
+    """Verify scheduler can be changed from DISABLED to ENABLED via ALTER."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "dynamic_table_scheduler.sql": models.DYNAMIC_TABLE_SCHEDULER_ENABLED,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, project, setup_class):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        update_model(project, "dynamic_table_scheduler", models.DYNAMIC_TABLE_SCHEDULER_ENABLED)
+
+    def test_alter_scheduler_to_disabled(self, project):
+        """Verify scheduler can be altered from ENABLE to DISABLE."""
+        update_model(project, "dynamic_table_scheduler", models.DYNAMIC_TABLE_SCHEDULER_DISABLED)
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying UPDATE SCHEDULER to:", logs)
+        assert_message_in_logs("scheduler = 'DISABLE'", logs)
+        assert_message_in_logs("alter dynamic table", logs)
+        assert_message_in_logs("Applying REFRESH to:", logs)
+
+    def test_alter_scheduler_to_enabled_with_target_lag(self, project):
+        """Verify scheduler changes to ENABLE when only target_lag is added."""
+        update_model(project, "dynamic_table_scheduler", models.DYNAMIC_TABLE_SCHEDULER_DISABLED)
+        run_dbt(["run"])
+
+        update_model(project, "dynamic_table_scheduler", models.DYNAMIC_TABLE_TARGET_LAG_ONLY)
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying UPDATE SCHEDULER to:", logs)
+        assert_message_in_logs("scheduler = 'ENABLE'", logs)
+        assert_message_in_logs("target_lag = '2 minutes'", logs)
+        assert_message_not_in_logs("Applying REFRESH to:", logs)
+
+    def test_alter_scheduler_disabled_to_enabled_explicit(self, project):
+        """Verify scheduler can be altered from DISABLE to ENABLE with explicit scheduler config."""
+        update_model(project, "dynamic_table_scheduler", models.DYNAMIC_TABLE_SCHEDULER_DISABLED)
+        run_dbt(["run"])
+
+        update_model(
+            project, "dynamic_table_scheduler", models.DYNAMIC_TABLE_SCHEDULER_DISABLED_TO_ENABLED
+        )
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying UPDATE SCHEDULER to:", logs)
+        assert_message_in_logs("scheduler = 'ENABLE'", logs)
+        assert_message_in_logs("target_lag = '2 minutes'", logs)
+        assert_message_not_in_logs("Applying REFRESH to:", logs)
+
+    def test_alter_scheduler_enabled_to_disabled_explicit(self, project):
+        """Verify scheduler can be altered from ENABLE to DISABLE (reverse direction)."""
+        update_model(
+            project, "dynamic_table_scheduler", models.DYNAMIC_TABLE_SCHEDULER_DISABLED_TO_ENABLED
+        )
+        run_dbt(["run"])
+
+        update_model(project, "dynamic_table_scheduler", models.DYNAMIC_TABLE_SCHEDULER_DISABLED)
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying UPDATE SCHEDULER to:", logs)
+        assert_message_in_logs("scheduler = 'DISABLE'", logs)
+        assert_message_in_logs("alter dynamic table", logs)
+        assert_message_in_logs("Applying REFRESH to:", logs)
+
+
+class _SchedulerNoOpBase:
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": models.SEED}
+
+    def _assert_no_op_run_behavior(
+        self, project, relation_name: str, expect_refresh: bool
+    ) -> None:
+        run_dbt(["seed"])
+        run_dbt(["run"])
+
+        initial_count = query_row_count(project, relation_name)
+        assert initial_count == 3
+
+        insert_record(project, "my_seed", {"id": 4, "value": 400})
+
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+        assert_message_in_logs("No configuration changes were identified on:", logs)
+        assert_message_in_logs("Applying REFRESH to:", logs, expect_refresh)
+
+        refreshed_count = query_row_count(project, relation_name)
+        if expect_refresh:
+            assert refreshed_count == 4
+        else:
+            assert refreshed_count == 3
+
+
+class TestSchedulerDisabledNoOpRefresh(_SchedulerNoOpBase):
+    """
+    Verify no-op runs still refresh disabled-scheduler dynamic tables when source data changes.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "my_dt_scheduler_disabled_noop_refresh.sql": models.DYNAMIC_TABLE_SCHEDULER_DISABLED,
+        }
+
+    def test_no_op_run_refreshes_disabled_scheduler_dynamic_table(self, project):
+        self._assert_no_op_run_behavior(
+            project, "my_dt_scheduler_disabled_noop_refresh", expect_refresh=True
+        )
+
+
+class TestSchedulerDefaultDisabledNoOpRefresh(_SchedulerNoOpBase):
+    """
+    Verify no-op runs still refresh when scheduler defaults to disabled (no target_lag).
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "my_dt_no_target_lag_noop_refresh.sql": models.DYNAMIC_TABLE_NO_TARGET_LAG,
+        }
+
+    def test_no_op_run_refreshes_default_disabled_scheduler_dynamic_table(self, project):
+        self._assert_no_op_run_behavior(
+            project, "my_dt_no_target_lag_noop_refresh", expect_refresh=True
+        )
+
+
+class TestSchedulerEnabledNoOpNoRefresh:
+    """
+    Verify no-op runs do not issue explicit REFRESH when scheduler is enabled.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "my_dt_scheduler_enabled_noop.sql": models.DYNAMIC_TABLE_SCHEDULER_ENABLED,
+        }
+
+    def test_no_op_run_does_not_refresh_enabled_scheduler_dynamic_table(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+
+        insert_record(project, "my_seed", {"id": 4, "value": 400})
+
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+        assert_message_in_logs("No configuration changes were identified on:", logs)
+        assert_message_not_in_logs("Applying REFRESH to:", logs)
+
+
+class TestIcebergSchedulerDisabled:
+    """Verify SCHEDULER=DISABLE on a dynamic iceberg table."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "my_iceberg_dt_sched_disabled.sql": models.DYNAMIC_ICEBERG_TABLE_SCHEDULER_DISABLED,
+        }
+
+    def test_iceberg_scheduler_disabled_in_create_ddl(self, project):
+        run_dbt(["seed"])
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("create dynamic iceberg table", logs)
+        assert_message_in_logs("scheduler = 'DISABLE'", logs)
+        assert_message_in_logs("Applying REFRESH to:", logs)
+        assert query_relation_type(project, "my_iceberg_dt_sched_disabled") == "dynamic_table"
+
+
+class TestIcebergSchedulerEnabled:
+    """Verify SCHEDULER=ENABLE with target_lag on a dynamic iceberg table."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        return {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "my_iceberg_dt_sched_enabled.sql": models.DYNAMIC_ICEBERG_TABLE_SCHEDULER_ENABLED,
+        }
+
+    def test_iceberg_scheduler_enabled_in_create_ddl(self, project):
+        run_dbt(["seed"])
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("create dynamic iceberg table", logs)
+        assert_message_in_logs("scheduler = 'ENABLE'", logs)
+        assert_message_in_logs("target_lag = '2 minutes'", logs)
+        assert_message_not_in_logs("Applying REFRESH to:", logs)
+        assert query_relation_type(project, "my_iceberg_dt_sched_enabled") == "dynamic_table"
+
+
+class TestIcebergSchedulerConfigChange:
+    """Verify scheduler can be toggled on a dynamic iceberg table via ALTER."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "iceberg_dt_scheduler.sql": models.DYNAMIC_ICEBERG_TABLE_SCHEDULER_ENABLED,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, project, setup_class):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        update_model(
+            project, "iceberg_dt_scheduler", models.DYNAMIC_ICEBERG_TABLE_SCHEDULER_ENABLED
+        )
+
+    def test_iceberg_alter_scheduler_to_disabled(self, project):
+        """Verify scheduler can be altered from ENABLE to DISABLE on iceberg."""
+        update_model(
+            project, "iceberg_dt_scheduler", models.DYNAMIC_ICEBERG_TABLE_SCHEDULER_DISABLED
+        )
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying UPDATE SCHEDULER to:", logs)
+        assert_message_in_logs("scheduler = 'DISABLE'", logs)
+        assert_message_in_logs("alter dynamic table", logs)
+        assert_message_in_logs("Applying REFRESH to:", logs)
+
+    def test_iceberg_alter_scheduler_to_enabled(self, project):
+        """Verify scheduler can be altered from DISABLE to ENABLE on iceberg."""
+        update_model(
+            project, "iceberg_dt_scheduler", models.DYNAMIC_ICEBERG_TABLE_SCHEDULER_DISABLED
+        )
+        run_dbt(["run"])
+
+        update_model(
+            project, "iceberg_dt_scheduler", models.DYNAMIC_ICEBERG_TABLE_SCHEDULER_ENABLED
+        )
+        _, logs = run_dbt_and_capture(["--debug", "run"])
+
+        assert_message_in_logs("Applying UPDATE SCHEDULER to:", logs)
+        assert_message_in_logs("scheduler = 'ENABLE'", logs)
+        assert_message_in_logs("target_lag = '2 minutes'", logs)
+        assert_message_not_in_logs("Applying REFRESH to:", logs)

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_configuration_changes.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_configuration_changes.py
@@ -287,6 +287,81 @@ class TestImmutableWhereChanges:
         dt_after = describe_dynamic_table(project, "dynamic_table_immutable")
         assert dt_after.immutable_where is None
 
+    def test_alter_immutable_where_with_other_changes(self, project):
+        """Verify immutable_where changes alongside other config changes don't cause a syntax error.
+
+        Snowflake does not allow IMMUTABLE WHERE in the same SET clause as other options
+        (e.g. TARGET_LAG). Each must be issued as a separate ALTER statement.
+        """
+        # Initial state
+        dt_before = describe_dynamic_table(project, "dynamic_table_immutable")
+        assert dt_before.immutable_where == "id < 100"
+        assert dt_before.target_lag == "2 minutes"
+
+        # Update both immutable_where and target_lag simultaneously
+        update_model(
+            project,
+            "dynamic_table_immutable",
+            models.DYNAMIC_TABLE_WITH_IMMUTABLE_WHERE_AND_LAG_ALTER,
+        )
+        run_dbt(["run"])
+
+        # Verify both changes were applied
+        dt_after = describe_dynamic_table(project, "dynamic_table_immutable")
+        assert dt_after.immutable_where == "id < 50"
+        assert dt_after.target_lag == "5 minutes"
+
+
+class TestImmutableWhereWithClusterByChanges:
+    """Tests for the immutable_where and cluster_by ALTER statements being applied simultaneously."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": models.SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "dynamic_table_imw_cluster.sql": models.DYNAMIC_TABLE_WITH_IMMUTABLE_WHERE_NO_CLUSTER,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"on_configuration_change": "apply"}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_class(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self, project, setup_class):
+        run_dbt(["run", "--full-refresh"])
+        yield
+        update_model(
+            project,
+            "dynamic_table_imw_cluster",
+            models.DYNAMIC_TABLE_WITH_IMMUTABLE_WHERE_NO_CLUSTER,
+        )
+
+    def test_alter_immutable_where_and_cluster_by_simultaneously(self, project):
+        """Verify immutable_where and cluster_by can be altered simultaneously."""
+        dt_before = describe_dynamic_table(project, "dynamic_table_imw_cluster")
+        assert dt_before.immutable_where == "id < 100"
+        assert dt_before.cluster_by is None
+
+        update_model(
+            project,
+            "dynamic_table_imw_cluster",
+            models.DYNAMIC_TABLE_WITH_IMMUTABLE_WHERE_AND_CLUSTER_ALTER,
+        )
+        run_dbt(["run"])
+
+        dt_after = describe_dynamic_table(project, "dynamic_table_imw_cluster")
+        assert dt_after.immutable_where == "id < 50"
+        assert dt_after.cluster_by is not None
+
 
 class TestClusterByChanges:
     """Tests for cluster_by configuration changes."""

--- a/dbt-snowflake/tests/functional/utils.py
+++ b/dbt-snowflake/tests/functional/utils.py
@@ -70,6 +70,14 @@ def describe_dynamic_table(project, name: str) -> Optional[SnowflakeDynamicTable
     return SnowflakeDynamicTableConfig.from_relation_results(results)
 
 
+def query_transient_status(project, name: str) -> bool:
+    """Check if a dynamic table is transient via describe_dynamic_table with transient info."""
+    relation = relation_from_name(project.adapter, name)
+    with get_connection(project.adapter):
+        results = project.adapter.describe_dynamic_table(relation, include_transient=True)
+    return SnowflakeDynamicTableConfig.from_relation_results(results).transient
+
+
 def refresh_dynamic_table(project, name: str) -> None:
     macro = "snowflake__refresh_dynamic_table"
     dynamic_table = relation_from_name(project.adapter, name)

--- a/dbt-snowflake/tests/unit/test_alter_relation_comment_macro.py
+++ b/dbt-snowflake/tests/unit/test_alter_relation_comment_macro.py
@@ -1,13 +1,18 @@
+import os
 import unittest
 from unittest import mock
 import re
 from jinja2 import Environment, FileSystemLoader
 
+MACROS_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "../../src/dbt/include/snowflake/macros")
+)
+
 
 class TestSnowflakeAlterRelationCommentMacro(unittest.TestCase):
     def setUp(self):
         self.jinja_env = Environment(
-            loader=FileSystemLoader("src/dbt/include/snowflake/macros"),
+            loader=FileSystemLoader(MACROS_DIR),
             extensions=[
                 "jinja2.ext.do",
             ],

--- a/dbt-snowflake/tests/unit/test_dynamic_table_config.py
+++ b/dbt-snowflake/tests/unit/test_dynamic_table_config.py
@@ -2,6 +2,7 @@
 Unit tests for SnowflakeDynamicTableConfig, testing:
 - snowflake_initialization_warehouse parameter
 - immutable_where parameter
+- transient parameter
 """
 
 import pytest
@@ -12,6 +13,7 @@ from dbt.adapters.snowflake.relation_configs import (
     SnowflakeDynamicTableConfigChangeset,
     SnowflakeDynamicTableImmutableWhereConfigChange,
     SnowflakeDynamicTableInitializationWarehouseConfigChange,
+    SnowflakeDynamicTableTransientConfigChange,
 )
 
 
@@ -192,3 +194,283 @@ class TestImmutableWhereChangeset:
         assert changeset.immutable_where.context is None
         assert changeset.has_changes is True
         assert changeset.requires_full_refresh is False
+
+
+class TestTransientOptional:
+    """Tests to verify transient is an optional parameter for dynamic tables."""
+
+    def test_transient_is_optional(self):
+        """transient should be optional and default to None (use behavior flag)."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "target_lag": "1 hour",
+                "snowflake_warehouse": "MY_WH",
+            }
+        )
+        # None means "not explicitly set by user, use behavior flag default"
+        assert config.transient is None
+
+    def test_transient_can_be_set_true(self):
+        """transient should be settable to True."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "target_lag": "1 hour",
+                "snowflake_warehouse": "MY_WH",
+                "transient": True,
+            }
+        )
+        assert config.transient is True
+
+    def test_transient_can_be_set_false(self):
+        """transient can be explicitly set to False."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "target_lag": "1 hour",
+                "snowflake_warehouse": "MY_WH",
+                "transient": False,
+            }
+        )
+        assert config.transient is False
+
+    def test_transient_can_be_none(self):
+        """transient can be None (meaning not explicitly set by user)."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "target_lag": "1 hour",
+                "snowflake_warehouse": "MY_WH",
+                "transient": None,
+            }
+        )
+        assert config.transient is None
+
+
+class TestTransientChangeset:
+    """Tests for transient change detection in SnowflakeDynamicTableConfigChangeset."""
+
+    def test_changeset_without_transient_has_no_changes(self):
+        """A changeset with no transient change should not have changes."""
+        changeset = SnowflakeDynamicTableConfigChangeset()
+        assert changeset.transient is None
+        assert changeset.has_changes is False
+        assert changeset.requires_full_refresh is False
+
+    def test_changeset_with_transient_change(self):
+        """A changeset with transient change should have changes and require full refresh."""
+        changeset = SnowflakeDynamicTableConfigChangeset(
+            transient=SnowflakeDynamicTableTransientConfigChange(
+                action=RelationConfigChangeAction.create,
+                context=True,
+            )
+        )
+        assert changeset.transient is not None
+        assert changeset.has_changes is True
+        # Transient changes REQUIRE full refresh (cannot be altered)
+        assert changeset.requires_full_refresh is True
+
+    def test_transient_change_requires_full_refresh(self):
+        """Changing transient should require a full refresh (cannot be altered in place)."""
+        change = SnowflakeDynamicTableTransientConfigChange(
+            action=RelationConfigChangeAction.create,
+            context=True,
+        )
+        assert change.requires_full_refresh is True
+
+    def test_transient_change_to_false_requires_full_refresh(self):
+        """Changing transient to False should also require full refresh."""
+        change = SnowflakeDynamicTableTransientConfigChange(
+            action=RelationConfigChangeAction.create,
+            context=False,
+        )
+        assert change.requires_full_refresh is True
+
+    def test_changeset_with_transient_and_other_changes(self):
+        """A changeset with transient and other changes should require full refresh."""
+        changeset = SnowflakeDynamicTableConfigChangeset(
+            transient=SnowflakeDynamicTableTransientConfigChange(
+                action=RelationConfigChangeAction.create,
+                context=True,
+            ),
+            immutable_where=SnowflakeDynamicTableImmutableWhereConfigChange(
+                action=RelationConfigChangeAction.alter,
+                context="id < 100",
+            ),
+        )
+        assert changeset.has_changes is True
+        # Even though immutable_where doesn't require full refresh,
+        # transient does, so the entire changeset requires full refresh
+        assert changeset.requires_full_refresh is True
+
+
+class TestTransientChangeDetectionLogic:
+    """
+    Tests for transient change detection in SnowflakeRelation.dynamic_table_config_changeset().
+
+    Transient is only compared when:
+    - The user explicitly set transient in their config (not None)
+    - The existing transient column is present in the relation results (not None)
+    """
+
+    @staticmethod
+    def _make_relation_results(transient=None):
+        import agate
+
+        dt_row_data = {
+            "name": "test_table",
+            "schema_name": "test_schema",
+            "database_name": "test_db",
+            "text": "SELECT 1",
+            "target_lag": "1 hour",
+            "warehouse": "MY_WH",
+            "refresh_mode": "AUTO",
+            "immutable_where": None,
+        }
+        column_types = [agate.Text()] * len(dt_row_data)
+
+        if transient is not None:
+            dt_row_data["transient"] = transient
+            column_types.append(agate.Boolean())
+
+        return {
+            "dynamic_table": agate.Table(
+                [list(dt_row_data.values())],
+                list(dt_row_data.keys()),
+                column_types,
+            )
+        }
+
+    @staticmethod
+    def _make_relation_config(transient=None):
+        from unittest.mock import MagicMock
+
+        relation_config = MagicMock()
+        relation_config.identifier = "test_table"
+        relation_config.schema = "test_schema"
+        relation_config.database = "test_db"
+        relation_config.compiled_code = "SELECT 1"
+        relation_config.config.extra = {
+            "target_lag": "1 hour",
+            "snowflake_warehouse": "MY_WH",
+            "transient": transient,
+        }
+        relation_config.config.get = lambda key, default=None: relation_config.config.extra.get(
+            key, default
+        )
+        return relation_config
+
+    def test_no_transient_config_no_column_no_change(self):
+        """When user doesn't set transient and column is absent, no change is detected."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results()
+        relation_config = self._make_relation_config(transient=None)
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        if changeset is not None:
+            assert changeset.transient is None
+
+    def test_explicit_transient_matches_existing_no_change(self):
+        """When user sets transient=True and existing is also True, no change."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results(transient=True)
+        relation_config = self._make_relation_config(transient=True)
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        if changeset is not None:
+            assert changeset.transient is None
+
+    def test_explicit_transient_differs_from_existing_triggers_change(self):
+        """When user sets transient=True but existing is False, change is detected."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results(transient=False)
+        relation_config = self._make_relation_config(transient=True)
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        assert changeset is not None
+        assert changeset.transient is not None
+        assert changeset.transient.context is True
+        assert changeset.requires_full_refresh is True
+
+    def test_explicit_non_transient_differs_from_existing_triggers_change(self):
+        """When user sets transient=False but existing is True, change is detected."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results(transient=True)
+        relation_config = self._make_relation_config(transient=False)
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        assert changeset is not None
+        assert changeset.transient is not None
+        assert changeset.transient.context is False
+        assert changeset.requires_full_refresh is True
+
+    def test_explicit_transient_with_no_column_no_change(self):
+        """When user sets transient but column is absent in results, no change."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results()
+        relation_config = self._make_relation_config(transient=True)
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        if changeset is not None:
+            assert changeset.transient is None
+
+    def test_no_config_ignores_existing_transient_true(self):
+        """When user omits transient, no change even if existing table is transient."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results(transient=True)
+        relation_config = self._make_relation_config(transient=None)
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        if changeset is not None:
+            assert changeset.transient is None
+
+    def test_no_config_ignores_existing_transient_false(self):
+        """When user omits transient, no change even if existing table is non-transient."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results(transient=False)
+        relation_config = self._make_relation_config(transient=None)
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        if changeset is not None:
+            assert changeset.transient is None

--- a/dbt-snowflake/tests/unit/test_dynamic_table_config.py
+++ b/dbt-snowflake/tests/unit/test_dynamic_table_config.py
@@ -3,6 +3,7 @@ Unit tests for SnowflakeDynamicTableConfig, testing:
 - snowflake_initialization_warehouse parameter
 - immutable_where parameter
 - transient parameter
+- scheduler parameter
 """
 
 import pytest
@@ -13,8 +14,10 @@ from dbt.adapters.snowflake.relation_configs import (
     SnowflakeDynamicTableConfigChangeset,
     SnowflakeDynamicTableImmutableWhereConfigChange,
     SnowflakeDynamicTableInitializationWarehouseConfigChange,
+    SnowflakeDynamicTableSchedulerConfigChange,
     SnowflakeDynamicTableTransientConfigChange,
 )
+from dbt_common.exceptions import CompilationError
 
 
 class TestSnowflakeDynamicTableConfig:
@@ -474,3 +477,335 @@ class TestTransientChangeDetectionLogic:
 
         if changeset is not None:
             assert changeset.transient is None
+
+
+class TestSchedulerOptional:
+    """Tests to verify scheduler is an optional parameter for dynamic tables."""
+
+    def test_scheduler_is_optional(self):
+        """scheduler should be optional and default to None."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "target_lag": "1 hour",
+                "snowflake_warehouse": "MY_WH",
+            }
+        )
+        assert config.scheduler is None
+
+    def test_scheduler_can_be_set_enable(self):
+        """scheduler should be settable to ENABLE."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "target_lag": "1 hour",
+                "snowflake_warehouse": "MY_WH",
+                "scheduler": "ENABLE",
+            }
+        )
+        assert config.scheduler == "ENABLE"
+
+    def test_scheduler_can_be_set_disable(self):
+        """scheduler should be settable to DISABLE."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "snowflake_warehouse": "MY_WH",
+                "scheduler": "DISABLE",
+            }
+        )
+        assert config.scheduler == "DISABLE"
+
+    def test_scheduler_can_be_none(self):
+        """scheduler can be explicitly set to None."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "target_lag": "1 hour",
+                "snowflake_warehouse": "MY_WH",
+                "scheduler": None,
+            }
+        )
+        assert config.scheduler is None
+
+
+class TestSchedulerValidation:
+    """Tests for compile-time validation of scheduler/target_lag combinations."""
+
+    @staticmethod
+    def _make_relation_config(scheduler=None, target_lag=None):
+        from unittest.mock import MagicMock
+
+        relation_config = MagicMock()
+        relation_config.identifier = "test_table"
+        relation_config.schema = "test_schema"
+        relation_config.database = "test_db"
+        relation_config.compiled_code = "SELECT 1"
+        extra = {"snowflake_warehouse": "MY_WH"}
+        if scheduler is not None:
+            extra["scheduler"] = scheduler
+        if target_lag is not None:
+            extra["target_lag"] = target_lag
+        relation_config.config.extra = extra
+        relation_config.config.get = lambda key, default=None: relation_config.config.extra.get(
+            key, default
+        )
+        return relation_config
+
+    def test_scheduler_enable_invalid_when_target_lag_none(self):
+        relation_config = self._make_relation_config(scheduler="ENABLE", target_lag=None)
+
+        with pytest.raises(CompilationError, match="requires `target_lag`"):
+            SnowflakeDynamicTableConfig.from_relation_config(relation_config)
+
+    def test_scheduler_disable_invalid_when_target_lag_set(self):
+        relation_config = self._make_relation_config(scheduler="DISABLE", target_lag="1 hour")
+
+        with pytest.raises(CompilationError, match="requires `target_lag` to be omitted"):
+            SnowflakeDynamicTableConfig.from_relation_config(relation_config)
+
+    def test_scheduler_enable_valid_when_target_lag_set(self):
+        relation_config = self._make_relation_config(scheduler="ENABLE", target_lag="1 hour")
+
+        config = SnowflakeDynamicTableConfig.from_relation_config(relation_config)
+
+        assert config.scheduler == "ENABLE"
+        assert config.target_lag == "1 hour"
+
+    def test_invalid_scheduler_literal_still_rejected(self):
+        relation_config = self._make_relation_config(scheduler="ENABLED", target_lag="1 hour")
+
+        with pytest.raises(CompilationError, match="Invalid value for `scheduler`"):
+            SnowflakeDynamicTableConfig.from_relation_config(relation_config)
+
+
+class TestSchedulerChangeset:
+    """Tests for scheduler change detection in SnowflakeDynamicTableConfigChangeset."""
+
+    def test_changeset_without_scheduler_has_no_changes(self):
+        """A changeset with no scheduler change should not have changes."""
+        changeset = SnowflakeDynamicTableConfigChangeset()
+        assert changeset.scheduler is None
+        assert changeset.has_changes is False
+        assert changeset.requires_full_refresh is False
+
+    def test_changeset_with_scheduler_change(self):
+        """A changeset with scheduler change should have changes but not require full refresh."""
+        changeset = SnowflakeDynamicTableConfigChangeset(
+            scheduler=SnowflakeDynamicTableSchedulerConfigChange(
+                action=RelationConfigChangeAction.alter,
+                context="DISABLE",
+            )
+        )
+        assert changeset.scheduler is not None
+        assert changeset.has_changes is True
+        assert changeset.requires_full_refresh is False
+
+    def test_scheduler_change_does_not_require_full_refresh(self):
+        """Changing scheduler should not require a full refresh (can be altered in place)."""
+        change = SnowflakeDynamicTableSchedulerConfigChange(
+            action=RelationConfigChangeAction.alter,
+            context="ENABLE",
+        )
+        assert change.requires_full_refresh is False
+
+    def test_scheduler_change_to_disable(self):
+        """Changing scheduler to DISABLE should be a valid change."""
+        changeset = SnowflakeDynamicTableConfigChangeset(
+            scheduler=SnowflakeDynamicTableSchedulerConfigChange(
+                action=RelationConfigChangeAction.alter,
+                context="DISABLE",
+            )
+        )
+        assert changeset.scheduler is not None
+        assert changeset.scheduler.context == "DISABLE"
+        assert changeset.has_changes is True
+        assert changeset.requires_full_refresh is False
+
+
+class TestTargetLagOptional:
+    """Tests to verify target_lag is now optional."""
+
+    def test_target_lag_can_be_none(self):
+        """target_lag should now accept None (for scheduler=DISABLE scenarios)."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "snowflake_warehouse": "MY_WH",
+                "scheduler": "DISABLE",
+            }
+        )
+        assert config.target_lag is None
+        assert config.scheduler == "DISABLE"
+
+    def test_target_lag_can_still_be_set(self):
+        """target_lag should still work when provided."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "target_lag": "5 minutes",
+                "snowflake_warehouse": "MY_WH",
+            }
+        )
+        assert config.target_lag == "5 minutes"
+
+    def test_target_lag_defaults_to_none(self):
+        """target_lag should default to None when omitted."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "snowflake_warehouse": "MY_WH",
+            }
+        )
+        assert config.target_lag is None
+
+
+class TestSchedulerChangeDetectionLogic:
+    """
+    Tests for scheduler change detection in SnowflakeRelation.dynamic_table_config_changeset().
+    """
+
+    @staticmethod
+    def _make_relation_results(scheduler=None, target_lag="1 hour"):
+        import agate
+
+        dt_row_data = {
+            "name": "test_table",
+            "schema_name": "test_schema",
+            "database_name": "test_db",
+            "text": "SELECT 1",
+            "target_lag": target_lag,
+            "warehouse": "MY_WH",
+            "refresh_mode": "AUTO",
+            "immutable_where": None,
+        }
+        column_types = [agate.Text()] * len(dt_row_data)
+
+        if scheduler is not None:
+            dt_row_data["scheduler"] = scheduler
+            column_types.append(agate.Text())
+
+        return {
+            "dynamic_table": agate.Table(
+                [list(dt_row_data.values())],
+                list(dt_row_data.keys()),
+                column_types,
+            )
+        }
+
+    @staticmethod
+    def _make_relation_config(scheduler=None, target_lag="1 hour"):
+        from unittest.mock import MagicMock
+
+        relation_config = MagicMock()
+        relation_config.identifier = "test_table"
+        relation_config.schema = "test_schema"
+        relation_config.database = "test_db"
+        relation_config.compiled_code = "SELECT 1"
+        extra = {
+            "snowflake_warehouse": "MY_WH",
+        }
+        if target_lag is not None:
+            extra["target_lag"] = target_lag
+        if scheduler is not None:
+            extra["scheduler"] = scheduler
+        relation_config.config.extra = extra
+        relation_config.config.get = lambda key, default=None: relation_config.config.extra.get(
+            key, default
+        )
+        return relation_config
+
+    def test_no_scheduler_config_no_column_no_change(self):
+        """When user doesn't set scheduler and column is absent, no change detected."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results()
+        relation_config = self._make_relation_config(scheduler=None)
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        if changeset is not None:
+            assert changeset.scheduler is None
+
+    def test_scheduler_disable_matches_no_change(self):
+        """When user sets scheduler=DISABLE and SHOW output is DISABLE, no change."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results(scheduler="DISABLE", target_lag=None)
+        relation_config = self._make_relation_config(scheduler="DISABLE", target_lag=None)
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        if changeset is not None:
+            assert changeset.scheduler is None
+
+    def test_scheduler_enable_matches_no_change(self):
+        """When user sets scheduler=ENABLE and SHOW output is ENABLE, no change."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results(scheduler="ENABLE")
+        relation_config = self._make_relation_config(scheduler="ENABLE")
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        if changeset is not None:
+            assert changeset.scheduler is None
+
+    def test_scheduler_change_enable_to_disable(self):
+        """When user sets scheduler=DISABLE but SHOW output is ENABLE, change detected."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results(scheduler="ENABLE")
+        relation_config = self._make_relation_config(scheduler="DISABLE", target_lag=None)
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        assert changeset is not None
+        assert changeset.scheduler is not None
+        assert changeset.scheduler.context == "DISABLE"
+        assert changeset.requires_full_refresh is False
+
+    def test_scheduler_change_disable_to_enable(self):
+        """When user sets scheduler=ENABLE but SHOW output is DISABLE, change detected."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results(scheduler="DISABLE", target_lag=None)
+        relation_config = self._make_relation_config(scheduler="ENABLE", target_lag="1 hour")
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        assert changeset is not None
+        assert changeset.scheduler is not None
+        assert changeset.scheduler.context == "ENABLE"
+        assert changeset.requires_full_refresh is False

--- a/dbt-snowflake/tests/unit/test_dynamic_table_config.py
+++ b/dbt-snowflake/tests/unit/test_dynamic_table_config.py
@@ -1,6 +1,7 @@
 """
 Unit tests for SnowflakeDynamicTableConfig, testing:
 - snowflake_initialization_warehouse parameter
+- refresh_warehouse parameter and warehouse_parameter property
 - immutable_where parameter
 - transient parameter
 - scheduler parameter
@@ -16,6 +17,7 @@ from dbt.adapters.snowflake.relation_configs import (
     SnowflakeDynamicTableInitializationWarehouseConfigChange,
     SnowflakeDynamicTableSchedulerConfigChange,
     SnowflakeDynamicTableTransientConfigChange,
+    SnowflakeDynamicTableWarehouseConfigChange,
 )
 from dbt_common.exceptions import CompilationError
 
@@ -809,3 +811,202 @@ class TestSchedulerChangeDetectionLogic:
         assert changeset.scheduler is not None
         assert changeset.scheduler.context == "ENABLE"
         assert changeset.requires_full_refresh is False
+
+
+class TestRefreshWarehouseOptional:
+    """Tests to verify refresh_warehouse is an optional parameter."""
+
+    def test_refresh_warehouse_is_optional(self):
+        """refresh_warehouse should be optional and default to None."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "target_lag": "1 hour",
+                "snowflake_warehouse": "MY_EXECUTION_WH",
+            }
+        )
+        assert config.refresh_warehouse is None
+
+    def test_refresh_warehouse_can_be_set(self):
+        """refresh_warehouse can be set independently of snowflake_warehouse."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "target_lag": "1 hour",
+                "snowflake_warehouse": "MY_LARGE_EXECUTION_WH",
+                "refresh_warehouse": "MY_SMALL_REFRESH_WH",
+            }
+        )
+        assert config.snowflake_warehouse == "MY_LARGE_EXECUTION_WH"
+        assert config.refresh_warehouse == "MY_SMALL_REFRESH_WH"
+
+    def test_warehouse_parameter_falls_back_to_snowflake_warehouse(self):
+        """warehouse_parameter returns snowflake_warehouse when refresh_warehouse is not set."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "target_lag": "1 hour",
+                "snowflake_warehouse": "MY_WH",
+            }
+        )
+        assert config.warehouse_parameter == "MY_WH"
+
+    def test_warehouse_parameter_uses_refresh_warehouse_when_set(self):
+        """warehouse_parameter returns refresh_warehouse when it is set."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "target_lag": "1 hour",
+                "snowflake_warehouse": "MY_LARGE_EXECUTION_WH",
+                "refresh_warehouse": "MY_SMALL_REFRESH_WH",
+            }
+        )
+        assert config.warehouse_parameter == "MY_SMALL_REFRESH_WH"
+
+    def test_refresh_warehouse_can_be_explicit_none(self):
+        """refresh_warehouse can be explicitly set to None."""
+        config = SnowflakeDynamicTableConfig.from_dict(
+            {
+                "name": "test_table",
+                "schema_name": "test_schema",
+                "database_name": "test_db",
+                "query": "SELECT 1",
+                "target_lag": "1 hour",
+                "snowflake_warehouse": "MY_WH",
+                "refresh_warehouse": None,
+            }
+        )
+        assert config.refresh_warehouse is None
+        assert config.warehouse_parameter == "MY_WH"
+
+
+class TestRefreshWarehouseChangeset:
+    """Tests for refresh_warehouse change detection via warehouse_parameter comparison."""
+
+    def test_changeset_without_warehouse_change_has_no_changes(self):
+        """A changeset with no warehouse change should not have changes."""
+        changeset = SnowflakeDynamicTableConfigChangeset()
+        assert changeset.snowflake_warehouse is None
+        assert not changeset.has_changes
+        assert not changeset.requires_full_refresh
+
+    def test_changeset_with_warehouse_change_does_not_require_full_refresh(self):
+        """A warehouse changeset entry should have changes but not require full refresh."""
+        changeset = SnowflakeDynamicTableConfigChangeset(
+            snowflake_warehouse=SnowflakeDynamicTableWarehouseConfigChange(
+                action=RelationConfigChangeAction.alter,
+                context="NEW_REFRESH_WH",
+            )
+        )
+        assert changeset.snowflake_warehouse is not None
+        assert changeset.has_changes
+        assert not changeset.requires_full_refresh
+
+    @staticmethod
+    def _make_relation_results(warehouse="MY_WH"):
+        import agate
+
+        dt_row_data = {
+            "name": "test_table",
+            "schema_name": "test_schema",
+            "database_name": "test_db",
+            "text": "SELECT 1",
+            "target_lag": "1 hour",
+            "warehouse": warehouse,
+            "refresh_mode": "AUTO",
+            "immutable_where": None,
+        }
+        column_types = [agate.Text()] * len(dt_row_data)
+        return {
+            "dynamic_table": agate.Table(
+                [list(dt_row_data.values())],
+                list(dt_row_data.keys()),
+                column_types,
+            )
+        }
+
+    @staticmethod
+    def _make_relation_config(snowflake_warehouse="MY_WH", refresh_warehouse=None):
+        from unittest.mock import MagicMock
+
+        relation_config = MagicMock()
+        relation_config.identifier = "test_table"
+        relation_config.schema = "test_schema"
+        relation_config.database = "test_db"
+        relation_config.compiled_code = "SELECT 1"
+        extra = {
+            "target_lag": "1 hour",
+            "snowflake_warehouse": snowflake_warehouse,
+        }
+        if refresh_warehouse is not None:
+            extra["refresh_warehouse"] = refresh_warehouse
+        relation_config.config.extra = extra
+        relation_config.config.get = lambda key, default=None: relation_config.config.extra.get(
+            key, default
+        )
+        return relation_config
+
+    def test_no_refresh_warehouse_no_change(self):
+        """When refresh_warehouse is not set and the existing warehouse matches, no change."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results(warehouse="MY_WH")
+        relation_config = self._make_relation_config(snowflake_warehouse="MY_WH")
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        if changeset is not None:
+            assert changeset.snowflake_warehouse is None
+
+    def test_refresh_warehouse_differs_from_existing_triggers_change(self):
+        """Setting refresh_warehouse to a value different from the existing warehouse triggers a change."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        # Existing table has MY_WH as its refresh warehouse
+        relation_results = self._make_relation_results(warehouse="MY_WH")
+        # User now wants MY_SMALL_REFRESH_WH as the refresh warehouse
+        relation_config = self._make_relation_config(
+            snowflake_warehouse="MY_LARGE_WH",
+            refresh_warehouse="MY_SMALL_REFRESH_WH",
+        )
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        assert changeset is not None
+        assert changeset.snowflake_warehouse is not None
+        assert changeset.snowflake_warehouse.context == "MY_SMALL_REFRESH_WH"
+        assert changeset.has_changes
+        assert not changeset.requires_full_refresh
+
+    def test_refresh_warehouse_matches_existing_no_change(self):
+        """When refresh_warehouse equals the existing warehouse, no change is detected."""
+        from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+        relation_results = self._make_relation_results(warehouse="MY_SMALL_WH")
+        relation_config = self._make_relation_config(
+            snowflake_warehouse="MY_LARGE_WH",
+            refresh_warehouse="MY_SMALL_WH",
+        )
+
+        changeset = SnowflakeRelation.dynamic_table_config_changeset(
+            relation_results, relation_config
+        )
+
+        if changeset is not None:
+            assert changeset.snowflake_warehouse is None


### PR DESCRIPTION
## Summary

Consolidation backport of 6 Snowflake dynamic-table features and fixes that are on `main` but missing from `stable`. These were cherry-picked in dependency order to avoid the conflicts that caused individual promote-to-stable runs to fail (root cause: #1602 and #1603 landed the same day and touch overlapping files; cherry-picking one without the other left stable in a state where subsequent diffs couldn't apply cleanly).

## Commits included (in order)

- feat(snowflake): add transient support for dynamic tables ([#1603](https://github.com/dbt-labs/dbt-adapters/pull/1603))
- feat(snowflake): add scheduler support for dynamic tables ([#1710](https://github.com/dbt-labs/dbt-adapters/pull/1710))
- Add refresh_warehouse config for Snowflake dynamic tables ([#1788](https://github.com/dbt-labs/dbt-adapters/pull/1788))
- Fix immutable_where clause causing syntax errors ([#1835](https://github.com/dbt-labs/dbt-adapters/pull/1835))
- feat(snowflake): Add COPY GRANTS support for dynamic tables ([#1498](https://github.com/dbt-labs/dbt-adapters/pull/1498))
- feat(snowflake): add transient tmp relation type for incremental models ([#1894](https://github.com/dbt-labs/dbt-adapters/pull/1894))

## Related open PRs to close after this merges

- [#1708](https://github.com/dbt-labs/dbt-adapters/pull/1708) — duplicate of #1498 (COPY GRANTS), can be closed
- [#1709](https://github.com/dbt-labs/dbt-adapters/pull/1709) — draft backup of #1710 (scheduler), can be closed

## Not included

- [#1851](https://github.com/dbt-labs/dbt-adapters/pull/1851) (CREATE OR ALTER for DT config changes) — still open against `main`; promote separately once merged