### PR TITLE
fix(snowflake): drop COPY TAGS from built-in Iceberg CREATE TABLE DDL

### DIFF
--- a/dbt-snowflake/.changes/1.12.0/Fixes-20260527-113900.yaml
+++ b/dbt-snowflake/.changes/1.12.0/Fixes-20260527-113900.yaml
@@ -1,6 +1,9 @@
 kind: Fixes
-body: Remove unsupported COPY TAGS clause from Snowflake built-in Iceberg CREATE TABLE DDL.
+body: >-
+  Stop emitting unsupported COPY TAGS on CREATE ICEBERG TABLE for the Snowflake
+  built-in catalog; copy_tags is ignored on that path while copy_grants remains
+  supported.
 time: 2026-05-27T11:39:00.000000+05:30
 custom:
-  Author: codex
+  Author: aahelguha
   Issue: "1958"

--- a/dbt-snowflake/.changes/1.12.0/Fixes-20260527-113900.yaml
+++ b/dbt-snowflake/.changes/1.12.0/Fixes-20260527-113900.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove unsupported COPY TAGS clause from Snowflake built-in Iceberg CREATE TABLE DDL.
+time: 2026-05-27T11:39:00.000000+05:30
+custom:
+  Author: codex
+  Issue: "1958"

--- a/dbt-snowflake/.changes/unreleased/Fixes-20260527-113900.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260527-113900.yaml
@@ -5,5 +5,5 @@ body: >-
   supported.
 time: 2026-05-27T11:39:00.000000+05:30
 custom:
-  Author: aahelguha
+  Author: aahel
   Issue: "1958"

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
@@ -177,7 +177,6 @@ alter table {{ relation }} resume recluster;
 {%- endif -%}
 
 {%- set copy_grants = config.get('copy_grants', default=false) -%}
-{%- set copy_tags = config.get('copy_tags', default=false) -%}
 
 {%- set row_access_policy = config.get('row_access_policy', default=none) -%}
 {%- set table_tag = config.get('table_tag', default=none) -%}
@@ -207,7 +206,6 @@ create or replace iceberg table {{ relation }}
     {% if row_access_policy -%} with row access policy {{ row_access_policy }} {%- endif %}
     {% if table_tag -%} with tag ({{ table_tag }}) {%- endif %}
     {% if copy_grants -%} copy grants {%- endif %}
-    {% if copy_tags -%} copy tags {%- endif %}
 as (
     {%- if catalog_relation.cluster_by is not none -%}
     select * from (

--- a/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
@@ -27,6 +27,15 @@ MODEL__ICEBERG_TABLE_W_CONFIGS = """
                             select 1 as id
                             """
 
+MODEL__ICEBERG_TABLE_COPY_TAGS_AND_GRANTS = """
+                            {{ config(materialized='table',
+                                catalog_name='basic_iceberg_catalog',
+                                copy_grants=True,
+                                copy_tags=True)
+                                }}
+                            select 1 as id
+                            """
+
 
 class TestSnowflakeBuiltInCatalogIntegration(BaseCatalogIntegrationValidation):
 
@@ -60,6 +69,7 @@ class TestSnowflakeBuiltInCatalogIntegration(BaseCatalogIntegrationValidation):
         return {
             "basic_iceberg_table.sql": MODEL__BASIC_ICEBERG_TABLE,
             "iceberg_table_with_configs.sql": MODEL__ICEBERG_TABLE_W_CONFIGS,
+            "iceberg_table_copy_tags_and_grants.sql": MODEL__ICEBERG_TABLE_COPY_TAGS_AND_GRANTS,
         }
 
     def test_basic_iceberg_catalog_integration(self, project):
@@ -76,3 +86,9 @@ class TestSnowflakeBuiltInCatalogIntegration(BaseCatalogIntegrationValidation):
         assert "max_data_extension_time_in_days = 30" in iceberg_table_with_configs_sql
         assert "change_tracking = FALSE" in iceberg_table_with_configs_sql
         assert "data_retention_time_in_days = 1" in iceberg_table_with_configs_sql
+
+        iceberg_table_copy_tags_and_grants_sql = get_cleaned_model_ddl_from_file(
+            "iceberg_table_copy_tags_and_grants.sql"
+        )
+        assert "copy grants" in iceberg_table_copy_tags_and_grants_sql
+        assert "copy tags" not in iceberg_table_copy_tags_and_grants_sql


### PR DESCRIPTION
## Summary

- Removes unsupported `COPY TAGS` from `snowflake__create_table_built_in_sql` (Snowflake-as-catalog / built-in Iceberg `CREATE ICEBERG TABLE` DDL).
- Keeps `copy_grants` on that path; regular Snowflake tables still honor `copy_tags` via `snowflake__create_table_info_schema_sql`.
- Adds a functional regression test asserting `copy_tags=true` does not appear in compiled built-in Iceberg DDL.

Fixes #1958.

## Test plan

- [x] Pre-commit / commit hooks passed locally
- [x] `cd dbt-snowflake && hatch run integration-tests -- tests/functional/adapter/catalog_integrations/test_catalog_integrations.py::TestSnowflakeBuiltInCatalogIntegration -v`
- [x] `cd dbt-snowflake && hatch run integration-tests -- tests/functional/adapter/test_copy_tags.py -v` (confirms normal tables still emit `copy tags`)