### PR TITLE
Qualify source columns in inserted values in the default merge strategy SQL

### DIFF
--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/merge.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/merge.sql
@@ -55,7 +55,9 @@
     when not matched then insert
         ({{ dest_cols_csv }})
     values
-        ({{ dest_cols_csv }})
+        ({% for col in dest_columns -%}
+            DBT_INTERNAL_SOURCE.{{ adapter.quote(col.name) }}{%- if not loop.last %}, {% endif %}
+        {%- endfor %})
 
 {% endmacro %}
 


### PR DESCRIPTION
This is the change proposed in https://github.com/dbt-labs/dbt-adapters/issues/1972 

### Problem
see issue

### Solution
see issue

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR - existing tests should cover the code paths where the VALUES clause are generated for the merge query:
 - bigquery: dbt-bigquery/tests/functional/adapter/incremental/test_incremental_merge_exclude_columns.py:6
 - postgres: dbt-postgres/tests/functional/adapter/test_incremental.py:14
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
