### PR TITLE
chore(adapters): log debug Note when recorder row limit exceeded

### DIFF
--- a/dbt-adapters/.changes/unreleased/Under the Hood-20260511-000000.yaml
+++ b/dbt-adapters/.changes/unreleased/Under the Hood-20260511-000000.yaml
@@ -3,4 +3,4 @@ body: Emit a debug-level Note event when the recorder row limit is exceeded duri
 time: 2026-05-11T00:00:00.000000+00:00
 custom:
     Author: MichelleArk
-    Issue: "TBD"
+    Issue: "1923"

--- a/dbt-adapters/.changes/unreleased/Under the Hood-20260511-000000.yaml
+++ b/dbt-adapters/.changes/unreleased/Under the Hood-20260511-000000.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Emit a debug-level Note event when the recorder row limit is exceeded during agate table serialization
+time: 2026-05-11T00:00:00.000000+00:00
+custom:
+    Author: MichelleArk
+    Issue: "TBD"

--- a/dbt-adapters/src/dbt/adapters/record/serialization.py
+++ b/dbt-adapters/src/dbt/adapters/record/serialization.py
@@ -3,6 +3,9 @@ from datetime import datetime, date
 from decimal import Decimal
 from typing import Any, Dict, TYPE_CHECKING, List, Union, Optional
 
+from dbt_common.events.base_types import EventLevel
+from dbt_common.events.functions import fire_event
+from dbt_common.events.types import Note
 from dbt_common.record import get_record_row_limit_from_env
 
 RECORDER_ROW_LIMIT: Optional[int] = get_record_row_limit_from_env()
@@ -29,11 +32,9 @@ def serialize_agate_table(table: "Table") -> Dict[str, Any]:
     rows = []
 
     if RECORDER_ROW_LIMIT and len(table.rows) > RECORDER_ROW_LIMIT:
-        rows = [
-            [
-                f"Recording Error: Agate table contains {len(table.rows)} rows, maximum is {RECORDER_ROW_LIMIT} rows."
-            ]
-        ]
+        msg = f"Recording Error: Agate table contains {len(table.rows)} rows, maximum is {RECORDER_ROW_LIMIT} rows."
+        fire_event(Note(msg=msg), level=EventLevel.DEBUG)
+        rows = [[msg]]
     else:
         for row in table.rows:
             row = list(map(_column_filter, row))


### PR DESCRIPTION
Adds a debug-level Note event in serialize_agate_table that logs the same "Recording Error" message written into the recording file when an agate table exceeds the recorder row limit, making the truncation visible in dbt logs.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
