### PR TITLE
chore(athena): bump dbt-adapters floor to 1.24.1

### DIFF
--- a/dbt-athena/.changes/unreleased/Dependencies-20260521-000000.yaml
+++ b/dbt-athena/.changes/unreleased/Dependencies-20260521-000000.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Bump dbt-adapters floor to 1.24.1 for catalogs v2 and JS UDF support
+time: 2026-05-21T00:00:00.000000-08:00
+custom:
+  Author: sriramr98
+  PR: "1967"

--- a/dbt-athena/pyproject.toml
+++ b/dbt-athena/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies=[
-    "dbt-adapters>=1.0.0,<2.0",
+    "dbt-adapters>=1.24.1,<2.0",
     "dbt-common>=1.0.0,<2.0",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
     "dbt-core>=1.8.0",


### PR DESCRIPTION
## Summary
- Bumps `dbt-adapters` floor in `dbt-athena/pyproject.toml` from `>=1.0.0,<2.0` to `>=1.24.1,<2.0`.
- Prepares `dbt-athena` for the 1.12 release per the [1.12 release plan](https://www.notion.so/1-12-Release-364bb38ebda78142be78e1a45f28e02d).

## Why
- `dbt-adapters` 1.24.0 introduced the catalogs v2 re-architecture and JS UDF macros, but was yanked because the JS UDF macros crashed pre-1.12 core.
- `dbt-adapters` 1.24.1 ships a monkey-patch making the JS UDF macros safe on pre-1.12 core (no-op) and native on 1.12+, and includes the `persist_docs` quote-aware comparison + Snowflake double-fetch fix.
- This PR is part of the coordinated floor bump across warehouse adapters so the upcoming `1.11.0b1` ships with a safe minimum.

## Test plan
- [ ] CI green
- [ ] No additional manual validation — pure dependency floor bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)