### PR TITLE
feat(snowflake): support transient for Snowflake Horizon Iceberg tables

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Features-20260528-192635.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260528-192635.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Snowflake Horizon (SNOWFLAKE_MANAGED) Iceberg tables now support transient=true, matching regular Snowflake table behavior
+time: 2026-05-28T19:26:35.123507+05:30
+custom:
+    Author: aahelguha
+    Issue: "1985"

--- a/dbt-snowflake/.changes/unreleased/Features-20260528-192635.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260528-192635.yaml
@@ -2,5 +2,5 @@ kind: Features
 body: Snowflake Horizon (SNOWFLAKE_MANAGED) Iceberg tables now support transient=true, matching regular Snowflake table behavior
 time: 2026-05-28T19:26:35.123507+05:30
 custom:
-    Author: aahelguha
-    Issue: "1985"
+    Author: aahel
+    Issue: "15659"

--- a/dbt-snowflake/.changes/unreleased/Features-20260528-192635.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260528-192635.yaml
@@ -2,5 +2,5 @@ kind: Features
 body: Snowflake Horizon (SNOWFLAKE_MANAGED) Iceberg tables now support transient=true, matching regular Snowflake table behavior
 time: 2026-05-28T19:26:35.123507+05:30
 custom:
-    Author: aahel
-    Issue: "15659"
+    Author: aahelguha
+    Issue: "1985"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
@@ -121,6 +121,7 @@ class BuiltInCatalogIntegration(CatalogIntegration):
             cluster_by=parse_model.cluster_by(model),
             partition_by=parse_model.partition_by(model),
             automatic_clustering=parse_model.automatic_clustering(model),
+            is_transient=parse_model.is_transient(model),
             storage_serialization_policy=storage_serialization_policy,
             max_data_extension_time_in_days=max_data_extension_time_in_days,
             change_tracking=resolve_change_tracking(model, self.change_tracking),

--- a/dbt-snowflake/src/dbt/adapters/snowflake/parse_model.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/parse_model.py
@@ -103,15 +103,12 @@ def is_transient(model: RelationConfig) -> Optional[bool]:
 
     Returns:
         None if there is no materialized config on the model; this shouldn't happen
-        False if we know this is an iceberg table format (excludes format set by the catalog)
         True if the user has set it to True or if the user has explicitly unset it
         False otherwise
     """
     if not model.config:
         return None
 
-    if table_format(model) == constants.ICEBERG_TABLE_FORMAT:
-        return False
     return model.config.get("transient", False) or model.config.get("transient", True)
 
 

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
@@ -5,7 +5,7 @@ from typing import FrozenSet, Optional, Type, Iterator, Tuple
 
 from dbt.adapters.base.relation import BaseRelation, EventTimeFilter
 from dbt.adapters.contracts.relation import ComponentName, RelationConfig
-from dbt.adapters.events.types import AdapterEventWarning, AdapterEventDebug
+from dbt.adapters.events.types import AdapterEventDebug
 from dbt.adapters.relation_configs import (
     RelationConfigBase,
     RelationConfigChangeAction,
@@ -13,7 +13,7 @@ from dbt.adapters.relation_configs import (
 )
 from dbt.adapters.utils import classproperty
 from dbt_common.exceptions import DbtRuntimeError
-from dbt_common.events.functions import fire_event, warn_or_error
+from dbt_common.events.functions import fire_event
 
 from dbt.adapters.snowflake import constants
 from dbt.adapters.snowflake.relation_configs import (
@@ -201,49 +201,6 @@ class SnowflakeRelation(BaseRelation):
         The iceberg standard does support renaming, so this may change in the future.
         """
         return self.type in self.renameable_relations and not self.is_iceberg_format
-
-    def get_ddl_prefix_for_create(self, config: RelationConfig, temporary: bool) -> str:
-        """
-        This macro renders the appropriate DDL prefix during the create_table_as
-        macro. It decides based on mutually exclusive table configuration options:
-        - TEMPORARY: Indicates a table that exists only for the duration of the session.
-        - ICEBERG: A specific storage format that requires a distinct DDL layout.
-        - TRANSIENT: A table similar to a permanent table but without fail-safe.
-        Additional Caveats for Iceberg models:
-        - transient=true throws a warning because Iceberg does not support transient tables
-        - A temporary relation is never an Iceberg relation because Iceberg does not
-          support temporary relations.
-        """
-
-        transient_explicitly_set_true: bool = config.get("transient", False)  # type:ignore
-
-        # Temporary tables are a Snowflake feature that do not exist in the
-        # Iceberg framework. We ignore the Iceberg status of the model.
-        if temporary:
-            return "temporary"
-        elif self.is_iceberg_format:
-            # Log a warning that transient=true on an Iceberg relation is ignored.
-            if transient_explicitly_set_true:
-                warn_or_error(
-                    AdapterEventWarning(
-                        base_msg=(
-                            "Iceberg format relations cannot be transient. Please "
-                            "remove either the transient or iceberg config options "
-                            f"from {self.path.database}.{self.path.schema}."
-                            f"{self.path.identifier}. If left unmodified, dbt will "
-                            "ignore 'transient'."
-                        )
-                    )
-                )
-
-            return "iceberg"
-
-        # Always supply transient on table create DDL unless user specifically sets
-        # transient to false or unset. Might as well update the object attribute too!
-        elif transient_explicitly_set_true or config.get("transient", True):  # type:ignore
-            return "transient"
-        else:
-            return ""
 
     def get_ddl_prefix_for_alter(self) -> str:
         """All ALTER statements on Iceberg tables require an ICEBERG prefix"""

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
@@ -169,6 +169,12 @@ alter table {{ relation }} resume recluster;
 
 {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
 
+{%- if catalog_relation.is_transient -%}
+    {%- set transient='transient ' -%}
+{%- else -%}
+    {%- set transient='' -%}
+{%- endif -%}
+
 {%- set partition_by_keys = get_partition_by_keys(catalog_relation) -%}
 {%- if partition_by_keys -%}
   {%- set partition_by_string = partition_by_keys|join(", ")-%}
@@ -191,7 +197,7 @@ alter table {{ relation }} resume recluster;
 {%- set sql_header = config.get('sql_header', none) -%}
 {{ sql_header if sql_header is not none }}
 
-create or replace iceberg table {{ relation }}
+create or replace {{ transient }}iceberg table {{ relation }}
     {%- if contract_config.enforced %}
     {{ get_table_columns_and_constraints() }}
     {%- endif %}

--- a/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
@@ -27,6 +27,11 @@ MODEL__ICEBERG_TABLE_W_CONFIGS = """
                             select 1 as id
                             """
 
+MODEL__NON_TRANSIENT_ICEBERG_TABLE = """
+                            {{ config(materialized='table', catalog_name='basic_iceberg_catalog', transient=False) }}
+                            select 1 as id
+                            """
+
 
 class TestSnowflakeBuiltInCatalogIntegration(BaseCatalogIntegrationValidation):
 
@@ -60,6 +65,7 @@ class TestSnowflakeBuiltInCatalogIntegration(BaseCatalogIntegrationValidation):
         return {
             "basic_iceberg_table.sql": MODEL__BASIC_ICEBERG_TABLE,
             "iceberg_table_with_configs.sql": MODEL__ICEBERG_TABLE_W_CONFIGS,
+            "non_transient_iceberg_table.sql": MODEL__NON_TRANSIENT_ICEBERG_TABLE,
         }
 
     def test_basic_iceberg_catalog_integration(self, project):
@@ -76,3 +82,13 @@ class TestSnowflakeBuiltInCatalogIntegration(BaseCatalogIntegrationValidation):
         assert "max_data_extension_time_in_days = 30" in iceberg_table_with_configs_sql
         assert "change_tracking = FALSE" in iceberg_table_with_configs_sql
         assert "data_retention_time_in_days = 1" in iceberg_table_with_configs_sql
+
+    def test_transient_iceberg_table_ddl(self, project):
+        run_dbt(["run"])
+        # Default (no transient config) → should emit TRANSIENT ICEBERG TABLE
+        default_sql = get_cleaned_model_ddl_from_file("basic_iceberg_table.sql")
+        assert "transient iceberg table" in default_sql.lower()
+
+        # Explicit transient=False → should NOT emit TRANSIENT
+        non_transient_sql = get_cleaned_model_ddl_from_file("non_transient_iceberg_table.sql")
+        assert "transient" not in non_transient_sql.lower()

--- a/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalogs_v2.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalogs_v2.py
@@ -84,6 +84,7 @@ class TestSnowflakeV2HorizonCatalog:
         run_dbt(["run"])
 
         basic_sql = get_cleaned_model_ddl_from_file("horizon_iceberg.sql")
+        assert "transient iceberg table" in basic_sql.lower()
         assert "external_volume = 's3_iceberg_snow'" in basic_sql
         assert "storage_serialization_policy = 'OPTIMIZED'" in basic_sql
         assert "change_tracking = TRUE" in basic_sql

--- a/dbt-snowflake/tests/unit/test_catalog_relation_built_in.py
+++ b/dbt-snowflake/tests/unit/test_catalog_relation_built_in.py
@@ -167,3 +167,18 @@ def test_iceberg_version_model_overrides_catalog():
     model.config.update({"iceberg_version": 3})
     relation = integration.build_relation(model)
     assert relation.iceberg_version == 3
+
+
+@pytest.mark.parametrize(
+    "config,expected",
+    [
+        ({}, True),  # not set → defaults to transient (same behavior as regular tables)
+        ({"transient": True}, True),
+        ({"transient": False}, False),
+    ],
+)
+def test_is_transient_model_config(fake_integration, config, expected):
+    model = deepcopy(model_base)
+    model.config.update(config)
+    relation = fake_integration.build_relation(model)
+    assert relation.is_transient == expected


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#N/A

### Problem

Snowflake Horizon (SNOWFLAKE_MANAGED / `BUILT_IN` catalog) Iceberg tables did not support `transient=true`. The adapter had an explicit block in `parse_model.is_transient()` that returned `False` whenever `table_format == "ICEBERG"`, and a warning in `get_ddl_prefix_for_create()` telling users that Iceberg and transient were mutually exclusive.

Snowflake has since added support for `CREATE [OR REPLACE] [TRANSIENT] ICEBERG TABLE` on Snowflake-managed Iceberg tables: https://docs.snowflake.com/en/sql-reference/sql/create-iceberg-table#snowflake-as-the-iceberg-catalog

### Solution

- **`parse_model.py`**: Removed the `if table_format == ICEBERG: return False` guard. `is_transient` now behaves the same regardless of catalog type — defaults to `True` (matching regular Snowflake table behavior), respects explicit `transient: false`.
- **`catalogs/_built_in.py`**: `BuiltInCatalogIntegration.build_relation()` now passes `is_transient=parse_model.is_transient(model)` instead of leaving it at the hardcoded `False` default.
- **`macros/relations/table/create.sql`**: `snowflake__create_table_built_in_sql` now emits `transient ` before `iceberg table` when `catalog_relation.is_transient` is set, matching the pattern in `snowflake__create_table_info_schema_sql`.
- **`relation.py`**: Removed the dead `get_ddl_prefix_for_create()` method (never called anywhere) which contained the now-incorrect "Iceberg format relations cannot be transient" warning. Cleaned up the two imports only used there (`AdapterEventWarning`, `warn_or_error`).

Note: This only applies to the `BUILT_IN` (Snowflake Horizon / SNOWFLAKE_MANAGED) catalog. `ICEBERG_REST` (Catalog Linked Databases) does not support transient tables and is unchanged.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX