### PR TITLE
[Backport stable] Add polling timeout

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fixes-20260131-120000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20260131-120000.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Ensure BigQuery query result polling enforces the configured job execution
+  timeout plus a short buffer to avoid indefinite hangs when connections drop mid-query.
+time: 2026-01-31T12:00:00.000000-08:00
+custom:
+  Author: "colin-rogers-dbt"
+  Issue: "1500"

--- a/dbt-bigquery/tests/unit/test_bigquery_connection_manager.py
+++ b/dbt-bigquery/tests/unit/test_bigquery_connection_manager.py
@@ -205,3 +205,69 @@ class TestBigQueryConnectionManager(unittest.TestCase):
         self.mock_client.query.side_effect = make_query_job
         self.connections.raw_execute("SELECT 1")
         self.assertEqual(self.mock_client.query.call_count, 2)
+
+    @patch("dbt.adapters.bigquery.connections.QueryJobConfig")
+    def test_query_and_results_passes_timeout_to_result(self, MockQueryJobConfig):
+        """Test that _query_and_results passes a timeout to query_job.result()"""
+        mock_job = Mock(job_id="test_job", location="US", project="project")
+        mock_job.result.return_value = iter([])
+        self.mock_client.query.return_value = mock_job
+
+        self.connections._query_and_results(
+            self.mock_connection,
+            "SELECT 1",
+            {"dry_run": False},
+            job_id="test_job",
+        )
+
+        # Verify result() was called with a timeout parameter
+        mock_job.result.assert_called_once()
+        call_kwargs = mock_job.result.call_args[1]
+        self.assertIn("timeout", call_kwargs)
+        # timeout should be job_execution_timeout (1) + 30 second buffer = 31
+        self.assertEqual(call_kwargs["timeout"], 31)
+
+    @patch("dbt.adapters.bigquery.connections.QueryJobConfig")
+    def test_query_and_results_polling_timeout_includes_buffer(self, MockQueryJobConfig):
+        """Test that the polling timeout is job_execution_timeout + 30 seconds buffer"""
+        # Set a specific job_execution_timeout and recreate the connection manager
+        self.credentials.job_execution_timeout_seconds = 120
+        connections = BigQueryConnectionManager(
+            profile=Mock(credentials=self.credentials, query_comment=None),
+            mp_context=Mock(),
+        )
+        connections.get_thread_connection = lambda: self.mock_connection
+
+        mock_job = Mock(job_id="test_job", location="US", project="project")
+        mock_job.result.return_value = iter([])
+        self.mock_client.query.return_value = mock_job
+
+        connections._query_and_results(
+            self.mock_connection,
+            "SELECT 1",
+            {"dry_run": False},
+            job_id="test_job",
+        )
+
+        call_kwargs = mock_job.result.call_args[1]
+        # timeout should be 120 + 30 = 150
+        self.assertEqual(call_kwargs["timeout"], 150)
+
+    @patch("dbt.adapters.bigquery.connections.QueryJobConfig")
+    def test_retryable_google_api_error_is_reraised(self, MockQueryJobConfig):
+        """Test that retryable GoogleAPICallError is re-raised for retry mechanism"""
+        exceptions = dbt.adapters.bigquery.impl.google.cloud.exceptions
+
+        mock_job = Mock(job_id="test_job", location="US", project="project")
+        # ServiceUnavailable is a retryable error
+        mock_job.result.side_effect = exceptions.ServiceUnavailable("Service unavailable")
+        self.mock_client.query.return_value = mock_job
+
+        # Should raise ServiceUnavailable, not DbtDatabaseError
+        with self.assertRaises(exceptions.ServiceUnavailable):
+            self.connections._query_and_results(
+                self.mock_connection,
+                "SELECT 1",
+                {"dry_run": False},
+                job_id="test_job",
+            )


### PR DESCRIPTION
Backport de9eb1e7 from #1591 onto `stable` (1.11.x maintenance line).

## Background

PR #1591 fixes a hang in `BigQueryConnectionManager._query_and_results` where `query_job.result(...)` without a `timeout=` can block indefinitely. It merged into `main` on 2026-02-02 but isn't on `stable` — 1.11.1 (the current release from `stable`) is still affected. A downstream user has observed the hang in production multiple times on 1.11.x.

## Scope

Cherry-pick of `de9eb1e7` from `main` to `stable`. Applies cleanly with no conflicts. Three files:

- `dbt-bigquery/src/dbt/adapters/bigquery/connections.py` — the fix itself (4 changed lines)
- `dbt-bigquery/tests/unit/test_bigquery_connection_manager.py` — 3 unit tests covering the timeout path
- `dbt-bigquery/.changes/unreleased/Fixes-20260131-120000.yaml` — changelog entry

## References

- Original PR: #1591
- Original issue: #1500