### PR TITLE
fix: dbt-athena snapshot dbt_valid_to_current #1942

### DIFF
--- a/dbt-athena/src/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
@@ -41,7 +41,12 @@
     on dbt_internal_source.dbt_scd_id = dbt_internal_dest.dbt_scd_id
 
     when matched
-     and dbt_internal_dest.dbt_valid_to is null
+      {% if config.get("dbt_valid_to_current") %}
+        and ( dbt_internal_dest.dbt_valid_to = {{ config.get('dbt_valid_to_current') }} or
+              dbt_internal_dest.dbt_valid_to is null )
+      {% else %}
+        and dbt_internal_dest.dbt_valid_to is null
+      {% endif %}
      and dbt_internal_source.dbt_change_type in ('update', 'delete')
         then update
         set dbt_valid_to = dbt_internal_source.dbt_valid_to


### PR DESCRIPTION
resolves #1942 
docs: N/A

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
dbt-athena iceberg snapshots do not close open rows when dbt_valid_to_current is set

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
The merge logic is patched to take into account both types of open rows - `NULL` and fixed date in (distant) future.
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
