### PR TITLE
feat(athena): let Python models self-materialize by returning None

### DIFF
--- a/dbt-athena/.changes/unreleased/Features-20260604-103714.yaml
+++ b/dbt-athena/.changes/unreleased/Features-20260604-103714.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: 'feat(athena): allow Python models to return None to skip adapter materialize()'
+body: 'feat(athena): allow Python models to skip adapter materialize() by returning None, with incremental flows auto-detecting and skipping the tmp/merge post-step'
 time: 2026-06-04T10:37:14.055371+09:00
 custom:
     Author: dtaniwaki

--- a/dbt-athena/.changes/unreleased/Features-20260604-103714.yaml
+++ b/dbt-athena/.changes/unreleased/Features-20260604-103714.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: 'feat(athena): allow Python models to return None to skip adapter materialize()'
+time: 2026-06-04T10:37:14.055371+09:00
+custom:
+    Author: dtaniwaki
+    Issue: "2002"

--- a/dbt-athena/src/dbt/include/athena/macros/adapters/python_submissions.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/adapters/python_submissions.sql
@@ -57,7 +57,42 @@ def materialize(spark_session, df, target_relation):
 
 dbt = SparkdbtObj()
 df = model(dbt, spark)
-materialize(spark, df, dbt.this)
+if df is None:
+    import boto3
+    from botocore.exceptions import ClientError
+
+    {%- set assume_role_arn = target.assume_role_arn or "" %}
+    {%- if assume_role_arn %}
+    _sts_creds = boto3.client("sts", region_name="{{ target.region_name }}").assume_role(
+        RoleArn="{{ assume_role_arn }}",
+        RoleSessionName="{{ target.assume_role_session_name or 'dbt-athena-skip-materialize-check' }}",
+        {%- if target.assume_role_external_id %}
+        ExternalId="{{ target.assume_role_external_id }}",
+        {%- endif %}
+    )["Credentials"]
+    glue = boto3.client(
+        "glue",
+        region_name="{{ target.region_name }}",
+        aws_access_key_id=_sts_creds["AccessKeyId"],
+        aws_secret_access_key=_sts_creds["SecretAccessKey"],
+        aws_session_token=_sts_creds["SessionToken"],
+    )
+    {%- else %}
+    glue = boto3.client("glue", region_name="{{ target.region_name }}")
+    {%- endif %}
+
+    try:
+        glue.get_table(DatabaseName="{{ target_relation.schema }}", Name="{{ target_relation.identifier }}")
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "EntityNotFoundException":
+            raise Exception(
+                "model() returned None but target table "
+                "{{ target_relation.schema }}.{{ target_relation.identifier }} does not exist. "
+                "Models returning None must materialize the target themselves."
+            ) from e
+        raise
+else:
+    materialize(spark, df, dbt.this)
 {%- endmacro -%}
 
 {%- macro athena__py_execute_query(query) -%}

--- a/dbt-athena/src/dbt/include/athena/macros/adapters/python_submissions.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/adapters/python_submissions.sql
@@ -82,12 +82,12 @@ if df is None:
     {%- endif %}
 
     try:
-        glue.get_table(DatabaseName="{{ target_relation.schema }}", Name="{{ target_relation.identifier }}")
+        glue.get_table(DatabaseName="{{ this.schema }}", Name="{{ this.identifier }}")
     except ClientError as e:
         if e.response.get("Error", {}).get("Code") == "EntityNotFoundException":
             raise Exception(
                 "model() returned None but target table "
-                "{{ target_relation.schema }}.{{ target_relation.identifier }} does not exist. "
+                "{{ this.schema }}.{{ this.identifier }} does not exist. "
                 "Models returning None must materialize the target themselves."
             ) from e
         raise

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -15,6 +15,7 @@
   {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}
   {% set s3_data_naming = config.get('s3_data_naming', default=target.s3_data_naming) %}
+  {%- set external_location = config.get('external_location', default=none) %}
   -- If using insert_overwrite on Hive table, allow to set a unique tmp table suffix
   {% if unique_tmp_table_suffix == True and strategy == 'insert_overwrite' and table_type == 'hive' %}
     {% set tmp_table_suffix = adapter.generate_unique_temporary_table_suffix() %}

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -98,23 +98,35 @@
       {% endcall %}
     {%- endif -%}
 
-    -- create a backup relation
-    {%- set relation_bkp = make_temp_relation(target_relation, '__bkp') -%}
+    {# Python models can return None and self-materialize the final relation
+       directly; tmp_relation then never gets created and the rename dance must
+       be skipped. Detect by re-loading the tmp from the catalog. #}
+    {%- set tmp_check = adapter.get_relation(
+      database=tmp_relation.database,
+      schema=tmp_relation.schema,
+      identifier=tmp_relation.identifier
+    ) -%}
+    {%- if model_language == 'python' and tmp_check is none -%}
+      {% set build_sql = "select 'python self-materialized; skipping HA rename'" -%}
+    {%- else -%}
+      -- create a backup relation
+      {%- set relation_bkp = make_temp_relation(target_relation, '__bkp') -%}
 
-    -- if something failed in a prior run and previously created
-    -- backup migration still exists, drop it
-    {%- if relation_bkp is not none -%}
-      {{ drop_relation(relation_bkp) }}
+      -- if something failed in a prior run and previously created
+      -- backup migration still exists, drop it
+      {%- if relation_bkp is not none -%}
+        {{ drop_relation(relation_bkp) }}
+      {%- endif -%}
+
+      -- rename the current target_relation to a backup_relation
+      {%- do rename_relation(target_relation, relation_bkp) -%}
+      -- rename the new full refreshed tmp_relation to the target_relation
+      {%- do rename_relation(tmp_relation, target_relation) -%}
+      -- drop the backup_relation
+      {%- do drop_relation(relation_bkp) -%}
+
+      {% set build_sql = "select '" ~ query_result ~ "'" -%}
     {%- endif -%}
-
-    -- rename the current target_relation to a backup_relation
-    {%- do rename_relation(target_relation, relation_bkp) -%}
-    -- rename the new full refreshed tmp_relation to the target_relation
-    {%- do rename_relation(tmp_relation, target_relation) -%}
-    -- drop the backup_relation
-    {%- do drop_relation(relation_bkp) -%}
-
-    {% set build_sql = "select '" ~ query_result ~ "'" -%}
 
   -- Running in full refresh, drop existing relation, and do full build --
   {% elif existing_relation.is_view or should_full_refresh() %}
@@ -138,12 +150,21 @@
         {{ query_result }}
       {% endcall %}
     {%- endif -%}
-    {% do delete_overlapping_partitions(target_relation, tmp_relation, partitioned_by) %}
-    {% set build_sql = incremental_insert(
-        on_schema_change, tmp_relation, target_relation, existing_relation, force_batch
-      )
-    %}
-    {% do to_drop.append(tmp_relation) %}
+    {%- set tmp_check = adapter.get_relation(
+      database=tmp_relation.database,
+      schema=tmp_relation.schema,
+      identifier=tmp_relation.identifier
+    ) -%}
+    {%- if model_language == 'python' and tmp_check is none -%}
+      {% set build_sql = "select 'python self-materialized; skipping insert_overwrite'" -%}
+    {%- else -%}
+      {% do delete_overlapping_partitions(target_relation, tmp_relation, partitioned_by) %}
+      {% set build_sql = incremental_insert(
+          on_schema_change, tmp_relation, target_relation, existing_relation, force_batch
+        )
+      %}
+      {% do to_drop.append(tmp_relation) %}
+    {%- endif -%}
 
   -- Append Strategy --
   {% elif strategy == 'append' %}
@@ -156,11 +177,22 @@
         {{ query_result }}
       {% endcall %}
     {%- endif -%}
-    {% set build_sql = incremental_insert(
-        on_schema_change, tmp_relation, target_relation, existing_relation, force_batch
-      )
-    %}
-    {% do to_drop.append(tmp_relation) %}
+    {# Python return-None auto-detection: if tmp does not exist, the model
+       wrote the final relation directly and we skip incremental_insert. #}
+    {%- set tmp_check = adapter.get_relation(
+      database=tmp_relation.database,
+      schema=tmp_relation.schema,
+      identifier=tmp_relation.identifier
+    ) -%}
+    {%- if model_language == 'python' and tmp_check is none -%}
+      {% set build_sql = "select 'python self-materialized; skipping incremental_insert'" -%}
+    {%- else -%}
+      {% set build_sql = incremental_insert(
+          on_schema_change, tmp_relation, target_relation, existing_relation, force_batch
+        )
+      %}
+      {% do to_drop.append(tmp_relation) %}
+    {%- endif -%}
 
   -- Iceberge Merge Stategy --
   {% elif strategy == 'merge' and table_type == 'iceberg' %}
@@ -196,20 +228,29 @@
         {{ query_result }}
       {% endcall %}
     {%- endif -%}
-    {% set build_sql = iceberg_merge(
-        on_schema_change=on_schema_change,
-        tmp_relation=tmp_relation,
-        target_relation=target_relation,
-        unique_key=unique_key,
-        incremental_predicates=incremental_predicates,
-        existing_relation=existing_relation,
-        delete_condition=delete_condition,
-        update_condition=update_condition,
-        insert_condition=insert_condition,
-        force_batch=force_batch,
-      )
-    %}
-    {% do to_drop.append(tmp_relation) %}
+    {%- set tmp_check = adapter.get_relation(
+      database=tmp_relation.database,
+      schema=tmp_relation.schema,
+      identifier=tmp_relation.identifier
+    ) -%}
+    {%- if model_language == 'python' and tmp_check is none -%}
+      {% set build_sql = "select 'python self-materialized; skipping iceberg_merge'" -%}
+    {%- else -%}
+      {% set build_sql = iceberg_merge(
+          on_schema_change=on_schema_change,
+          tmp_relation=tmp_relation,
+          target_relation=target_relation,
+          unique_key=unique_key,
+          incremental_predicates=incremental_predicates,
+          existing_relation=existing_relation,
+          delete_condition=delete_condition,
+          update_condition=update_condition,
+          insert_condition=insert_condition,
+          force_batch=force_batch,
+        )
+      %}
+      {% do to_drop.append(tmp_relation) %}
+    {%- endif -%}
   {% endif %}
 
   {% call statement("main", language=model_language) %}

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -64,13 +64,22 @@
           {{ query_result }}
         {% endcall %}
       {%- endif -%}
-      -- swap table
-      {%- set swap_table = adapter.swap_table(tmp_relation, target_relation) -%}
+      {# Python return-None auto-detection: if tmp does not exist, the model
+         wrote the final relation directly and we skip the swap. #}
+      {%- set tmp_check_ha = adapter.get_relation(
+        database=tmp_relation.database,
+        schema=tmp_relation.schema,
+        identifier=tmp_relation.identifier
+      ) -%}
+      {%- if not (language == 'python' and tmp_check_ha is none) -%}
+        -- swap table
+        {%- set swap_table = adapter.swap_table(tmp_relation, target_relation) -%}
 
-      -- delete glue tmp table, do not use drop_relation, as it will remove data of the target table
-      {%- do adapter.delete_from_glue_catalog(tmp_relation) -%}
+        -- delete glue tmp table, do not use drop_relation, as it will remove data of the target table
+        {%- do adapter.delete_from_glue_catalog(tmp_relation) -%}
 
-      {% do adapter.expire_glue_table_versions(target_relation, versions_to_keep, True) %}
+        {% do adapter.expire_glue_table_versions(target_relation, versions_to_keep, True) %}
+      {%- endif -%}
 
     {%- else -%}
       -- Here we are in the case of non-ha tables or ha tables but in case of full refresh.
@@ -132,27 +141,38 @@
           {% endcall %}
         {%- endif -%}
 
-        {%- set old_relation_table_type = adapter.get_glue_table_type(old_relation).value if old_relation else none -%}
+        {# Python return-None auto-detection: if tmp does not exist, the model
+           wrote the final relation directly and we skip the __ha rename swap. #}
+        {%- set tmp_check = adapter.get_relation(
+          database=tmp_relation.database,
+          schema=tmp_relation.schema,
+          identifier=tmp_relation.identifier
+        ) -%}
+        {%- if language == 'python' and tmp_check is none -%}
+          {# self-materialized to final, nothing to swap #}
+        {%- else -%}
+          {%- set old_relation_table_type = adapter.get_glue_table_type(old_relation).value if old_relation else none -%}
 
-        -- we cannot use old_bkp_relation, because it returns None if the relation doesn't exist
-        -- we need to create a python object via the make_temp_relation instead
-        {%- set old_relation_bkp = make_temp_relation(old_relation, '__bkp') -%}
+          -- we cannot use old_bkp_relation, because it returns None if the relation doesn't exist
+          -- we need to create a python object via the make_temp_relation instead
+          {%- set old_relation_bkp = make_temp_relation(old_relation, '__bkp') -%}
 
-        {%- if old_relation_table_type == 'iceberg_table' -%}
-          {{ rename_relation(old_relation, old_relation_bkp) }}
-        {%- else  -%}
-          {%- do drop_relation_glue(old_relation) -%}
-        {%- endif -%}
+          {%- if old_relation_table_type == 'iceberg_table' -%}
+            {{ rename_relation(old_relation, old_relation_bkp) }}
+          {%- else  -%}
+            {%- do drop_relation_glue(old_relation) -%}
+          {%- endif -%}
 
-        -- publish the target table doing a final renaming
-        {{ rename_relation(tmp_relation, target_relation) }}
+          -- publish the target table doing a final renaming
+          {{ rename_relation(tmp_relation, target_relation) }}
 
-        -- if old relation is iceberg_table, we have a backup
-        -- therefore we can drop the old relation backup, in all other cases there is nothing to do
-        -- in case of switch from hive to iceberg the backup table do not exists
-        -- in case of first run, the backup table do not exists
-        {%- if old_relation_table_type == 'iceberg_table' -%}
-          {%- do drop_relation(old_relation_bkp) -%}
+          -- if old relation is iceberg_table, we have a backup
+          -- therefore we can drop the old relation backup, in all other cases there is nothing to do
+          -- in case of switch from hive to iceberg the backup table do not exists
+          -- in case of first run, the backup table do not exists
+          {%- if old_relation_table_type == 'iceberg_table' -%}
+            {%- do drop_relation(old_relation_bkp) -%}
+          {%- endif -%}
         {%- endif -%}
 
       {%- endif -%}

--- a/dbt-athena/tests/unit/test_py_save_table_as.py
+++ b/dbt-athena/tests/unit/test_py_save_table_as.py
@@ -5,6 +5,7 @@ Unit tests for the athena__py_save_table_as macro, focused on the
 
 import os
 from types import SimpleNamespace
+from unittest import mock
 
 import jinja2
 import pytest
@@ -24,55 +25,96 @@ _MACRO_DIR = os.path.normpath(
 )
 
 
-def _render(optional_args, compiled_code="def model(dbt, spark):\n    return spark"):
-    target_relation = SimpleNamespace(schema="my_schema", identifier="my_table")
+def _render(
+    optional_args,
+    *,
+    compiled_code="def model(dbt, spark):\n    return spark",
+    target_identifier="my_table__dbt_tmp",
+    this_identifier="my_table",
+    schema="my_schema",
+):
+    """Render athena__py_save_table_as with stubbed dbt context.
+
+    ``target_identifier`` defaults to a ``__dbt_tmp`` suffix to mirror the
+    incremental Python flow, where create_table_as is invoked with the
+    intermediate temp relation. ``this_identifier`` is the final relation
+    that the guard must look up — regression test for the case where the
+    two diverge.
+    """
+    target_relation = SimpleNamespace(schema=schema, identifier=target_identifier)
+    context = {
+        "target": SimpleNamespace(
+            assume_role_arn=None,
+            assume_role_external_id=None,
+            assume_role_session_name=None,
+            region_name="us-east-1",
+        ),
+        "this": SimpleNamespace(schema=schema, identifier=this_identifier),
+    }
     env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(_MACRO_DIR),
         extensions=["jinja2.ext.do"],
     )
-    template = env.get_template("python_submissions.sql")
+    template = env.get_template("python_submissions.sql", globals=context)
     return template.module.athena__py_save_table_as(compiled_code, target_relation, optional_args)
 
 
 class TestSkipMaterializeWhenModelReturnsNone:
-    """Rendered template must branch on `df is None` and only call
+    """Rendered template must branch on ``df is None`` and only call
     materialize() when the user returned a DataFrame."""
 
-    def test_renders_none_branch_with_tableExists_guard(self):
+    def test_renders_none_branch_with_glue_guard(self):
         rendered = _render({"location": "s3://b/p"})
         assert "if df is None:" in rendered
-        assert "spark.catalog.tableExists(target_fqn)" in rendered
+        assert "glue.get_table(" in rendered
         assert "else:" in rendered
         assert "materialize(spark, df, dbt.this)" in rendered
 
-    def _exec_trailing_block(self, table_exists, model_returns):
-        """Execute the rendered trailing block (after the materialize def)
-        with stubbed model(), dbt, spark — return whether materialize() was
-        called."""
+    def test_guard_uses_final_relation_not_tmp(self):
+        """The guard must look up the final (``this``) relation, never the
+        ``__dbt_tmp`` intermediate. Otherwise incremental Python models
+        that write the final relation directly always raise on first run."""
+        rendered = _render(
+            {"location": "s3://b/p"},
+            target_identifier="my_table__dbt_tmp",
+            this_identifier="my_table",
+        )
+        assert 'Name="my_table"' in rendered
+        assert "my_table__dbt_tmp" not in rendered.split("if df is None:", 1)[1]
+
+    def _exec_trailing_block(self, *, table_exists, model_returns):
+        """Execute the rendered ``if df is None:`` ... ``else: materialize(...)``
+        block with stubbed dbt / model / spark / boto3."""
         rendered = _render({"location": "s3://b/p"})
-        # Pull the trailing `dbt = SparkdbtObj() ... materialize(...)` block.
         marker = "dbt = SparkdbtObj()"
         body = rendered[rendered.index(marker) :]
-        # Strip the trailing endmacro artifacts if any.
-        body = body.split("\n\n{%")[0]
 
         materialize_calls = []
 
         def fake_materialize(spark_session, df, target):
             materialize_calls.append((df, target))
 
-        spark_stub = SimpleNamespace(
-            catalog=SimpleNamespace(tableExists=lambda fqn: table_exists),
-        )
+        glue_client = mock.Mock()
+        if table_exists:
+            glue_client.get_table.return_value = {}
+        else:
+            from botocore.exceptions import ClientError
+
+            glue_client.get_table.side_effect = ClientError(
+                error_response={"Error": {"Code": "EntityNotFoundException"}},
+                operation_name="GetTable",
+            )
+
         ns = {
             "SparkdbtObj": lambda: SimpleNamespace(
-                this=SimpleNamespace(schema="s", identifier="t"),
+                this=SimpleNamespace(schema="my_schema", identifier="my_table"),
             ),
             "model": lambda dbt, spark: model_returns,
-            "spark": spark_stub,
+            "spark": mock.Mock(),
             "materialize": fake_materialize,
         }
-        exec(body, ns)
+        with mock.patch("boto3.client", return_value=glue_client):
+            exec(compile(body, "<rendered>", "exec"), ns)
         return materialize_calls
 
     def test_none_with_existing_target_skips_materialize(self):

--- a/dbt-athena/tests/unit/test_py_save_table_as.py
+++ b/dbt-athena/tests/unit/test_py_save_table_as.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for the athena__py_save_table_as macro, focused on the
+"model returns None" branch that skips adapter materialize().
+"""
+
+import os
+from types import SimpleNamespace
+
+import jinja2
+import pytest
+
+_MACRO_DIR = os.path.normpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        os.pardir,
+        os.pardir,
+        "src",
+        "dbt",
+        "include",
+        "athena",
+        "macros",
+        "adapters",
+    )
+)
+
+
+def _render(optional_args, compiled_code="def model(dbt, spark):\n    return spark"):
+    target_relation = SimpleNamespace(schema="my_schema", identifier="my_table")
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(_MACRO_DIR),
+        extensions=["jinja2.ext.do"],
+    )
+    template = env.get_template("python_submissions.sql")
+    return template.module.athena__py_save_table_as(compiled_code, target_relation, optional_args)
+
+
+class TestSkipMaterializeWhenModelReturnsNone:
+    """Rendered template must branch on `df is None` and only call
+    materialize() when the user returned a DataFrame."""
+
+    def test_renders_none_branch_with_tableExists_guard(self):
+        rendered = _render({"location": "s3://b/p"})
+        assert "if df is None:" in rendered
+        assert "spark.catalog.tableExists(target_fqn)" in rendered
+        assert "else:" in rendered
+        assert "materialize(spark, df, dbt.this)" in rendered
+
+    def _exec_trailing_block(self, table_exists, model_returns):
+        """Execute the rendered trailing block (after the materialize def)
+        with stubbed model(), dbt, spark — return whether materialize() was
+        called."""
+        rendered = _render({"location": "s3://b/p"})
+        # Pull the trailing `dbt = SparkdbtObj() ... materialize(...)` block.
+        marker = "dbt = SparkdbtObj()"
+        body = rendered[rendered.index(marker) :]
+        # Strip the trailing endmacro artifacts if any.
+        body = body.split("\n\n{%")[0]
+
+        materialize_calls = []
+
+        def fake_materialize(spark_session, df, target):
+            materialize_calls.append((df, target))
+
+        spark_stub = SimpleNamespace(
+            catalog=SimpleNamespace(tableExists=lambda fqn: table_exists),
+        )
+        ns = {
+            "SparkdbtObj": lambda: SimpleNamespace(
+                this=SimpleNamespace(schema="s", identifier="t"),
+            ),
+            "model": lambda dbt, spark: model_returns,
+            "spark": spark_stub,
+            "materialize": fake_materialize,
+        }
+        exec(body, ns)
+        return materialize_calls
+
+    def test_none_with_existing_target_skips_materialize(self):
+        calls = self._exec_trailing_block(table_exists=True, model_returns=None)
+        assert calls == []
+
+    def test_none_with_missing_target_raises(self):
+        with pytest.raises(Exception, match="model\\(\\) returned None"):
+            self._exec_trailing_block(table_exists=False, model_returns=None)
+
+    def test_dataframe_return_still_materializes(self):
+        sentinel = object()
+        calls = self._exec_trailing_block(table_exists=True, model_returns=sentinel)
+        assert len(calls) == 1
+        assert calls[0][0] is sentinel


### PR DESCRIPTION
resolves #2002

## Problem

Today's Python submission template forces dbt-athena to write the target whenever the model runs. The trailing line of `python_submissions.sql` is unconditional:

```python
dbt = SparkdbtObj()
df = model(dbt, spark)
materialize(spark, df, dbt.this)
```

Two patterns can't be expressed cleanly:

1. **Custom writers (e.g. Iceberg MERGE INTO from Spark)** — Trino's MERGE has a per-writer 100-partition limit that hurts high-cardinality bucketed tables. Spark's Iceberg MERGE has no such cap, so users want to drive it from the Python model via `session.sql("MERGE INTO ...")` and keep the adapter out of the write path. Today, returning a DataFrame writes twice; returning anything else fails an `isinstance` check.
2. **`materialized='incremental'` Python models that self-materialize** — even if the user-managed write succeeds, dbt-athena still runs `incremental_insert(tmp_relation, target)` (or `iceberg_merge`, or the HA full-refresh rename) as a post-step. The user's model never produced the tmp relation, so the run fails on `tmp_relation does not exist` after the user code was already correct.

## Solution

A single, scoped contract: **`return None` means "I materialized the target myself"**, and dbt-athena adapts accordingly.

1. **`return None` from `model()` skips `materialize()`.** The submission template wraps the call: `if df is None: ... else: materialize(...)`. To keep "forgot to return df" loud, the `None` branch verifies the target exists via `boto3.client('glue').get_table(...)`. The lookup uses `this.schema` / `this.identifier` (the final relation) so it works for both `materialized='table'` (where `target_relation` is already the final) and `materialized='incremental'` (where the macro passes the `__dbt_tmp` intermediate but the user model writes the final via `dbt.this`).
2. **Incremental flows auto-detect and skip the post-step.** After executing the Python script, each strategy branch (`insert_overwrite` / `append` / `merge` / Iceberg HA full-refresh) re-loads `tmp_relation` from the Glue catalog. If it's absent — which only happens when the user returned `None` and wrote the final relation directly, since standard `return df` always creates tmp via `materialize()` — the post-step (`incremental_insert`, `iceberg_merge`, or the rename dance) is skipped and the run completes. Standard `return df` flows are unaffected.

When `assume_role_arn` is configured, the Glue client mirrors dbt-athena's own AssumeRole logic (including `external_id` / `session_name`) — boto3 calls from the Spark runtime otherwise use the default credential chain, which is not necessarily granted `glue:GetTable`.

One unrelated Jinja fix rides along because the new path exposes it: `incremental.sql` references `external_location` in the Iceberg full-refresh HA condition without setting it in scope, so `Undefined is not none` evaluates `True` and the HA `tmp+rename` branch fires for every Iceberg full-refresh. Setting `external_location` from `config` at the top of `incremental.sql` mirrors the other materializations.

Example after this PR:

```python
def model(dbt, session):
    dbt.config(materialized="incremental", table_type="iceberg")
    df = ...
    target_fqn = f"{dbt.this.schema}.{dbt.this.identifier}"
    if not dbt.is_incremental:
        df.writeTo(target_fqn).using("iceberg").createOrReplace()
    else:
        df.createOrReplaceTempView("src")
        session.sql(f"MERGE INTO {target_fqn} t USING src s ON ...")
    return None  # adapter skips materialize() and the incremental post-step
```

## Alternatives considered

- **Explicit `skip_post_merge` config** to opt out of the post-step. Workable but couples the user-facing API to dbt-athena's internal flow split; the catalog check has zero false positives (a model that returns `None` and writes tmp manually is not a realistic pattern — that's just a more roundabout `return df`).
- **New config (`skip_python_materialize=True`)** for the first piece — explicit but adds an extra knob; `return None` reuses the existing `isinstance` check site and stays close to the dbt-spark / dbt-bigquery "return df" convention.
- **Dedicated exception (`raise MaterializedExternally`)** — most explicit but requires exporting/importing a class from the user model.

## Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes — marking unchecked because this exposes a new accepted `model()` return value (None), so it warrants Product/DX review.