### PR TITLE
fix: wrap microbatch DELETE+INSERT in explicit transaction

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20260514-130916.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260514-130916.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Wrap microbatch DELETE+INSERT in an explicit transaction so concurrent readers
+  do not observe an empty intermediate state.
+time: 2026-05-14T13:09:16-08:00
+custom:
+  Author: aalan3
+  PR: "1931"

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/incremental/merge.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/incremental/merge.sql
@@ -86,6 +86,7 @@
     {% endif %}
     {% do arg_dict.update({'incremental_predicates': incremental_predicates}) %}
 
+    {%- set dml -%}
     delete from {{ target }} DBT_INTERNAL_TARGET
     where (
     {% for predicate in incremental_predicates %}
@@ -99,4 +100,12 @@
         select {{ dest_cols_csv }}
         from {{ source }}
     )
+    {%- endset -%}
+
+    {#-- Skip transaction wrapping for catalog-linked databases --#}
+    {% if snowflake__is_catalog_linked_database(relation=config.model) %}
+        {% do return(dml) %}
+    {% else %}
+        {% do return(snowflake_dml_explicit_transaction(dml)) %}
+    {% endif %}
 {% endmacro %}


### PR DESCRIPTION
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

### Problem

`snowflake__get_incremental_microbatch_sql` in
`dbt-snowflake/src/dbt/include/snowflake/macros/materializations/incremental/merge.sql`
emits a `DELETE` followed by an `INSERT` and returns the raw SQL string. Unlike every
other DML-emitting macro in the same file, it does **not** wrap the statements with
`snowflake_dml_explicit_transaction`.

Under Snowflake's default `AUTOCOMMIT=TRUE`, that means the two statements run as
two independent transactions:

1. `DELETE` commits — the batch range is now empty.
2. `INSERT` runs in its own transaction and eventually commits.

For the wall-clock window between (1) and (2), any concurrent reader that filters
to the same batch range sees zero rows. In an event-pipeline-shaped DAG where a
downstream microbatch model reads from an upstream microbatch model for the
current batch's window, the downstream run can observe the upstream as empty
mid-update and silently produce an empty batch.

Illustrative timeline of two microbatch models that overlap on the same batch
window (sanitized example):

```
t=0   upstream  : DELETE WHERE event_time IN [t-1d, t)  -> commits
t=0+  downstream: SELECT FROM upstream WHERE event_time IN [t-1d, t)  -> 0 rows
t=1   upstream  : INSERT ... <batch contents>           -> commits
```

The downstream microbatch run between `t=0` and `t=1` writes an empty batch even
though the upstream eventually contains data.

Every sibling strategy macro in the same file already uses
`snowflake_dml_explicit_transaction` (with the `snowflake__is_catalog_linked_database`
escape hatch) to avoid exactly this class of failure:

| Macro                                    | Wraps DML in explicit transaction? |
| ---------------------------------------- | ---------------------------------- |
| `snowflake__get_merge_sql`               | yes                                |
| `snowflake__get_delete_insert_merge_sql` | yes                                |
| `snowflake__snapshot_merge_sql`          | yes                                |
| `snowflake__get_incremental_append_sql`  | yes                                |
| `snowflake__insert_overwrite_get_sql`    | yes                                |
| `snowflake__get_incremental_microbatch_sql` | **no** (before this PR)         |

### Solution

Move the `DELETE` and `INSERT` into a `{% set dml -%} ... {%- endset -%}` block and
return `snowflake_dml_explicit_transaction(dml)`, matching the pattern used by the
five sibling macros. Preserve the existing `snowflake__is_catalog_linked_database`
escape hatch so catalog-linked databases keep their current behaviour.

The rendered SQL goes from:

```sql
delete from <target> DBT_INTERNAL_TARGET where ( ... );
insert into <target> ( ... ) ( select ... from <temp> )
```

to:

```sql
begin;
delete from <target> DBT_INTERNAL_TARGET where ( ... );
insert into <target> ( ... ) ( select ... from <temp> );
commit;
```

Both statements now succeed-or-fail atomically. Concurrent readers see either the
pre-batch state or the post-batch state; never the empty intermediate.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX

#### Notes for reviewers

- The change is structural only — the emitted DML is identical, just wrapped in
  `begin; ... commit;` via the existing helper.
- I did not add a functional test. The existing tests under
  `dbt-snowflake/tests/functional/adapter/test_incremental_microbatch.py` exercise
  correctness of microbatch runs but do not (and probably cannot cheaply) exercise
  concurrent reader visibility, which is the failure mode being fixed. Happy to
  add a snapshot test that asserts the rendered SQL contains `begin;`/`commit;`
  if maintainers want one.
- Catalog-linked database behaviour is unchanged: the escape hatch matches the
  five sibling macros that already use this pattern.
