### PR TITLE
fix: clear excluded path components in BaseRelation.include() so Set dedup works

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20260514-110625.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20260514-110625.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Make BaseRelation.include() clear excluded path components so Set[BaseRelation]
+    deduplicates relations that render identically, eliminating N redundant list_schemas
+    queries per dbt run.
+time: 2026-05-14T11:06:25.349822+00:00
+custom:
+    Author: 0xRobin
+    Issue: "1929"

--- a/dbt-adapters/src/dbt/adapters/base/relation.py
+++ b/dbt-adapters/src/dbt/adapters/base/relation.py
@@ -229,7 +229,27 @@ class BaseRelation(FakeAPIObject, Hashable):
         )
 
         new_include_policy = self.include_policy.replace_dict(policy)
-        return self.replace(include_policy=new_include_policy)
+        new_relation = self.replace(include_policy=new_include_policy)
+
+        # Clear path components that we're now excluding from rendering, so
+        # that `__eq__` (`to_dict`-based) stays consistent with `__hash__`
+        # (`render`-based). Without this, two relations built from different
+        # originals via `include(..., schema=False, identifier=False)` render
+        # to the same string but compare unequal, defeating `Set` dedup -- see
+        # `RunTask.create_schemas` in dbt-core, which then issues N identical
+        # `list_schemas` queries instead of one per unique database.
+        path_clears = {
+            name: None
+            for name, included in (
+                ("database", database),
+                ("schema", schema),
+                ("identifier", identifier),
+            )
+            if included is False
+        }
+        if path_clears:
+            new_relation = new_relation.replace_path(**path_clears)
+        return new_relation
 
     def information_schema(self, view_name=None) -> "InformationSchema":
         # some of our data comes from jinja, where things can be `Undefined`.

--- a/dbt-adapters/tests/unit/test_relation.py
+++ b/dbt-adapters/tests/unit/test_relation.py
@@ -188,3 +188,43 @@ def test_create_ephemeral_from_uses_identifier():
     node = Node(name="name_should_not_be_used", identifier="test")
     ephemeral_relation = BaseRelation.create_ephemeral_from(node)
     assert str(ephemeral_relation) == "__dbt__cte__test"
+
+
+def _db_only(database: str, schema: str, identifier: str) -> BaseRelation:
+    """Mirror what dbt-core RunTask.create_schemas does for each model."""
+    full = BaseRelation.create(
+        database=database,
+        schema=schema,
+        identifier=identifier,
+        type=RelationType.Table,
+    )
+    return full.include(database=True, schema=False, identifier=False)
+
+
+def test_db_only_relations_dedupe_in_a_set():
+    """
+    Relations that render to the same string must compare equal so that
+    `Set[BaseRelation]` deduplicates them.
+
+    Regression test: `RunTask.create_schemas` in dbt-core builds
+    `required_databases: Set[BaseRelation]` from
+    `required.include(database=True, schema=False, identifier=False)`.
+    When this dedup fails, dbt fans out one `list_schemas(database)` future
+    per (database, schema) pair instead of one per unique database, causing
+    N redundant `information_schema.schemata` queries on engines like Trino.
+    """
+    relations = [_db_only("hive", f"schema_{i}", f"table_{i}") for i in range(5)]
+    assert {r.render() for r in relations} == {'"hive"'}
+    assert len({hash(r) for r in relations}) == 1
+    assert relations[0] == relations[1]
+    assert len(set(relations)) == 1
+
+
+def test_relation_eq_matches_hash():
+    """`a == b` must imply `hash(a) == hash(b)`, and the practically harmful
+    inverse (`hash(a) == hash(b) and a != b`) must not be reachable for
+    relations that render identically."""
+    a = _db_only("hive", "schema_a", "table_a")
+    b = _db_only("hive", "schema_b", "table_b")
+    assert hash(a) == hash(b)
+    assert a == b


### PR DESCRIPTION
## Summary

Fixes #1929.

`BaseRelation.__hash__` is `hash(self.render())` while `__eq__` compares `to_dict(omit_none=True)`. `include(..., schema=False, identifier=False)` only flips `include_policy` and leaves the underlying `path` populated, so two relations built from different originals render the same and hash equal but compare unequal under `__eq__`. `Set[BaseRelation]` then keeps every entry instead of one per unique render.

The visible consequence is `RunTask.create_schemas` in dbt-core building `required_databases` with one entry per `(database, schema)` pair touched by the run, dispatching one `list_schemas` future per entry. On a Trino/Hive project with ~500 `(db, schema)` pairs that's ~500 identical `select schema_name from <db>.information_schema.schemata` queries during every `before_run`. The same dedup hazard exists in `get_model_schemas` (`runnable.py`) and `clone.py`.

## Fix

Clear the underlying `path` for components excluded via `include(...=False)`, mirroring what `without_identifier()` already does manually today (`self.include(identifier=False).replace_path(identifier=None)`).

```python
new_relation = self.replace(include_policy=new_include_policy)
path_clears = {
    name: None
    for name, included in (("database", database), ("schema", schema), ("identifier", identifier))
    if included is False
}
if path_clears:
    new_relation = new_relation.replace_path(**path_clears)
```

## Tests

- New `test_db_only_relations_dedupe_in_a_set` — five relations sharing a database but differing in `schema`/`identifier` collapse to a single entry in `set()` after `include(database=True, schema=False, identifier=False)`.
- New `test_relation_eq_matches_hash` — two such relations compare equal under `__eq__` (matching their already-equal `__hash__`).
- Full `tests/unit/` suite: 147 passed (26 prior in `test_relation.py` + 2 new).

Repro before the fix (`dbt-adapters==1.24.0` HEAD):
```
distinct render() outputs:    {'"hive"'}
distinct hash() values:       1     (expected 1)
db_onlys[0] == db_onlys[1]:   False (expected True)
len(set(db_onlys)):           500   (expected 1)
```

After the fix:
```
distinct render() outputs:    {'"hive"'}
distinct hash() values:       1     (expected 1)
db_onlys[0] == db_onlys[1]:   True
len(set(db_onlys)):           1
```

## Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development, and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX