### PR TITLE
Use dbt.type_string and dbt.concat in default__snapshot_hash_arguments

### DIFF
--- a/dbt-adapters/.changes/unreleased/Under the Hood-20260519-144347.yaml
+++ b/dbt-adapters/.changes/unreleased/Under the Hood-20260519-144347.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Use dbt.type_string and dbt.concat in default__snapshot_hash_arguments so adapters with non-PostgreSQL string types or concat syntax inherit the right behavior automatically
+time: 2026-05-19T14:43:47.000000+00:00
+custom:
+  Author: sdebruyn
+  Issue: "1950"

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/snapshots/strategies.sql
@@ -40,10 +40,14 @@
 {%- endmacro %}
 
 {% macro default__snapshot_hash_arguments(args) -%}
-    md5({%- for arg in args -%}
-        coalesce(cast({{ arg }} as varchar ), '')
-        {% if not loop.last %} || '|' || {% endif %}
-    {%- endfor -%})
+    {%- set parts = [] -%}
+    {%- for arg in args -%}
+        {%- do parts.append("coalesce(cast(" ~ arg ~ " as " ~ dbt.type_string() ~ "), '')") -%}
+        {%- if not loop.last -%}
+            {%- do parts.append("'|'") -%}
+        {%- endif -%}
+    {%- endfor -%}
+    md5({{ dbt.concat(parts) }})
 {%- endmacro %}
 
 {#


### PR DESCRIPTION
Closes #1950

### Problem

`default__snapshot_hash_arguments` hardcodes a PostgreSQL `cast(... as varchar)` and a PostgreSQL `||` concatenation, even though dbt-adapters already ships `dbt.type_string()` and `dbt.concat()` for exactly these purposes. As a result, almost every non-Postgres adapter (this repo's own dbt-spark, dbt-bigquery, dbt-athena; plus microsoft/dbt-fabric, dbt-trino, dbt-hive/impala, dbt-glue, dbt-netezza, dbt-sqlite, dbt-oracle, dbt-mysql, dbt-doris, dbt-watsonx-spark, dbt-ibmdb2, dbt-odps, dbt-singlestore, dbt-sap-hana-cloud, dbt-azuresynapse, dbt-timeplus, dbt-exasol, sdebruyn/dbt-fabric, and others) overrides the entire macro just to swap one or two tokens. Full evidence (with quoted overrides) is in #1950.

### Solution

Route the default through the two existing cross-database macros:

```jinja
{% macro default__snapshot_hash_arguments(args) -%}
    {%- set parts = [] -%}
    {%- for arg in args -%}
        {%- do parts.append(\"coalesce(cast(\" ~ arg ~ \" as \" ~ dbt.type_string() ~ \"), '')\") -%}
        {%- if not loop.last -%}
            {%- do parts.append(\"'|'\") -%}
        {%- endif -%}
    {%- endfor -%}
    md5({{ dbt.concat(parts) }})
{%- endmacro %}
```

`md5(...)` is intentionally kept (not swapped for `dbt.hash()`): `dbt.hash()` wraps a cast-to-string itself, so layering it would double-cast and is a behavior change. That broader idea is the older closed/stale #82; this PR is the conservative subset.

### Backward compatibility

- Adapters that already override `default__snapshot_hash_arguments` (`spark__`, `bigquery__`, `athena__`, every community override) continue to win via `adapter.dispatch`. **No behavior change** for those adapters.
- On PostgreSQL, `default__type_string` resolves to `text` and `default__concat` joins with ` || `. The compiled SQL is semantically equivalent to the previous output (the only token difference is `varchar` -> `text`, which Postgres treats interchangeably here).
- Adapters that override `type_string`/`concat` but not `snapshot_hash_arguments` now get the right SQL automatically. That is the intended improvement.

### Follow-ups (out of scope here)

Once this is in, the `spark__`, `bigquery__`, and `athena__` overrides in this repo become candidates for deletion (each currently differs from the new default only in the cast type or md5 wrapping, both of which are now handled by dispatch). Community adapter maintainers can do the same in their forks. Doing those deletions in this PR would expand the blast radius unnecessarily.

### Test plan

- [ ] Existing snapshot functional tests in `dbt-tests-adapter` pass on `dbt-postgres` (compiled SQL is semantically equivalent to today's output).
- [ ] Snapshot functional tests pass on `dbt-spark`, `dbt-bigquery`, `dbt-athena`, `dbt-redshift`, `dbt-snowflake` (each of these either keeps its override, in which case nothing changes, or hits the new default, which now uses the correct dispatched macros).
- [ ] No new compile/parse errors in unit tests.

Changie entry added under `dbt-adapters/.changes/unreleased/`.