### PR TITLE
ci(snowflake): allow tests to use WIF auth

### DIFF
--- a/.github/workflows/_integration-tests.yml
+++ b/.github/workflows/_integration-tests.yml
@@ -407,6 +407,9 @@ jobs:
                 working-directory: "./dbt-snowflake"
         environment:
             name: "dbt-snowflake"
+        permissions:
+            id-token: write
+            contents: read
         env:
             SNOWFLAKE_TEST_ACCOUNT: ${{ secrets.SNOWFLAKE_TEST_ACCOUNT }}
             SNOWFLAKE_TEST_USER: ${{ vars.SNOWFLAKE_TEST_USER }}
@@ -425,6 +428,7 @@ jobs:
             SNOWFLAKE_TEST_PRIVATE_KEY: ${{ secrets.SNOWFLAKE_TEST_PRIVATE_KEY }}
             SNOWFLAKE_TEST_PRIVATE_KEY_PASSPHRASE: ${{ secrets.SNOWFLAKE_TEST_PRIVATE_KEY_PASSPHRASE }}
             SNOWFLAKE_TEST_TOKEN: ${{ secrets.SNOWFLAKE_TEST_TOKEN }}
+            SNOWFLAKE_TEST_WIF_USER: ${{ vars.SNOWFLAKE_TEST_WIF_USER }}
         steps:
             - name: "Checkout ${{ inputs.branch }}"
               uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4


### PR DESCRIPTION
resolves N/A

### Problem

The `integration-tests-snowflake` CI job can't authenticate via Workload Identity Federation, blocking the WIF functional test in #1316.

### Solution

- Adds `id-token: write` to the snowflake job so the runner exposes the OIDC env vars (`ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN`) to the test process.
- Adds `SNOWFLAKE_TEST_WIF_USER` env var pointing at a dedicated WIF service user (separate from `SNOWFLAKE_TEST_USER` because Snowflake WIF requires `TYPE = SERVICE`, which can't have password auth).

Currently unused. Consumed by #1316; landing first so the consuming PR has the infra it needs (`pull_request_target` workflows load YAML from `main`).

### Testing

`[gw3] [ 50%] PASSED tests/functional/auth_tests/test_workload_identity_federation_oidc.py::TestSnowflakeWorkloadIdentityFederation::test_snowflake_wif_basic_functionality `


Ran the [test](https://github.com/dbt-labs/dbt-adapters/actions/runs/26111841868/job/76790840939#step:6:723) against the PR #1316 


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
