### PR TITLE
fix(bigquery): ride out getQueryResults rate-limit storms instead of failing

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fixes-20260605-120000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20260605-120000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixed a regression where transient getQueryResults rate-limit errors (rateLimitExceeded) surfaced as hard job failures during bursts of concurrent jobs. The polling retry no longer caps attempts at job_retries; retryable errors now back off (initial 5s) until job_retry_deadline_seconds, while still short-circuiting immediately when the underlying job is in a terminal failed state. Rate-limit errors back off without an extra jobs.get reload to avoid adding pressure to the rate limit being waited out.
+time: 2026-06-05T12:00:00.000000-05:00
+custom:
+    Author: tauhid621
+    Issue: "1957"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/retry.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/retry.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Optional
 
-from google.api_core.exceptions import GoogleAPICallError
+from google.api_core.exceptions import GoogleAPICallError, RetryError
 from google.api_core.future.polling import DEFAULT_POLLING
 from google.api_core.retry import Retry
 from google.cloud.bigquery.retry import DEFAULT_JOB_RETRY, _job_should_retry
@@ -19,6 +19,20 @@ _logger = AdapterLogger("BigQuery")
 _MINUTE = 60.0
 _DAY = 24 * 60 * 60.0
 _DEFAULT_POLLING_RETRY_DEADLINE = 10 * _MINUTE
+
+# Throttle reasons that say nothing about job health: the job is fine, BQ is
+# just busy. We back these off without a jobs.get reload to avoid piling extra
+# API pressure onto a getQueryResults rate-limit storm.
+_RATE_LIMIT_REASONS = frozenset({"rateLimitExceeded", "jobRateLimitExceeded"})
+
+
+def _is_rate_limit_error(error: Exception) -> bool:
+    if isinstance(error, RetryError):
+        error = error.cause
+    errors = getattr(error, "errors", None)
+    if not errors:
+        return False
+    return errors[0].get("reason") in _RATE_LIMIT_REASONS
 
 
 class RetryFactory:
@@ -70,14 +84,19 @@ class RetryFactory:
         - Uses job_retry_deadline_seconds (default 10 min) as the retry budget,
           decoupled from job_execution_timeout_seconds so that a long-running job
           does not silently burn the full execution timeout on getQueryResults errors.
-        - Enforces job_retries as an attempt cap.
+        - Uses a slower retry cadence to dampen burst pressure on getQueryResults
+          when many jobs are polling concurrently.
         - Short-circuits immediately when the underlying BQ job has reached a
           terminal failed state (state == DONE + error_result), avoiding the
           scenario where a permanently-dead job is polled for hours.
         """
         deadline = self._job_deadline or _DEFAULT_POLLING_RETRY_DEADLINE
         predicate = _TerminalJobAwarePredicate(query_job, self._retries)
-        return DEFAULT_JOB_RETRY.with_predicate(predicate).with_deadline(deadline)
+        return (
+            DEFAULT_JOB_RETRY.with_predicate(predicate)
+            .with_deadline(deadline)
+            .with_delay(initial=5.0, maximum=60.0, multiplier=2.0)
+        )
 
 
 class _DeferredException:
@@ -118,13 +137,19 @@ class _TerminalJobAwarePredicate:
     otherwise consider the error retryable. This prevents dbt from polling
     getQueryResults for hours against a job that BQ has already killed.
 
-    Also enforces a per-run attempt cap via _DeferredException.
+    The authoritative jobs.get reload is only performed for ambiguous errors
+    (e.g. internalError/backendError) that could indicate a dead job. Pure
+    throttle errors (rateLimitExceeded) skip the reload and back off directly,
+    since the job is healthy and the extra jobs.get would only add pressure to
+    the rate limit being waited out.
+
+    Retry cadence and overall budget are controlled by the enclosing Retry
+    object. This predicate only decides whether polling should continue.
     """
 
     def __init__(self, query_job: Any, retries: int) -> None:
         self._query_job = query_job
         self._retries = retries
-        self._deferred = _DeferredException(retries)
 
     def __call__(self, error: Exception) -> bool:
         # If the user opted out of retries, bail immediately. Avoids an
@@ -136,33 +161,35 @@ class _TerminalJobAwarePredicate:
         if not _job_should_retry(error):
             return False
 
-        # Reload from jobs.get to get authoritative job state. Both branches
-        # below fall through to the standard retry path; raising out of a
-        # Retry predicate would crash the entire query_job.result() call,
-        # which is worse than continuing to retry. We split the catch so that
-        # truly unexpected errors (auth bugs, programming errors, new SDK
-        # exception types) are loud (warning), and routine API/transport
-        # flakes during reload are also warning for observability.
-        try:
-            self._query_job.reload()
-            if self._query_job.state == "DONE" and self._query_job.error_result:
-                _logger.debug(
-                    f"Job {self._query_job.job_id} is in a terminal failed state; "
-                    "stopping getQueryResults polling."
+        # Rate-limit errors are healthy-job throttles (see class docstring) — skip the reload.
+        if not _is_rate_limit_error(error):
+            # Confirm the job isn't already terminally dead. Never raise from a
+            # predicate — that crashes the whole result() call — so reload failures
+            # are logged (expected vs unexpected) and fall through to retry.
+            try:
+                self._query_job.reload()
+                if self._query_job.state == "DONE" and self._query_job.error_result:
+                    _logger.debug(
+                        f"Job {self._query_job.job_id} is in a terminal failed state; "
+                        "stopping getQueryResults polling."
+                    )
+                    return False
+            except (GoogleAPICallError, RequestException) as reload_error:
+                _logger.warning(
+                    f"Expected transient error reloading job state during retry "
+                    f"predicate (falling back to standard retry logic): {reload_error}"
                 )
-                return False
-        except (GoogleAPICallError, RequestException) as reload_error:
-            _logger.warning(
-                f"Expected transient error reloading job state during retry "
-                f"predicate (falling back to standard retry logic): {reload_error}"
-            )
-        except Exception as reload_error:
-            _logger.warning(
-                f"Unexpected error reloading job state during retry predicate "
-                f"(falling back to standard retry logic): {reload_error}"
-            )
+            except Exception as reload_error:
+                _logger.warning(
+                    f"Unexpected error reloading job state during retry predicate "
+                    f"(falling back to standard retry logic): {reload_error}"
+                )
 
-        return self._deferred(error)
+        _logger.debug(
+            f"Retrying getQueryResults for job {self._query_job.job_id} "
+            f"after retryable error: {repr(error)}"
+        )
+        return True
 
 
 def _create_reopen_on_error(connection: Connection) -> Callable[[Exception], None]:

--- a/dbt-bigquery/tests/unit/test_bigquery_connection_manager.py
+++ b/dbt-bigquery/tests/unit/test_bigquery_connection_manager.py
@@ -371,6 +371,14 @@ class TestTerminalJobAwarePredicate(unittest.TestCase):
         exceptions = dbt.adapters.bigquery.impl.google.cloud.exceptions
         return exceptions.BadRequest("syntax error", errors=[{"reason": "invalidQuery"}])
 
+    def _make_rate_limit_error(self):
+        """Reproduce the reported getQueryResults rate-limit error."""
+        exceptions = dbt.adapters.bigquery.impl.google.cloud.exceptions
+        return exceptions.Forbidden(
+            "Exceeded rate limits: too many api requests per user per method",
+            errors=[{"reason": "rateLimitExceeded"}],
+        )
+
     def test_short_circuits_on_terminal_failed_job(self):
         """Core regression test: internalError on a DONE+failed job must not retry."""
         mock_job = Mock()
@@ -385,7 +393,7 @@ class TestTerminalJobAwarePredicate(unittest.TestCase):
         mock_job.reload.assert_called_once()
 
     def test_retries_when_job_still_running(self):
-        """A retryable error on a still-running job should be retried (up to the cap)."""
+        """A retryable error on a still-running job should be retried."""
         mock_job = Mock()
         mock_job.job_id = "job_abc"
         mock_job.state = "RUNNING"
@@ -397,18 +405,18 @@ class TestTerminalJobAwarePredicate(unittest.TestCase):
         self.assertTrue(result)
         mock_job.reload.assert_called_once()
 
-    def test_respects_attempt_cap_on_running_job(self):
-        """Even for a still-running job, stop after job_retries attempts."""
+    def test_continues_retrying_on_running_job(self):
+        """Predicate should continue allowing retries while the job is still running."""
         mock_job = Mock()
         mock_job.job_id = "job_abc"
         mock_job.state = "RUNNING"
         mock_job.error_result = None
 
-        predicate = _TerminalJobAwarePredicate(mock_job, retries=2)
+        predicate = _TerminalJobAwarePredicate(mock_job, retries=1)
 
-        self.assertTrue(predicate(self._make_internal_error()))  # attempt 1
-        self.assertTrue(predicate(self._make_internal_error()))  # attempt 2
-        self.assertFalse(predicate(self._make_internal_error()))  # attempt 3 → cap hit
+        self.assertTrue(predicate(self._make_internal_error()))
+        self.assertTrue(predicate(self._make_internal_error()))
+        self.assertTrue(predicate(self._make_internal_error()))
 
     def test_no_retry_when_retries_zero(self):
         """job_retries=0 means never retry, and skips the jobs.get reload call."""
@@ -431,6 +439,35 @@ class TestTerminalJobAwarePredicate(unittest.TestCase):
 
         self.assertFalse(result)
         mock_job.reload.assert_not_called()
+
+    def test_rate_limit_error_retries_without_reload(self):
+        """A rate-limit error says nothing about job health: retry without the
+        extra jobs.get reload, so we don't add pressure to the rate limit."""
+        mock_job = Mock()
+        mock_job.job_id = "job_abc"
+        mock_job.state = "RUNNING"
+        mock_job.error_result = None
+
+        predicate = _TerminalJobAwarePredicate(mock_job, retries=3)
+        result = predicate(self._make_rate_limit_error())
+
+        self.assertTrue(result)
+        mock_job.reload.assert_not_called()
+
+    def test_retry_path_logs_debug(self):
+        """The continue-polling path should emit a debug line for observability."""
+        mock_job = Mock()
+        mock_job.job_id = "job_abc"
+        mock_job.state = "RUNNING"
+        mock_job.error_result = None
+
+        predicate = _TerminalJobAwarePredicate(mock_job, retries=3)
+
+        with patch("dbt.adapters.bigquery.retry._logger") as mock_logger:
+            result = predicate(self._make_rate_limit_error())
+
+        self.assertTrue(result)
+        mock_logger.debug.assert_called_once()
 
     def test_reload_expected_api_error_logs_warning(self):
         """Expected API errors during reload() log at warning and fall through."""
@@ -517,6 +554,79 @@ class TestRetryFactoryPollingRetry(unittest.TestCase):
             errors=[{"reason": "internalError"}],
         )
 
+    def _make_rate_limit_error(self):
+        """Reproduce the reported getQueryResults rate-limit error."""
+        exceptions = dbt.adapters.bigquery.impl.google.cloud.exceptions
+        return exceptions.Forbidden(
+            "Exceeded rate limits: too many api requests per user per method "
+            "for this user_method (JobService.getQueryResults)",
+            errors=[{"reason": "rateLimitExceeded"}],
+        )
+
+    def test_rate_limit_on_running_job_retries_beyond_job_retries_then_succeeds(self):
+        """Regression test for #1957: transient rateLimitExceeded errors on a
+        still-running job must be retried past the job_retries count and allowed
+        to succeed, rather than surfacing as a hard failure after job_retries.
+        """
+        creds = self._make_credentials(job_retries=1)
+        factory = RetryFactory(creds)
+
+        mock_job = Mock()
+        mock_job.job_id = "job_abc"
+        mock_job.state = "RUNNING"
+        mock_job.error_result = None
+
+        retry = factory.create_query_job_polling_retry(mock_job)
+        err = self._make_rate_limit_error()
+
+        call_count = {"n": 0}
+
+        def fail_then_succeed():
+            call_count["n"] += 1
+            # Fail more times than job_retries (1) before succeeding.
+            if call_count["n"] <= 5:
+                raise err
+            return "results"
+
+        # Patch sleep so exponential backoff doesn't slow the test down.
+        with patch("time.sleep"):
+            result = retry(fail_then_succeed)()
+
+        self.assertEqual(result, "results")
+        self.assertEqual(
+            call_count["n"],
+            6,
+            "Transient rate-limit errors must retry past job_retries until success",
+        )
+
+    def test_internal_error_on_running_job_retries_beyond_job_retries(self):
+        """A still-running job hitting transient internalError is retried well
+        beyond the job_retries count (no attempt cap on the polling retry)."""
+        creds = self._make_credentials(job_retries=2)
+        factory = RetryFactory(creds)
+
+        mock_job = Mock()
+        mock_job.job_id = "job_abc"
+        mock_job.state = "RUNNING"
+        mock_job.error_result = None
+
+        retry = factory.create_query_job_polling_retry(mock_job)
+        err = self._make_internal_error()
+
+        call_count = {"n": 0}
+
+        def fail_then_succeed():
+            call_count["n"] += 1
+            if call_count["n"] <= 4:  # > 1 initial + 2 retries
+                raise err
+            return "results"
+
+        with patch("time.sleep"):
+            result = retry(fail_then_succeed)()
+
+        self.assertEqual(result, "results")
+        self.assertGreater(call_count["n"], 3)
+
     def test_retry_short_circuits_on_terminal_failed_job(self):
         """Tyson regression: a terminal failed job should fail on the first attempt."""
         creds = self._make_credentials(job_retries=5)
@@ -542,32 +652,6 @@ class TestRetryFactoryPollingRetry(unittest.TestCase):
 
         self.assertEqual(call_count["n"], 1, "Terminal-failed job should not be retried at all")
 
-    def test_retry_attempts_match_job_retries_for_running_job(self):
-        """Retries on a still-running job are bounded by job_retries (1 initial + N retries)."""
-        creds = self._make_credentials(job_retries=2)
-        factory = RetryFactory(creds)
-
-        mock_job = Mock()
-        mock_job.job_id = "job_abc"
-        mock_job.state = "RUNNING"
-        mock_job.error_result = None
-
-        retry = factory.create_query_job_polling_retry(mock_job)
-        exceptions = dbt.adapters.bigquery.impl.google.cloud.exceptions
-        err = self._make_internal_error()
-
-        call_count = {"n": 0}
-
-        def always_fail():
-            call_count["n"] += 1
-            raise err
-
-        with self.assertRaises(exceptions.BadRequest):
-            retry(always_fail)()
-
-        # 1 initial attempt + 2 retries = 3 total
-        self.assertEqual(call_count["n"], 3)
-
     @patch("dbt.adapters.bigquery.retry.DEFAULT_JOB_RETRY")
     def test_factory_passes_job_retry_deadline_seconds_to_retry(self, mock_retry):
         """Deadline plumbing: job_retry_deadline_seconds (not job_execution_timeout_seconds)
@@ -585,6 +669,11 @@ class TestRetryFactoryPollingRetry(unittest.TestCase):
 
         chained = mock_retry.with_predicate.return_value
         chained.with_deadline.assert_called_once_with(300)
+        chained.with_deadline.return_value.with_delay.assert_called_once_with(
+            initial=5.0,
+            maximum=60.0,
+            multiplier=2.0,
+        )
 
     @patch("dbt.adapters.bigquery.retry.DEFAULT_JOB_RETRY")
     def test_factory_falls_back_to_default_deadline(self, mock_retry):
@@ -600,3 +689,8 @@ class TestRetryFactoryPollingRetry(unittest.TestCase):
 
         chained = mock_retry.with_predicate.return_value
         chained.with_deadline.assert_called_once_with(600)
+        chained.with_deadline.return_value.with_delay.assert_called_once_with(
+            initial=5.0,
+            maximum=60.0,
+            multiplier=2.0,
+        )


### PR DESCRIPTION
Resolves #1957

## What
`getQueryResults` polling retries are now bounded by a **time deadline** (`job_retry_deadline_seconds`, ~10 min) with exponential backoff, instead of a fixed **attempt count** (`job_retries`). Rate-limit errors skip the extra `jobs.get` reload. The terminal-failed-job short-circuit is preserved.

## Why
During bursts of concurrent jobs, transient `rateLimitExceeded` errors on `getQueryResults` exhausted the small `job_retries` cap (often 1) and surfaced as **hard job failures**. A throttle is a transient "slow down" signal, not a fatal error — it should be waited out.

## How
- Drop the per-attempt cap in `_TerminalJobAwarePredicate`; retries continue until the deadline budget is spent.
- Slow the backoff cadence (`initial=5s`, `max=60s`, `multiplier=2x`) to ease pressure on the rate limit; jitter de-syncs concurrent jobs.
- Skip the authoritative `jobs.get` reload for rate-limit errors (the job is healthy) — only ambiguous errors (`internalError`/`backendError`) reload to detect a dead job.
- Keep the terminal-state short-circuit so a job BQ has already killed still fails fast.
- Restore a per-retry debug log for observability.

Unit tests cover: retry past `job_retries` until success, rate-limit skips reload, terminal job fails fast, and backoff wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)