### PR TITLE
pin athena's dbt-core to <2.0

### DIFF
--- a/dbt-athena/pyproject.toml
+++ b/dbt-athena/pyproject.toml
@@ -30,7 +30,7 @@ dependencies=[
     "dbt-adapters>=1.0.0,<2.0",
     "dbt-common>=1.0.0,<2.0",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-    "dbt-core>=1.8.0",
+    "dbt-core>=1.8.0,<2.0",
     "boto3>=1.28",
     "boto3-stubs[athena,glue,lakeformation,sts]>=1.28",
     "mmh3>=4.0.1,<4.2.0",


### PR DESCRIPTION
resolves #

- dbt-athena/pyproject.toml declares dbt-core>=1.8.0 with no upper bound. pip resolves this to dbt-core==2.0.0a1, which removed dbt.config and breaks all athena unit tests with ModuleNotFoundError: No module named 'dbt.config'.
- Adds <2.0 cap to match what dbt-snowflake and dbt-bigquery already have.
- This specifically affects dbt-athena-community CI, whose hatch env installs dbt-core purely through dbt-athena's transitive dependency (no explicit git pin to 1.latest like other adapters have). The other adapters (postgres, redshift,
  spark) are shielded because their hatch.toml CI envs explicitly install dbt-core@git+...@1.latest, which satisfies the requirement before pip can resolve to 2.0.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
