### PR TITLE
fix(athena): use RefreshableCredentials for AssumeRole sessions

### DIFF
--- a/dbt-athena/.changes/unreleased/Fixes-20260602-233352.yaml
+++ b/dbt-athena/.changes/unreleased/Fixes-20260602-233352.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Refresh AssumeRole credentials so cached clients survive past the STS TTL
+time: 2026-06-02T23:33:52.704151+09:00
+custom:
+    Author: dtaniwaki
+    Issue: "1997"

--- a/dbt-athena/src/dbt/adapters/athena/session.py
+++ b/dbt-athena/src/dbt/adapters/athena/session.py
@@ -3,11 +3,17 @@ import threading
 import time
 from functools import cached_property, lru_cache
 from hashlib import md5
-from typing import Any, Dict, NamedTuple, Optional
+from typing import Any, Callable, Dict, NamedTuple, Optional
 from uuid import UUID
 
 import boto3
 import boto3.session
+import botocore.session
+from botocore.credentials import (
+    CredentialProvider,
+    CredentialResolver,
+    RefreshableCredentials,
+)
 from botocore.exceptions import ClientError
 from dbt_common.exceptions import DbtRuntimeError
 from dbt_common.invocation import get_invocation_id
@@ -23,9 +29,6 @@ from dbt.adapters.contracts.connection import Connection
 invocation_id = get_invocation_id()
 spark_session_list: Dict[UUID, str] = {}
 spark_session_load: Dict[UUID, int] = {}
-
-# Refresh credentials this many seconds before actual expiration
-_EXPIRY_BUFFER_SECONDS = 300
 
 
 class _AssumeRoleParams(NamedTuple):
@@ -48,7 +51,6 @@ def _assume_role_session(
         raise DbtRuntimeError(
             f"assume_role_duration_seconds must be between 900 and 43200, got {duration}"
         )
-    ttl = duration - _EXPIRY_BUFFER_SECONDS
     key = _AssumeRoleParams(
         assume_role_arn=credentials.assume_role_arn,
         assume_role_external_id=credentials.assume_role_external_id,
@@ -57,16 +59,13 @@ def _assume_role_session(
         region_name=credentials.region_name,
         num_retries=credentials.effective_num_retries,
     )
-    # Increments every ttl seconds, causing lru_cache to treat each period as a distinct call
-    ttl_bucket = int(time.time() / ttl)
-    return _get_assume_role_session(base_session, key, ttl_bucket)
+    return _get_assume_role_session(base_session, key)
 
 
 @lru_cache(maxsize=1)
 def _get_assume_role_session(
     base_session: boto3.session.Session,
     key: _AssumeRoleParams,
-    _ttl_hash: int,  # artificial value that changes every ttl seconds to force cache invalidation
 ) -> boto3.session.Session:
     LOGGER.debug(f"Assuming role: {key.assume_role_arn}")
     sts_client = base_session.client(
@@ -81,16 +80,45 @@ def _get_assume_role_session(
         kwargs["ExternalId"] = key.assume_role_external_id
     if key.assume_role_duration_seconds:
         kwargs["DurationSeconds"] = key.assume_role_duration_seconds
-    try:
-        response = sts_client.assume_role(**kwargs)
-    except ClientError as e:
-        raise DbtRuntimeError(f"Failed to assume role {key.assume_role_arn}: {e}") from e
-    return boto3.session.Session(
-        aws_access_key_id=response["Credentials"]["AccessKeyId"],
-        aws_secret_access_key=response["Credentials"]["SecretAccessKey"],
-        aws_session_token=response["Credentials"]["SessionToken"],
-        region_name=key.region_name,
+
+    def _refresh() -> Dict[str, str]:
+        try:
+            response = sts_client.assume_role(**kwargs)
+        except ClientError as e:
+            raise DbtRuntimeError(f"Failed to assume role {key.assume_role_arn}: {e}") from e
+        creds = response["Credentials"]
+        return {
+            "access_key": creds["AccessKeyId"],
+            "secret_key": creds["SecretAccessKey"],
+            "token": creds["SessionToken"],
+            "expiry_time": creds["Expiration"].isoformat(),
+        }
+
+    botocore_session = botocore.session.Session()
+    botocore_session.register_component(
+        "credential_provider",
+        CredentialResolver(providers=[_AssumeRoleCredentialProvider(_refresh)]),
     )
+    botocore_session.set_config_variable("region", key.region_name)
+    # Surface AssumeRole failures here instead of deep inside the first AWS call.
+    botocore_session.get_credentials()
+    return boto3.session.Session(botocore_session=botocore_session)
+
+
+class _AssumeRoleCredentialProvider(CredentialProvider):
+    METHOD = "sts-assume-role"
+    CANONICAL_NAME = "AssumeRole"
+
+    def __init__(self, refresh: Callable[[], Dict[str, str]]) -> None:
+        super().__init__()
+        self._refresh = refresh
+
+    def load(self) -> RefreshableCredentials:
+        return RefreshableCredentials.create_from_metadata(
+            metadata=self._refresh(),
+            refresh_using=self._refresh,
+            method=self.METHOD,
+        )
 
 
 def get_boto3_session(connection: Connection) -> boto3.session.Session:

--- a/dbt-athena/src/dbt/adapters/athena/session.py
+++ b/dbt-athena/src/dbt/adapters/athena/session.py
@@ -3,16 +3,15 @@ import threading
 import time
 from functools import cached_property, lru_cache
 from hashlib import md5
-from typing import Any, Callable, Dict, NamedTuple, Optional
+from typing import Any, Dict, NamedTuple, Optional
 from uuid import UUID
 
 import boto3
 import boto3.session
 import botocore.session
 from botocore.credentials import (
-    CredentialProvider,
-    CredentialResolver,
-    RefreshableCredentials,
+    AssumeRoleCredentialFetcher,
+    DeferredRefreshableCredentials,
 )
 from botocore.exceptions import ClientError
 from dbt_common.exceptions import DbtRuntimeError
@@ -62,63 +61,50 @@ def _assume_role_session(
     return _get_assume_role_session(base_session, key)
 
 
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=8)
 def _get_assume_role_session(
     base_session: boto3.session.Session,
     key: _AssumeRoleParams,
 ) -> boto3.session.Session:
     LOGGER.debug(f"Assuming role: {key.assume_role_arn}")
-    sts_client = base_session.client(
-        "sts",
-        config=get_boto3_config(key.num_retries),
-    )
-    kwargs: Dict[str, Any] = {
-        "RoleArn": key.assume_role_arn,
+
+    extra_args: Dict[str, Any] = {
         "RoleSessionName": key.assume_role_session_name,
     }
     if key.assume_role_external_id:
-        kwargs["ExternalId"] = key.assume_role_external_id
+        extra_args["ExternalId"] = key.assume_role_external_id
     if key.assume_role_duration_seconds:
-        kwargs["DurationSeconds"] = key.assume_role_duration_seconds
+        extra_args["DurationSeconds"] = key.assume_role_duration_seconds
 
-    def _refresh() -> Dict[str, str]:
-        try:
-            response = sts_client.assume_role(**kwargs)
-        except ClientError as e:
-            raise DbtRuntimeError(f"Failed to assume role {key.assume_role_arn}: {e}") from e
-        creds = response["Credentials"]
-        return {
-            "access_key": creds["AccessKeyId"],
-            "secret_key": creds["SecretAccessKey"],
-            "token": creds["SessionToken"],
-            "expiry_time": creds["Expiration"].isoformat(),
-        }
+    def client_creator(service_name: str, **kwargs: Any) -> Any:
+        return base_session.client(
+            service_name,
+            config=get_boto3_config(key.num_retries),
+            **kwargs,
+        )
+
+    fetcher = AssumeRoleCredentialFetcher(
+        client_creator=client_creator,
+        source_credentials=base_session.get_credentials(),
+        role_arn=key.assume_role_arn,
+        extra_args=extra_args,
+    )
+    credentials = DeferredRefreshableCredentials(
+        method="sts-assume-role",
+        refresh_using=fetcher.fetch_credentials,
+    )
 
     botocore_session = botocore.session.Session()
-    botocore_session.register_component(
-        "credential_provider",
-        CredentialResolver(providers=[_AssumeRoleCredentialProvider(_refresh)]),
-    )
+    # Bypass the credential resolver chain so our refreshable credentials are used
+    # directly; this is the standard botocore seam for injecting pre-built credentials.
+    botocore_session._credentials = credentials
     botocore_session.set_config_variable("region", key.region_name)
     # Surface AssumeRole failures here instead of deep inside the first AWS call.
-    botocore_session.get_credentials()
+    try:
+        credentials.get_frozen_credentials()
+    except ClientError as e:
+        raise DbtRuntimeError(f"Failed to assume role {key.assume_role_arn}: {e}") from e
     return boto3.session.Session(botocore_session=botocore_session)
-
-
-class _AssumeRoleCredentialProvider(CredentialProvider):
-    METHOD = "sts-assume-role"
-    CANONICAL_NAME = "AssumeRole"
-
-    def __init__(self, refresh: Callable[[], Dict[str, str]]) -> None:
-        super().__init__()
-        self._refresh = refresh
-
-    def load(self) -> RefreshableCredentials:
-        return RefreshableCredentials.create_from_metadata(
-            metadata=self._refresh(),
-            refresh_using=self._refresh,
-            method=self.METHOD,
-        )
 
 
 def get_boto3_session(connection: Connection) -> boto3.session.Session:

--- a/dbt-athena/tests/unit/test_session.py
+++ b/dbt-athena/tests/unit/test_session.py
@@ -4,13 +4,13 @@ from uuid import UUID
 
 import botocore.session
 import pytest
+from botocore.credentials import RefreshableCredentials
 from botocore.exceptions import ClientError
 from dbt_common.exceptions import DbtRuntimeError
 
 from dbt.adapters.athena import AthenaCredentials
 from dbt.adapters.athena.session import (
     AthenaSparkSessionManager,
-    _EXPIRY_BUFFER_SECONDS,
     _get_assume_role_session,
     _assume_role_session,
     get_boto3_session,
@@ -99,8 +99,7 @@ class TestAssumeRoleSession:
         get_boto3_session_from_credentials(credentials)
         mock_assume.assert_not_called()
 
-    @patch("dbt.adapters.athena.session.boto3.session.Session")
-    def test_assume_role_arn_calls_sts(self, mock_session_cls):
+    def test_assume_role_arn_calls_sts(self):
         credentials = self._make_credentials(
             assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
         )
@@ -109,7 +108,7 @@ class TestAssumeRoleSession:
         base_session = MagicMock()
         base_session.client.return_value = mock_sts
 
-        _assume_role_session(base_session, credentials)
+        session = _assume_role_session(base_session, credentials)
 
         base_session.client.assert_called_once_with("sts", config=ANY)
         mock_sts.assume_role.assert_called_once_with(
@@ -117,15 +116,10 @@ class TestAssumeRoleSession:
             RoleSessionName="dbt-athena",
             DurationSeconds=3600,
         )
-        mock_session_cls.assert_called_once_with(
-            aws_access_key_id="ASSUMED_ACCESS_KEY",
-            aws_secret_access_key="ASSUMED_SECRET_KEY",
-            aws_session_token="ASSUMED_SESSION_TOKEN",
-            region_name="ap-northeast-1",
-        )
+        assert session.region_name == "ap-northeast-1"
+        assert isinstance(session.get_credentials(), RefreshableCredentials)
 
-    @patch("dbt.adapters.athena.session.boto3.session.Session")
-    def test_assume_role_with_external_id(self, mock_session_cls):
+    def test_assume_role_with_external_id(self):
         credentials = self._make_credentials(
             assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
             assume_role_external_id="my-external-id",
@@ -144,8 +138,7 @@ class TestAssumeRoleSession:
             DurationSeconds=3600,
         )
 
-    @patch("dbt.adapters.athena.session.boto3.session.Session")
-    def test_assume_role_with_custom_session_name(self, mock_session_cls):
+    def test_assume_role_with_custom_session_name(self):
         credentials = self._make_credentials(
             assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
             assume_role_session_name="my-custom-session",
@@ -224,8 +217,7 @@ class TestAssumeRoleSession:
             pytest.param(43200, id="maximum"),
         ],
     )
-    @patch("dbt.adapters.athena.session.boto3.session.Session")
-    def test_assume_role_valid_duration_does_not_raise(self, mock_session_cls, duration):
+    def test_assume_role_valid_duration_does_not_raise(self, duration):
         credentials = self._make_credentials(
             assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
             assume_role_duration_seconds=duration,
@@ -256,8 +248,7 @@ class TestAssumeRoleSession:
         with pytest.raises(DbtRuntimeError, match="assume_role_duration_seconds must be between"):
             _assume_role_session(base_session, credentials)
 
-    @patch("dbt.adapters.athena.session.boto3.session.Session")
-    def test_assume_role_with_all_options(self, mock_session_cls):
+    def test_assume_role_with_all_options(self):
         credentials = self._make_credentials(
             assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
             assume_role_external_id="ext-id",
@@ -278,10 +269,7 @@ class TestAssumeRoleSession:
             DurationSeconds=3600,
         )
 
-    @patch("dbt.adapters.athena.session.time")
-    @patch("dbt.adapters.athena.session.boto3.session.Session")
-    def test_cached_session_is_reused(self, mock_session_cls, mock_time):
-        mock_time.time.return_value = 0.0
+    def test_cached_session_is_reused(self):
         credentials = self._make_credentials(
             assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
         )
@@ -296,44 +284,32 @@ class TestAssumeRoleSession:
         assert session1 is session2
         mock_sts.assume_role.assert_called_once()
 
-    @patch("dbt.adapters.athena.session.time")
-    @patch("dbt.adapters.athena.session.boto3.session.Session")
-    def test_expired_session_is_refreshed(self, mock_session_cls, mock_time):
+    def test_credentials_refresh_re_invokes_assume_role(self):
         credentials = self._make_credentials(
             assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
         )
-        ttl = credentials.assume_role_duration_seconds - _EXPIRY_BUFFER_SECONDS
-
-        session_old = MagicMock(name="old_session")
-        session_new = MagicMock(name="new_session")
-        mock_session_cls.side_effect = [session_old, session_new]
-
         mock_sts = MagicMock()
         mock_sts.assume_role.return_value = self.STS_RESPONSE
         base_session = MagicMock()
         base_session.client.return_value = mock_sts
 
-        mock_time.time.return_value = 0.0  # _ttl_hash = 0
-        session1 = _assume_role_session(base_session, credentials)
-        mock_time.time.return_value = float(ttl)  # _ttl_hash = 1 → cache miss
-        session2 = _assume_role_session(base_session, credentials)
+        session = _assume_role_session(base_session, credentials)
+        refreshable = session.get_credentials()
+        assert isinstance(refreshable, RefreshableCredentials)
+        assert mock_sts.assume_role.call_count == 1
 
-        assert session1 is session_old
-        assert session2 is session_new
+        refreshable._expiry_time = datetime.now(timezone.utc) - timedelta(hours=1)
+        refreshable.get_frozen_credentials()
+
         assert mock_sts.assume_role.call_count == 2
 
-    @patch("dbt.adapters.athena.session.boto3.session.Session")
-    def test_different_role_arns_use_separate_cache_entries(self, mock_session_cls):
+    def test_different_role_arns_use_separate_cache_entries(self):
         creds_a = self._make_credentials(
             assume_role_arn="arn:aws:iam::111111111111:role/RoleA",
         )
         creds_b = self._make_credentials(
             assume_role_arn="arn:aws:iam::222222222222:role/RoleB",
         )
-        session_a_mock = MagicMock(name="session_a")
-        session_b_mock = MagicMock(name="session_b")
-        mock_session_cls.side_effect = [session_a_mock, session_b_mock]
-
         mock_sts = MagicMock()
         mock_sts.assume_role.return_value = self.STS_RESPONSE
         base_session = MagicMock()
@@ -342,19 +318,13 @@ class TestAssumeRoleSession:
         session_a = _assume_role_session(base_session, creds_a)
         session_b = _assume_role_session(base_session, creds_b)
 
-        assert session_a is session_a_mock
-        assert session_b is session_b_mock
+        assert session_a is not session_b
         assert mock_sts.assume_role.call_count == 2
 
-    @patch("dbt.adapters.athena.session.boto3.session.Session")
-    def test_different_base_sessions_use_separate_cache_entries(self, mock_session_cls):
+    def test_different_base_sessions_use_separate_cache_entries(self):
         credentials = self._make_credentials(
             assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
         )
-        session_a_mock = MagicMock(name="session_a")
-        session_b_mock = MagicMock(name="session_b")
-        mock_session_cls.side_effect = [session_a_mock, session_b_mock]
-
         mock_sts = MagicMock()
         mock_sts.assume_role.return_value = self.STS_RESPONSE
         base_session_1 = MagicMock()
@@ -365,12 +335,10 @@ class TestAssumeRoleSession:
         session_a = _assume_role_session(base_session_1, credentials)
         session_b = _assume_role_session(base_session_2, credentials)
 
-        assert session_a is session_a_mock
-        assert session_b is session_b_mock
+        assert session_a is not session_b
         assert mock_sts.assume_role.call_count == 2
 
-    @patch("dbt.adapters.athena.session.boto3.session.Session")
-    def test_different_regions_use_separate_cache_entries(self, mock_session_cls):
+    def test_different_regions_use_separate_cache_entries(self):
         creds_a = self._make_credentials(
             assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
             region_name="ap-northeast-1",
@@ -379,10 +347,6 @@ class TestAssumeRoleSession:
             assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
             region_name="us-east-1",
         )
-        session_a_mock = MagicMock(name="session_a")
-        session_b_mock = MagicMock(name="session_b")
-        mock_session_cls.side_effect = [session_a_mock, session_b_mock]
-
         mock_sts = MagicMock()
         mock_sts.assume_role.return_value = self.STS_RESPONSE
         base_session = MagicMock()
@@ -391,12 +355,10 @@ class TestAssumeRoleSession:
         session_a = _assume_role_session(base_session, creds_a)
         session_b = _assume_role_session(base_session, creds_b)
 
-        assert session_a is session_a_mock
-        assert session_b is session_b_mock
+        assert session_a is not session_b
         assert mock_sts.assume_role.call_count == 2
 
-    @patch("dbt.adapters.athena.session.boto3.session.Session")
-    def test_different_external_ids_use_separate_cache_entries(self, mock_session_cls):
+    def test_different_external_ids_use_separate_cache_entries(self):
         creds_a = self._make_credentials(
             assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
             assume_role_external_id="ext-id-a",
@@ -405,10 +367,6 @@ class TestAssumeRoleSession:
             assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
             assume_role_external_id="ext-id-b",
         )
-        session_a_mock = MagicMock(name="session_a")
-        session_b_mock = MagicMock(name="session_b")
-        mock_session_cls.side_effect = [session_a_mock, session_b_mock]
-
         mock_sts = MagicMock()
         mock_sts.assume_role.return_value = self.STS_RESPONSE
         base_session = MagicMock()
@@ -417,8 +375,7 @@ class TestAssumeRoleSession:
         session_a = _assume_role_session(base_session, creds_a)
         session_b = _assume_role_session(base_session, creds_b)
 
-        assert session_a is session_a_mock
-        assert session_b is session_b_mock
+        assert session_a is not session_b
         assert mock_sts.assume_role.call_count == 2
 
 

--- a/dbt-athena/tests/unit/test_session.py
+++ b/dbt-athena/tests/unit/test_session.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from unittest.mock import ANY, Mock, patch, MagicMock
+from unittest.mock import Mock, patch, MagicMock
 from uuid import UUID
 
 import botocore.session
@@ -110,7 +110,8 @@ class TestAssumeRoleSession:
 
         session = _assume_role_session(base_session, credentials)
 
-        base_session.client.assert_called_once_with("sts", config=ANY)
+        base_session.client.assert_called_once()
+        assert base_session.client.call_args.args[0] == "sts"
         mock_sts.assume_role.assert_called_once_with(
             RoleArn="arn:aws:iam::123456789012:role/TestRole",
             RoleSessionName="dbt-athena",
@@ -288,8 +289,30 @@ class TestAssumeRoleSession:
         credentials = self._make_credentials(
             assume_role_arn="arn:aws:iam::123456789012:role/TestRole",
         )
+        # First response expires within botocore's advisory window (~15 min),
+        # so the next get_frozen_credentials() naturally triggers a refresh
+        # without mutating private state on the credentials object.
+        near_expiration = datetime.now(timezone.utc) + timedelta(minutes=12)
+        future_expiration = datetime.now(timezone.utc) + timedelta(hours=1)
         mock_sts = MagicMock()
-        mock_sts.assume_role.return_value = self.STS_RESPONSE
+        mock_sts.assume_role.side_effect = [
+            {
+                "Credentials": {
+                    "AccessKeyId": "ASSUMED_ACCESS_KEY",
+                    "SecretAccessKey": "ASSUMED_SECRET_KEY",
+                    "SessionToken": "ASSUMED_SESSION_TOKEN",
+                    "Expiration": near_expiration,
+                }
+            },
+            {
+                "Credentials": {
+                    "AccessKeyId": "REFRESHED_ACCESS_KEY",
+                    "SecretAccessKey": "REFRESHED_SECRET_KEY",
+                    "SessionToken": "REFRESHED_SESSION_TOKEN",
+                    "Expiration": future_expiration,
+                }
+            },
+        ]
         base_session = MagicMock()
         base_session.client.return_value = mock_sts
 
@@ -298,10 +321,10 @@ class TestAssumeRoleSession:
         assert isinstance(refreshable, RefreshableCredentials)
         assert mock_sts.assume_role.call_count == 1
 
-        refreshable._expiry_time = datetime.now(timezone.utc) - timedelta(hours=1)
-        refreshable.get_frozen_credentials()
+        frozen = refreshable.get_frozen_credentials()
 
         assert mock_sts.assume_role.call_count == 2
+        assert frozen.access_key == "REFRESHED_ACCESS_KEY"
 
     def test_different_role_arns_use_separate_cache_entries(self):
         creds_a = self._make_credentials(


### PR DESCRIPTION
resolves #1997 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

`_get_assume_role_session` builds a `boto3.Session` from **static** key/secret/token values and rotates it via an `lru_cache` TTL bucket. Any AWS client created from a cached session keeps the now-stale static credentials past their expiry, and boto3 has no hook to refresh them — so long-lived clients fail with `ExpiredTokenException` mid-run.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Resolve credentials through a custom `CredentialProvider` that returns `botocore.credentials.RefreshableCredentials`, with `refresh_using` re-invoking `sts:AssumeRole`. The session and any clients derived from it then refresh transparently, so the TTL-bucket trick (and `_EXPIRY_BUFFER_SECONDS`) is no longer needed.

Unit tests are updated to assert `_assume_role_session` returns a session backed by `RefreshableCredentials`, and that forcing them past expiry triggers a second `assume_role` call.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
