### PR TITLE
fix(athena): cancel in-flight Athena queries when a dbt invocation is cancelled

### DIFF
--- a/dbt-athena/.changes/unreleased/Fixes-20260528-162219.yaml
+++ b/dbt-athena/.changes/unreleased/Fixes-20260528-162219.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Cancel in-flight Athena queries when a dbt invocation is cancelled
+time: 2026-05-28T16:22:19.786142+05:30
+custom:
+    Author: aahel
+    Issue: "406"

--- a/dbt-athena/.changes/unreleased/Fixes-20260528-162219.yaml
+++ b/dbt-athena/.changes/unreleased/Fixes-20260528-162219.yaml
@@ -2,5 +2,5 @@ kind: Fixes
 body: Cancel in-flight Athena queries when a dbt invocation is cancelled
 time: 2026-05-28T16:22:19.786142+05:30
 custom:
-    Author: aahel, Jrmyy
+    Author: aahel Jrmyy
     Issue: "406"

--- a/dbt-athena/.changes/unreleased/Fixes-20260528-162219.yaml
+++ b/dbt-athena/.changes/unreleased/Fixes-20260528-162219.yaml
@@ -2,5 +2,5 @@ kind: Fixes
 body: Cancel in-flight Athena queries when a dbt invocation is cancelled
 time: 2026-05-28T16:22:19.786142+05:30
 custom:
-    Author: aahel
+    Author: aahel, Jrmyy
     Issue: "406"

--- a/dbt-athena/src/dbt/adapters/athena/connections.py
+++ b/dbt-athena/src/dbt/adapters/athena/connections.py
@@ -1,16 +1,21 @@
 import json
 import re
 import time
+import weakref
 from concurrent.futures.thread import ThreadPoolExecutor
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any, ContextManager, Dict, List, Optional, Tuple
+from typing import Any, ContextManager, Dict, List, Optional, Tuple, Type, Union
 
 from dbt_common.exceptions import ConnectionError, DbtRuntimeError
 from dbt_common.utils import md5
-from pyathena.connection import Connection as AthenaConnection
+from pyathena.connection import (
+    Connection as PyAthenaConnection,
+    ConnectionCursor,
+    FunctionalCursor,
+)
 from pyathena.cursor import Cursor
 from pyathena.error import OperationalError, ProgrammingError
 
@@ -34,6 +39,7 @@ from typing_extensions import Self
 
 from dbt.adapters.athena.config import get_boto3_config
 from dbt.adapters.athena.constants import LOGGER
+from dbt.adapters.athena.exceptions import CancelledQueryException
 from dbt.adapters.athena.query_headers import AthenaMacroQueryStringSetter
 from dbt.adapters.athena.session import get_boto3_session
 from dbt.adapters.contracts.connection import (
@@ -120,10 +126,33 @@ class AthenaCredentials(Credentials):
         )
 
 
+class AthenaConnection(PyAthenaConnection):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._cursors_created: weakref.WeakSet = weakref.WeakSet()
+
+    def cursor(
+        self, cursor: Optional[Type[FunctionalCursor]] = None, **kwargs
+    ) -> Union[FunctionalCursor, ConnectionCursor]:
+        cursor_created = super().cursor(cursor, **kwargs)
+        self._cursors_created.add(cursor_created)
+        return cursor_created
+
+    def cancel(self) -> None:
+        for cursor in self._cursors_created:
+            cursor.cancel()
+
+
 class AthenaCursor(Cursor):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._executor = ThreadPoolExecutor()
+
+    def cancel(self) -> None:
+        if not self.query_id:
+            LOGGER.warning("QueryExecutionId is none or empty.")
+            return
+        self._cancel(self.query_id)
 
     def _collect_result_set(self, query_id: str) -> AthenaResultSet:
         query_execution = self._poll(query_id)
@@ -182,7 +211,8 @@ class AthenaCursor(Cursor):
             retry=retry_if_exception(
                 lambda e: (
                     False
-                    if catch_partitions_limit and "TOO_MANY_OPEN_PARTITIONS" in str(e)
+                    if (catch_partitions_limit and "TOO_MANY_OPEN_PARTITIONS" in str(e))
+                    or isinstance(e, CancelledQueryException)
                     else True
                 )
             ),
@@ -209,7 +239,7 @@ class AthenaCursor(Cursor):
                 reraise=True,
             )
             def execute_with_iceberg_retries() -> AthenaCursor:
-                query_id = self._execute(
+                self.query_id = self._execute(
                     operation,
                     parameters=parameters,
                     work_group=work_group,
@@ -218,11 +248,15 @@ class AthenaCursor(Cursor):
                     cache_expiration_time=cache_expiration_time,
                 )
 
-                LOGGER.debug(f"Athena query ID {query_id}")
+                LOGGER.debug(f"Athena query ID {self.query_id}")
 
                 query_execution = self._executor.submit(
-                    self._collect_result_set, query_id
+                    self._collect_result_set, self.query_id
                 ).result()
+
+                if query_execution.state == AthenaQueryExecution.STATE_CANCELLED:
+                    raise CancelledQueryException("Query cancelled")
+
                 if query_execution.state == AthenaQueryExecution.STATE_SUCCEEDED:
                     self.result_set = self._result_set_class(
                         self._connection,
@@ -345,7 +379,8 @@ class AthenaConnectionManager(SQLConnectionManager):
         return cursor.rowcount, cursor.data_scanned_in_bytes
 
     def cancel(self, connection: Connection) -> None:
-        pass
+        if connection.handle:
+            connection.handle.cancel()
 
     def add_begin_query(self) -> None:
         pass

--- a/dbt-athena/src/dbt/adapters/athena/exceptions.py
+++ b/dbt-athena/src/dbt/adapters/athena/exceptions.py
@@ -7,3 +7,7 @@ class SnapshotMigrationRequired(CompilationError):
 
 class S3LocationException(DbtRuntimeError):
     pass
+
+
+class CancelledQueryException(DbtRuntimeError):
+    pass


### PR DESCRIPTION
resolves #406
docs N/A

### Problem

When a dbt invocation is cancelled (e.g. via the dbt platform UI or Ctrl+C), the running Athena query is not cancelled. The query continues in the background, which causes concurrent request errors and "Destination table already exists" failures when the user retries.

The root cause is that `AthenaConnectionManager.cancel()` was a no-op (`pass`). Since model execution runs in a worker thread, `KeyboardInterrupt` from the main thread never reaches the cursor's `_poll` loop, so the existing `kill_on_interrupt` path inside the cursor is never triggered.

### Solution

- Subclasses `PyAthenaConnection` as `AthenaConnection`, which tracks all cursors it creates via a `weakref.WeakSet` and adds a `cancel()` method that calls `cursor.cancel()` on each tracked cursor.
- Adds `AthenaCursor.cancel()` which calls pyathena's `_cancel(query_id)` directly. Guards against a `None` query ID (returns early with a warning rather than passing `None` to the AWS API).
- Implements `AthenaConnectionManager.cancel()` to call `connection.handle.cancel()`.
- Stores the running query ID on `self.query_id` (instead of a local variable) so it is accessible during cancellation.
- Adds `CancelledQueryException` and raises it when a query reaches `STATE_CANCELLED`, preventing the outer retry loop from retrying after a cancellation.

This is substantially the same approach as the community PR #873, which was closed without merging due to CI failures. Those failures were caused by a bug in that PR's `cancel()` guard (it logged a warning but still called `_cancel(None)`); this implementation returns early instead.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX