### PR TITLE
fix(snowflake): Replace invalid FIXED dtype with NUMBER(p, s)

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20260529-154501.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260529-154501.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Replace invalid FIXED dtype with NUMBER(p, s) in column type mapping
+time: 2026-05-29T15:45:01.991974+10:00
+custom:
+    Author: rio-not-real
+    Issue: "1986"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
@@ -281,6 +281,26 @@ class SnowflakeAdapter(SQLAdapter):
             else:
                 raise
 
+    def get_column_schema_from_query(self, sql: str) -> List[SnowflakeColumn]:
+        """Get a list of the Columns with names and data types from the given sql."""
+        _, cursor = self.connections.add_select_query(sql)
+        columns = []
+
+        # https://peps.python.org/pep-0249/#description
+        for column_name, column_type_code, _, _, precision, scale, _ in cursor.description:
+            dtype = self.connections.data_type_code_to_name(column_type_code)
+            if dtype == "FIXED":
+                # fixed-point numbers
+                # but FIXED is not a valid SQL type, so we need to convert it
+                dtype = (
+                    f"NUMBER({precision}, {scale})"
+                    if precision is not None and scale is not None
+                    else "NUMBER"
+                )
+            columns.append(self.Column.create(column_name, dtype))
+
+        return columns
+
     def _show_object_metadata(self, relation: SnowflakeRelation) -> Optional[dict]:
         try:
             kwargs = {"relation": relation}

--- a/dbt-snowflake/tests/unit/test_snowflake_adapter.py
+++ b/dbt-snowflake/tests/unit/test_snowflake_adapter.py
@@ -836,6 +836,58 @@ class TestSnowflakeAdapter(unittest.TestCase):
         assert isinstance(normalized.columns["name"].data_type, agate.Text)
         assert isinstance(normalized.columns["kind"].data_type, agate.Text)
 
+    def test_get_column_schema_from_query_fixed_type(self):
+        """FIXED type codes are converted to NUMBER(precision, scale)."""
+        mock_cursor = mock.Mock()
+        # https://peps.python.org/pep-0249/#description
+        mock_cursor.description = [
+            ("ID", 0, None, None, 38, 0, True),
+            ("AMOUNT", 0, None, None, 10, 2, True),
+        ]
+        self.adapter.connections.add_select_query = mock.Mock(
+            return_value=(None, mock_cursor)
+        )
+
+        with mock.patch.object(
+            self.adapter.connections,
+            "data_type_code_to_name",
+            return_value="FIXED",
+        ) as data_type_code_to_name:
+            columns = self.adapter.get_column_schema_from_query("select 42")
+
+        assert [(column.column, column.dtype) for column in columns] == [
+            ("ID", "NUMBER(38, 0)"),
+            ("AMOUNT", "NUMBER(10, 2)"),
+        ]
+        assert data_type_code_to_name.call_count == 2
+
+    def test_get_column_schema_from_query_non_fixed_types(self):
+        """Non-FIXED type_code is looked up via data_type_code_to_name."""
+        mock_cursor = mock.Mock()
+        mock_cursor.description = [
+            ("SCORE", 1, None, None, None, None, True),
+            ("NAME", 2, None, None, None, None, True),
+            ("FLAG", 13, None, None, None, None, True),
+        ]
+        self.adapter.connections.add_select_query = mock.Mock(
+            return_value=(None, mock_cursor)
+        )
+
+        type_names = {1: "REAL", 2: "TEXT", 13: "BOOLEAN"}
+        with mock.patch.object(
+            self.adapter.connections,
+            "data_type_code_to_name",
+            side_effect=lambda code: type_names[code],
+        ) as data_type_code_to_name:
+            columns = self.adapter.get_column_schema_from_query("select 1")
+
+        assert [(column.column, column.dtype) for column in columns] == [
+            ("SCORE", "REAL"),
+            ("NAME", "TEXT"),
+            ("FLAG", "BOOLEAN"),
+        ]
+        assert data_type_code_to_name.call_count == 3
+
 
 class TestSnowflakeAdapterConversions(TestAdapterConversions):
     def test_convert_text_type(self):


### PR DESCRIPTION
resolves #1986
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Currently, `SnowflakeAdapter` inherits `get_column_schema_from_query()` from `BaseAdapter`. However, this method returns 'FIXED' for fixed-point data types, which is not a valid data type in Snowflake SQL. Because of this, when macro `default__snapshot_staging_table` in [helpers.sql](https://github.com/dbt-labs/dbt-adapters/blob/63140d8b177fdcba82a8b5292276fe5eff4c763f/dbt-adapters/src/dbt/include/global_project/macros/materializations/snapshots/helpers.sql#L174) calls it, it fails with the following:

```shell
11:50:25  Failure in snapshot test_snapshot (snapshots/_test__snapshot.yml)
11:50:25    Database Error in snapshot test_snapshot (snapshots/_test__snapshot.yml)
  001003 (42000): SQL compilation error:
  syntax error line 181 at position 25 unexpected 'FIXED'.
```

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Propose overriding `BaseAdapter.get_column_schema_from_query()` in `SnowflakeAdapter` to normalise the data type names returned from the Snowflake connector's `SnowflakeCursorBase.description` for fixed-point data types.

When `data_type_code_to_name()` returns `FIXED`, it will now be converted to a valid Snowflake numeric type:

- `NUMERIC(precision, scale)` when both precision and scale are available.
- `NUMERIC` when they're unavailable (added as a safety net, though I'm not sure in what scenario this would occur).

Non-fixed-point data types (which do not return `FIXED`) will continue to use the existing dtype name returned from `data_type_code_to_name()` without modification.

Unit tests added for:

- converting the `FIXED` type to `NUMERIC`.
- preserving the existing behavior for non-fixed-point data types.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
