### PR TITLE
chore(snowflake): bump dbt-adapters floor to 1.24.1

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Dependencies-20260521-000000.yaml
+++ b/dbt-snowflake/.changes/unreleased/Dependencies-20260521-000000.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump dbt-adapters floor to 1.24.1 for catalogs v2 and JS UDF support
+time: 2026-05-21T00:00:00.000000-08:00
+custom:
+  Author: sriramr98
+  PR: "1963"

--- a/dbt-snowflake/pyproject.toml
+++ b/dbt-snowflake/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "dbt-common>=1.10,<2.0",
-    "dbt-adapters>=1.22.4,<2.0",
+    "dbt-adapters>=1.24.1,<2.0",
     # cursor.stats support requires >= 4.2.0 (SNOW-295953)
     "snowflake-connector-python[secure-local-storage]>=4.2.0,<5.0.0",
     "certifi<2025.4.26",


### PR DESCRIPTION
## Summary
- Bumps `dbt-adapters` floor in `dbt-snowflake/pyproject.toml` from `>=1.22.4,<2.0` to `>=1.24.1,<2.0`.
- Prepares `dbt-snowflake` for the 1.12 release per the [1.12 release plan](https://www.notion.so/1-12-Release-364bb38ebda78142be78e1a45f28e02d).

## Why
- `dbt-adapters` 1.24.0 introduced the catalogs v2 re-architecture and JS UDF macros, but was yanked because the JS UDF macros crashed pre-1.12 core.
- `dbt-adapters` 1.24.1 ships a monkey-patch making the JS UDF macros safe on pre-1.12 core (no-op) and native on 1.12+, and includes the `persist_docs` quote-aware comparison + Snowflake double-fetch fix.
- This PR is part of the coordinated floor bump across warehouse adapters (Snowflake / BigQuery / Postgres / Redshift / Athena / Spark) so the upcoming `1.12.0b1` ships with a safe minimum.

## Test plan
- [ ] CI green
- [ ] No additional manual validation — pure dependency floor bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)