### PR TITLE
feat(bigquery): flip bigquery_use_standard_sql_for_partitions default to true

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Breaking Changes-20260519-085000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Breaking Changes-20260519-085000.yaml
@@ -1,0 +1,13 @@
+kind: Breaking Changes
+body: >-
+  Enable `bigquery_use_standard_sql_for_partitions` by default, switching partition metadata queries
+  from Legacy SQL (`$__PARTITIONS_SUMMARY__`) to Standard SQL (`INFORMATION_SCHEMA.PARTITIONS`) ahead
+  of BigQuery's Legacy SQL deprecation on June 1, 2026. This may require IAM permission updates
+  (`bigquery.tables.get` + `bigquery.tables.list` instead of `bigquery.tables.getData`) for users
+  with custom roles, and custom macros that access columns beyond `partition_id` from
+  `get_partitions_metadata()` will need updating. Users can revert to Legacy SQL by setting
+  `flags.bigquery_use_standard_sql_for_partitions: false` in `dbt_project.yml`.
+time: 2026-05-19T08:50:00.000000-07:00
+custom:
+  Author: aahel
+  Issue: "1725"

--- a/dbt-bigquery/.changes/unreleased/Under the Hood-20260519-085000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Under the Hood-20260519-085000.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Enable `bigquery_use_standard_sql_for_partitions` behavior flag by default, switching partition metadata queries from Legacy SQL to Standard SQL (INFORMATION_SCHEMA.PARTITIONS) ahead of BigQuery's Legacy SQL deprecation on June 1, 2026
-time: 2026-05-19T08:50:00.000000-07:00
-custom:
-  Author: aahel
-  Issue: "1725"

--- a/dbt-bigquery/.changes/unreleased/Under the Hood-20260519-085000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Under the Hood-20260519-085000.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Enable `bigquery_use_standard_sql_for_partitions` behavior flag by default, switching partition metadata queries from Legacy SQL to Standard SQL (INFORMATION_SCHEMA.PARTITIONS) ahead of BigQuery's Legacy SQL deprecation on June 1, 2026
+time: 2026-05-19T08:50:00.000000-07:00
+custom:
+  Author: aahel
+  Issue: "1725"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
@@ -137,7 +137,7 @@ BIGQUERY_REJECT_WILDCARD_METADATA_SOURCE_FRESHNESS = BehaviorFlag(
 
 BIGQUERY_USE_STANDARD_SQL_FOR_PARTITIONS = BehaviorFlag(
     name="bigquery_use_standard_sql_for_partitions",
-    default=False,
+    default=True,
     description=(
         "Use Standard SQL (INFORMATION_SCHEMA.PARTITIONS) instead of Legacy SQL "
         "($__PARTITIONS_SUMMARY__) for partition metadata queries. Legacy SQL is being "


### PR DESCRIPTION
## Summary

- Flips the `bigquery_use_standard_sql_for_partitions` behavior flag default from `False` to `True`
- This enables Standard SQL (`INFORMATION_SCHEMA.PARTITIONS`) by default for partition metadata queries, replacing Legacy SQL (`$__PARTITIONS_SUMMARY__`)
- BigQuery is deprecating Legacy SQL on **June 1, 2026**, so this change ensures users are migrated before the deadline

## Test plan

- [ ] Existing functional tests in `tests/functional/test_changing_partitions.py` cover both code paths
- [ ] Verify partition metadata queries work correctly with the Standard SQL path enabled by default