### PR TITLE
fix: default__concat returns single element directly for 1-field lists

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20260519-124215.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20260519-124215.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Return the field unchanged from default__concat when called with a single-element
+  list, so adapters that override with a SQL CONCAT() function call do not receive
+  invalid single-argument input
+time: 2026-05-19T12:42:15.000000+00:00
+custom:
+  Author: sdebruyn
+  Issue: "1948"

--- a/dbt-adapters/src/dbt/include/global_project/macros/utils/concat.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/utils/concat.sql
@@ -3,5 +3,9 @@
 {%- endmacro %}
 
 {% macro default__concat(fields) -%}
-    {{ fields|join(' || ') }}
+    {%- if fields | length == 1 -%}
+        {{ fields[0] }}
+    {%- else -%}
+        {{ fields | join(' || ') }}
+    {%- endif -%}
 {%- endmacro %}

--- a/dbt-postgres/tests/functional/adapter/test_utils.py
+++ b/dbt-postgres/tests/functional/adapter/test_utils.py
@@ -7,7 +7,7 @@ from dbt.tests.adapter.utils.test_array_construct import BaseArrayConstruct
 from dbt.tests.adapter.utils.test_bool_or import BaseBoolOr
 from dbt.tests.adapter.utils.test_cast import BaseCast
 from dbt.tests.adapter.utils.test_cast_bool_to_text import BaseCastBoolToText
-from dbt.tests.adapter.utils.test_concat import BaseConcat
+from dbt.tests.adapter.utils.test_concat import BaseConcat, BaseConcatSingleField
 from dbt.tests.adapter.utils.test_current_timestamp import BaseCurrentTimestampAware
 from dbt.tests.adapter.utils.test_date import BaseDate
 from dbt.tests.adapter.utils.test_dateadd import BaseDateAdd
@@ -68,6 +68,10 @@ class TestCastBoolToText(BaseCastBoolToText):
 
 
 class TestConcat(BaseConcat):
+    pass
+
+
+class TestConcatSingleField(BaseConcatSingleField):
     pass
 
 

--- a/dbt-tests-adapter/.changes/unreleased/Features-20260519-124215.yaml
+++ b/dbt-tests-adapter/.changes/unreleased/Features-20260519-124215.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Add BaseConcatSingleField test class covering concat() with a single-element
+  field list, so every adapter inherits regression coverage for the CONCAT() single-argument
+  case
+time: 2026-05-19T12:42:15.000000+00:00
+custom:
+  Author: sdebruyn
+  Issue: "1948"

--- a/dbt-tests-adapter/src/dbt/tests/adapter/utils/fixture_concat.py
+++ b/dbt-tests-adapter/src/dbt/tests/adapter/utils/fixture_concat.py
@@ -43,3 +43,41 @@ models:
           actual: actual
           expected: expected
 """
+
+
+# Single-field concat: many adapters override default__concat with a SQL CONCAT()
+# function call, and CONCAT() requires at least two arguments on engines like
+# SQL Server / Fabric T-SQL. The default macro therefore short-circuits on a
+# single-element list and returns the field directly.
+models__test_concat_single_field_sql = """
+with seed_data as (
+
+    select * from {{ ref('data_concat') }}
+
+),
+
+data as (
+
+    select
+        {{ replace_empty('input_1') }} as input_1
+    from seed_data
+
+)
+
+select
+    {{ concat(['input_1']) }} as actual,
+    input_1 as expected
+
+from data
+"""
+
+
+models__test_concat_single_field_yml = """
+version: 2
+models:
+  - name: test_concat_single_field
+    data_tests:
+      - assert_equal:
+          actual: actual
+          expected: expected
+"""

--- a/dbt-tests-adapter/src/dbt/tests/adapter/utils/test_concat.py
+++ b/dbt-tests-adapter/src/dbt/tests/adapter/utils/test_concat.py
@@ -20,3 +20,30 @@ class BaseConcat(base_utils.BaseUtils):
 
 class TestConcat(BaseConcat):
     pass
+
+
+class BaseConcatSingleField(base_utils.BaseUtils):
+    """Exercise concat() with a single-element field list.
+
+    Adapters that override default__concat with a SQL CONCAT() function call
+    must handle the single-field case specially because CONCAT() requires at
+    least two arguments on engines like SQL Server / Fabric T-SQL. The default
+    macro short-circuits and returns the lone field unchanged.
+    """
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"data_concat.csv": fixture_concat.seeds__data_concat_csv}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_concat_single_field.yml": fixture_concat.models__test_concat_single_field_yml,
+            "test_concat_single_field.sql": self.interpolate_macro_namespace(
+                fixture_concat.models__test_concat_single_field_sql, "concat"
+            ),
+        }
+
+
+class TestConcatSingleField(BaseConcatSingleField):
+    pass


### PR DESCRIPTION
## Problem

`default__concat` joins fields with ` || `, which works correctly for a single-field list (it just returns the field). However, several adapters override `default__concat` with a SQL `CONCAT(...)` **function call** rather than the `||` operator (for example, dbt-spark uses `concat({{ fields|join(', ') }})`).

On engines like SQL Server / Microsoft Fabric T-SQL, `CONCAT()` requires at least two arguments — `CONCAT(x)` is a syntax error. Because the default macro propagates a single-element list down to overrides, every adapter using the function form must add its own defensive branch (or break on single-field input).

Concrete repro: `dbt_utils.generate_surrogate_key([single_field])` compiles to `dbt.hash(dbt.concat([field]))`, which becomes `HASHBYTES(... CONCAT(field) ...)` on Fabric and fails to parse.

This is an actively painful issue in the wild: dbt-fabric (community fork) currently ships a duplicated override of `dbt_utils.generate_surrogate_key` purely to work around this — see https://github.com/sdebruyn/dbt-fabric/blob/main/src/dbt/include/fabric/macros/dbt_package_support/dbt_utils/sql/generate_surrogate_key.sql. Any adapter that uses the function form of `CONCAT()` needs the same workaround, so the fix belongs at the default macro level rather than being repeated per adapter.

Tracked in https://github.com/dbt-labs/dbt-adapters/issues/1948.

## Fix

Short-circuit `default__concat` on `length == 1` and return the field directly:

```jinja
{% macro default__concat(fields) -%}
    {%- if fields | length == 1 -%}
        {{ fields[0] }}
    {%- else -%}
        {{ fields | join(' || ') }}
    {%- endif -%}
{%- endmacro %}
```

## Impact / backwards compatibility

- Multi-field lists: behavior identical (`a || b` etc.).
- Single-field lists with the default `||` macro: behavior identical (output was already the field unchanged, just produced via `join` of one element).
- Single-field lists with overrides that re-dispatch up: those overrides receive a literal field expression instead of a list, so they no longer emit `CONCAT(x)` — fixing the syntax error.
- No new public API.

## Test

Adds `BaseConcatSingleField` to `dbt-tests-adapter` so every adapter inherits regression coverage for the single-field path. Wires `TestConcatSingleField` into `dbt-postgres`'s functional adapter test suite to validate the default behavior in CI.

## Test plan

- [x] `BaseConcatSingleField` added to `dbt-tests-adapter`
- [x] `TestConcatSingleField(BaseConcatSingleField)` added to dbt-postgres
- [ ] Adapter maintainers may want to inherit `BaseConcatSingleField` in their own functional suites to confirm the fix on their dialect (especially dbt-spark and any adapter overriding `default__concat` with a SQL function call)

## Changelog

- `dbt-adapters/.changes/unreleased/Fixes-20260519-124215.yaml`
- `dbt-tests-adapter/.changes/unreleased/Features-20260519-124215.yaml`