### PR TITLE
chore(postgres): bump dbt-adapters floor to 1.24.1

### DIFF
--- a/dbt-postgres/.changes/unreleased/Dependencies-20260521-000000.yaml
+++ b/dbt-postgres/.changes/unreleased/Dependencies-20260521-000000.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump dbt-adapters floor to 1.24.1 for catalogs v2 and JS UDF support
+time: 2026-05-21T00:00:00.000000-08:00
+custom:
+  Author: sriramr98
+  PR: "1965"

--- a/dbt-postgres/pyproject.toml
+++ b/dbt-postgres/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "psycopg2-binary>=2.9,<3.0",
-    "dbt-adapters>=1.19.0,<2.0",
+    "dbt-adapters>=1.24.1,<2.0",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
     "dbt-core>=1.8.0rc1",
     # installed via dbt-adapters but used directly


### PR DESCRIPTION
## Summary
- Bumps `dbt-adapters` floor in `dbt-postgres/pyproject.toml` from `>=1.19.0,<2.0` to `>=1.24.1,<2.0`.
- Prepares `dbt-postgres` for the 1.12 release per the [1.12 release plan](https://www.notion.so/1-12-Release-364bb38ebda78142be78e1a45f28e02d).

## Why
- `dbt-adapters` 1.24.0 introduced the catalogs v2 re-architecture and JS UDF macros, but was yanked because the JS UDF macros crashed pre-1.12 core.
- `dbt-adapters` 1.24.1 ships a monkey-patch making the JS UDF macros safe on pre-1.12 core (no-op) and native on 1.12+, and includes the `persist_docs` quote-aware comparison + Snowflake double-fetch fix.
- This PR is part of the coordinated floor bump across warehouse adapters so the upcoming `1.11.0b1` ships with a safe minimum.

## Test plan
- [ ] CI green
- [ ] No additional manual validation — pure dependency floor bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)