### PR TITLE
deps: bump mashumaro upper bound from <3.15 to <3.18 (stable)

### DIFF
--- a/dbt-adapters/pyproject.toml
+++ b/dbt-adapters/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pytz>=2015.7",
     # installed via dbt-common but used directly
     "agate>=1.0,<2.0",
-    "mashumaro[msgpack]>=3.9,<3.15",
+    "mashumaro[msgpack]>=3.9,<3.18",
     "protobuf>=6.0,<7.0",
     "typing-extensions>=4.0,<5.0",
 ]


### PR DESCRIPTION
## Summary

- Bumps the `mashumaro` upper bound in `dbt-adapters/pyproject.toml` from `<3.15` to `<3.18`, matching `dbt-core` HEAD and the `main` branch of this repo.

## Root Cause

dbt-core PR [#12828](https://github.com/dbt-labs/dbt-core/pull/12828) (Python 3.14 support) made two related changes:
1. Widened `NodeVersion` from `Union[str, float]` to `Union[int, float, str]`
2. Bumped its own mashumaro requirement from `<3.15` → `<3.18`

These two changes are co-dependent. mashumaro 3.14 (the highest version satisfying the old `<3.15` cap) does not correctly handle `Union[int, float, str]` — YAML float scalars like `v: 4.5` (unquoted decimal version numbers) fail deserialization and are silently mis-routed as non-versioned model nodes.

This caused the scheduled CI run to fail on the `stable` branch:
- `version:none` incorrectly included `test.versioned_v4.5` 
- `version:prerelease` was missing `test.versioned.v4.5`

The `main` branch already has `mashumaro<3.18` and passes.

## Test plan

- [ ] Scheduled CI passes for `stable` after merge