### PR TITLE
ci(bigquery): speed up integration tests from ~4h30m to ~20m

### DIFF
--- a/.github/workflows/_integration-tests.yml
+++ b/.github/workflows/_integration-tests.yml
@@ -130,6 +130,10 @@ jobs:
     integration-tests-bigquery:
         if: contains(fromJSON(inputs.packages), 'dbt-bigquery')
         runs-on: ${{ inputs.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                group: [1, 2]
         defaults:
             run:
                 working-directory: "./dbt-bigquery"
@@ -169,18 +173,14 @@ jobs:
               uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc # pypa/hatch@install
 
             - name: "Run integration tests"
-              run: hatch run ${{ inputs.hatch-env }}:integration-tests
+              run: hatch run ${{ inputs.hatch-env }}:integration-tests --splits 2 --group ${{ matrix.group }}
 
     integration-tests-bigquery-flaky:
         # we only run this for one python version to avoid running in parallel
-        # we need to run with "!cancelled()" so that we run after non-flaky BQ tests even when they fail
         if: |
             contains(fromJSON(inputs.packages), 'dbt-bigquery') &&
-            inputs.python-version == vars.DEFAULT_PYTHON_VERSION &&
-            !cancelled()
+            inputs.python-version == vars.DEFAULT_PYTHON_VERSION
         runs-on: ${{ inputs.os }}
-        # make sure these don't kick off in parallel with the non-flaky tests, which defeats the purpose of running them separately
-        needs: integration-tests-bigquery
         defaults:
             run:
                 working-directory: "./dbt-bigquery"

--- a/dbt-bigquery/.changes/unreleased/Under the Hood-20260605-000000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Under the Hood-20260605-000000.yaml
@@ -1,0 +1,8 @@
+kind: Under the Hood
+body: Stabilize flaky BigQuery Python-model integration tests by retrying transient
+  Dataproc CPU-quota failures, and shard the suite across parallel CI runners with
+  pytest-split to keep it fast
+time: 2026-06-05T00:00:00.000000-06:00
+custom:
+  Author: tauhid621
+  Issue: ""

--- a/dbt-bigquery/hatch.toml
+++ b/dbt-bigquery/hatch.toml
@@ -78,14 +78,15 @@ dependencies = [
     "pytest>=7.0,<8.0",
     "pytest-csv~=3.0",
     "pytest-mock",
+    "pytest-split",
     "pytest-xdist",
     "requests",
 ]
 
 [envs.ci.scripts]
 unit-tests = "python -m pytest tests/unit --ddtrace"
-integration-tests = 'python -m pytest -m "not flaky" --profile service_account tests/functional --ddtrace'
-integration-tests-flaky = "python -m pytest -n1 -m flaky --profile service_account tests/functional --ddtrace"
+integration-tests = 'python -m pytest -m "not flaky" --profile service_account tests/functional --ddtrace -n 8 {args:}'
+integration-tests-flaky = "python -m pytest -m flaky --profile service_account tests/functional --ddtrace -n 8"
 
 [envs.cd]
 pre-install-commands = []
@@ -97,11 +98,12 @@ dependencies = [
     "pytest>=7.0,<8.0",
     "pytest-csv~=3.0",
     "pytest-mock",
+    "pytest-split",
     "pytest-xdist",
     "requests",
 ]
 
 [envs.cd.scripts]
 unit-tests = "python -m pytest tests/unit --ddtrace"
-integration-tests = 'python -m pytest -m "not flaky" --profile service_account tests/functional --ddtrace'
-integration-tests-flaky = "python -m pytest -n1 -m flaky --profile service_account tests/functional --ddtrace"
+integration-tests = 'python -m pytest -m "not flaky" --profile service_account tests/functional --ddtrace -n 8 {args:}'
+integration-tests-flaky = "python -m pytest -m flaky --profile service_account tests/functional --ddtrace -n 8"

--- a/dbt-bigquery/tests/_python_model_retry.py
+++ b/dbt-bigquery/tests/_python_model_retry.py
@@ -1,0 +1,82 @@
+"""
+Retry helper for a transient BigQuery Python-model infrastructure failure: serverless
+batches rejected by the shared, project-wide Dataproc CPU quota.
+
+Decision logic lives here (not in pytest) so it is importable and unit-tested in
+``tests/unit/test_python_model_retry.py``; the functional conftest wires it into an autouse
+fixture. Test-only — the adapter is unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from typing import Any, Callable
+
+_logger = logging.getLogger(__name__)
+
+_JITTER_RATIO = 0.25
+
+
+def is_cpu_quota_error(exc: BaseException) -> bool:
+    """True only for transient Dataproc CPU-quota rejections, not real model errors."""
+    message = str(exc).lower()
+    return "quota" in message and "cpu" in message
+
+
+def backoff_seconds(attempt: int, base: float, max_delay: float) -> float:
+    """Jittered exponential backoff for a 1-based attempt, capped at ``max_delay``."""
+    delay = min(base * 2 ** (attempt - 1), max_delay)
+    return delay + random.uniform(0, delay * _JITTER_RATIO)
+
+
+def _delete_batch_quietly(helper: Any) -> None:
+    """Best-effort delete of the batch a prior attempt registered before its quota error.
+
+    The quota error surfaces while polling, after ``create_batch`` already claimed the id,
+    so re-submitting the same id would hit ``409 Already exists``. Any failure here is
+    swallowed: the subsequent ``create_batch`` is the source of truth.
+    """
+    try:
+        client = helper._batch_controller_client
+        name = client.batch_path(helper._project, helper._region, helper._get_batch_id())
+        client.delete_batch(name=name)
+        _logger.debug("Deleted orphaned Dataproc batch before retry: %s", name)
+    except Exception as exc:  # noqa: BLE001 - best-effort cleanup
+        _logger.debug("No orphaned Dataproc batch to delete before retry: %s", exc)
+
+
+def make_dataproc_quota_retry(
+    original_submit: Callable,
+    attempts: int,
+    base: float,
+    max_delay: float,
+    sleep: Callable[[float], None] = time.sleep,
+) -> Callable:
+    """Re-submit serverless batches rejected by the shared, project-wide Dataproc CPU quota,
+    with jittered backoff so the wait lets quota free up (an instant rerun just re-hits it).
+
+    Deletes the orphaned batch id before each retry so the re-submit does not 409. This stays
+    on the quota path, so tests that reuse a fixed id to assert a 409 are unaffected.
+    """
+
+    def wrapped(self, compiled_code):
+        for attempt in range(1, attempts + 1):
+            try:
+                return original_submit(self, compiled_code)
+            except Exception as exc:
+                if attempt == attempts or not is_cpu_quota_error(exc):
+                    raise
+                _delete_batch_quietly(self)
+                delay = backoff_seconds(attempt, base, max_delay)
+                _logger.warning(
+                    "Dataproc CPU quota exhausted (attempt %d/%d); retrying in %.0fs: %s",
+                    attempt,
+                    attempts,
+                    delay,
+                    exc,
+                )
+                sleep(delay)
+
+    return wrapped

--- a/dbt-bigquery/tests/_python_model_retry.py
+++ b/dbt-bigquery/tests/_python_model_retry.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import random
 import time
+import uuid
 from typing import Any, Callable
 
 _logger = logging.getLogger(__name__)
@@ -29,6 +30,19 @@ def backoff_seconds(attempt: int, base: float, max_delay: float) -> float:
     """Jittered exponential backoff for a 1-based attempt, capped at ``max_delay``."""
     delay = min(base * 2 ** (attempt - 1), max_delay)
     return delay + random.uniform(0, delay * _JITTER_RATIO)
+
+
+def _pin_batch_id(helper: Any) -> None:
+    """Pin a stable batch id on first run so create and the pre-retry delete agree.
+
+    The adapter's ``_get_batch_id`` mints a fresh uuid on every call when ``batch_id`` is
+    unset (see ``python_submissions._get_batch_id``), so without this the delete would
+    target a different id than the batch ``submit`` actually created — leaking it. An
+    explicit ``batch_id`` is never overridden.
+    """
+    config = getattr(helper, "_parsed_model", {}).get("config")
+    if config is not None and not config.get("batch_id"):
+        config["batch_id"] = str(uuid.uuid4())
 
 
 def _delete_batch_quietly(helper: Any) -> None:
@@ -62,6 +76,7 @@ def make_dataproc_quota_retry(
     """
 
     def wrapped(self, compiled_code):
+        _pin_batch_id(self)
         for attempt in range(1, attempts + 1):
             try:
                 return original_submit(self, compiled_code)

--- a/dbt-bigquery/tests/functional/adapter/test_python_model.py
+++ b/dbt-bigquery/tests/functional/adapter/test_python_model.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import time
+import uuid
 from dbt.tests.util import run_dbt, run_dbt_and_capture, write_file
 import dbt.tests.adapter.python_model.test_python_model as dbt_tests
 
@@ -41,6 +42,7 @@ class TestPythonModelDataproc(dbt_tests.BasePythonModelTests):
 
 
 @pytest.mark.skip(reason=TEST_SKIP_MESSAGE)
+@pytest.mark.flaky
 class TestPythonIncrementalMatsDataproc(dbt_tests.BasePythonIncrementalTests):
     pass
 
@@ -109,15 +111,17 @@ def model(dbt, spark):
     return final_df
 """
 
-models__partitioned_model_yaml = """
+
+def _partitioned_model_yaml(batch_id: str) -> str:
+    return f"""
 models:
   - name: python_partitioned_model
     description: A random table with a calculated column defined in python.
     config:
-      batch_id: '{{ run_started_at.strftime("%Y-%m-%d-%H-%M-%S") }}-python-partitioned'
+      batch_id: {batch_id}-python-partitioned
     tests:
       - number_partitions:
-          expected: "{{ var('expected', 1) }}"
+          expected: "{{{{ var('expected', 1) }}}}"
     columns:
       - name: A
         description: Column A
@@ -138,10 +142,17 @@ class TestPythonPartitionedModels:
     def models(self):
         return {
             "python_partitioned_model.py": models__partitioned_model_python,
-            "python_partitioned_model.yml": models__partitioned_model_yaml,
+            "python_partitioned_model.yml": _partitioned_model_yaml("placeholder"),
         }
 
     def test_multiple_named_python_models(self, project):
+        # Unique batch id per invocation so flaky reruns / parallel shards never reuse one.
+        batch_id = f"custom-{uuid.uuid4().hex}"
+        write_file(
+            _partitioned_model_yaml(batch_id),
+            project.project_root + "/models",
+            "python_partitioned_model.yml",
+        )
         result = run_dbt(["run"])
         assert len(result) == 1
 
@@ -199,14 +210,14 @@ models:
         description: Column C
 """
 
-custom_ts_id = str("custom-" + str(time.time()).replace(".", "-"))
 
-models__bad_python_array_batch_id_yaml = f"""
+def _python_array_batch_id_yaml(batch_id: str) -> str:
+    return f"""
 models:
   - name: python_array_batch_id
     description: A random table with a calculated column defined in python.
     config:
-      batch_id: {custom_ts_id}-python-array
+      batch_id: {batch_id}-python-array
     columns:
       - name: A
         description: Column A
@@ -240,10 +251,18 @@ class TestPythonDuplicateBatchIdModels:
     def models(self):
         return {
             "python_array_batch_id.py": models__python_array_batch_id_python,
-            "python_array_batch_id.yml": models__bad_python_array_batch_id_yaml,
+            "python_array_batch_id.yml": models__python_array_batch_id_yaml,
         }
 
     def test_multiple_python_models_fixed_id(self, project):
+        # Unique id per invocation, but shared across run #1 and #2 so the second run
+        # still gets the expected 409 — without colliding with a prior attempt's batch.
+        batch_id = f"custom-{uuid.uuid4().hex}"
+        write_file(
+            _python_array_batch_id_yaml(batch_id),
+            project.project_root + "/models",
+            "python_array_batch_id.yml",
+        )
         result, output = run_dbt_and_capture(["run"], expect_pass=True)
         result_two, output_two = run_dbt_and_capture(["run"], expect_pass=False)
         assert result_two[0].message.startswith("409 Already exists: Failed to create batch:")
@@ -252,6 +271,7 @@ class TestPythonDuplicateBatchIdModels:
 
 
 @pytest.mark.skip(reason=TEST_SKIP_MESSAGE)
+@pytest.mark.flaky
 class TestChangingSchemaDataproc:
     @pytest.fixture(scope="class")
     def models(self):
@@ -274,14 +294,17 @@ class TestChangingSchemaDataproc:
             assert "Execution status: OK in" in log
 
 
+@pytest.mark.flaky
 class TestEmptyModeWithPythonModel(dbt_tests.BasePythonEmptyTests):
     pass
 
 
+@pytest.mark.flaky
 class TestSampleModeWithPythonModel(dbt_tests.BasePythonSampleTests):
     pass
 
 
+@pytest.mark.flaky
 class TestPythonMetaGetBigquery(dbt_tests.BasePythonMetaGetTests):
     pass
 

--- a/dbt-bigquery/tests/functional/conftest.py
+++ b/dbt-bigquery/tests/functional/conftest.py
@@ -1,0 +1,29 @@
+"""
+Autouse resilience for a transient Python-model submission flake (test-only; the adapter is
+unchanged): serverless batches transiently rejected by the shared project-wide Dataproc
+``CPUS`` quota (~12 vCPUs/batch) when concurrent CI runs exhaust it. The fixture wraps the
+submit path with jittered backoff so the wait lets quota free up.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._python_model_retry import make_dataproc_quota_retry
+
+_ATTEMPTS = 6
+_BASE_DELAY = 20.0
+_MAX_DELAY = 300.0
+
+
+@pytest.fixture(autouse=True)
+def retry_dataproc_cpu_quota(monkeypatch):
+    """Retry serverless batch submits rejected by the shared Dataproc CPU quota."""
+    from dbt.adapters.bigquery import python_submissions
+
+    helper = python_submissions.ServerlessDataProcHelper
+    monkeypatch.setattr(
+        helper,
+        "submit",
+        make_dataproc_quota_retry(helper.submit, _ATTEMPTS, _BASE_DELAY, _MAX_DELAY),
+    )

--- a/dbt-bigquery/tests/unit/test_python_model_retry.py
+++ b/dbt-bigquery/tests/unit/test_python_model_retry.py
@@ -1,0 +1,143 @@
+"""Unit tests for the retry wrapper in ``tests/_python_model_retry``: a fake ``submit``
+raises, and we assert how often it is re-invoked. ``sleep`` is stubbed for speed."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests._python_model_retry import (
+    backoff_seconds,
+    is_cpu_quota_error,
+    make_dataproc_quota_retry,
+)
+
+# Messages mirroring what the submit path actually raises.
+_QUOTA_ERR = "Insufficient 'CPUS' quota: requested 12 but available 0"
+_ALREADY_EXISTS = "409 Already exists: Failed to create batch: Batch ...custom-abc-python"
+_MODEL_ERR = "name 'undefined_var' is not defined"
+
+_NO_SLEEP = lambda _delay: None  # noqa: E731
+
+
+class _FakeBatchClient:
+    """Records delete_batch calls and builds resource names like the real client."""
+
+    def __init__(self):
+        self.deleted = []
+
+    def batch_path(self, project, region, batch_id):
+        return f"projects/{project}/locations/{region}/batches/{batch_id}"
+
+    def delete_batch(self, name):
+        self.deleted.append(name)
+
+
+def _fake_helper(batch_id="custom-abc-python"):
+    """A stand-in ServerlessDataProcHelper with the attrs _delete_batch_quietly reads."""
+    return SimpleNamespace(
+        _batch_controller_client=_FakeBatchClient(),
+        _project="proj",
+        _region="us-central1",
+        _get_batch_id=lambda: batch_id,
+    )
+
+
+class TestPredicates:
+    def test_cpu_quota_error_matches_only_cpu_quota(self):
+        assert is_cpu_quota_error(Exception(_QUOTA_ERR)) is True
+        assert is_cpu_quota_error(Exception("some other quota")) is False  # no "cpu"
+        assert is_cpu_quota_error(Exception(_MODEL_ERR)) is False
+
+    def test_backoff_grows_and_is_capped(self):
+        # base=10, cap=60: 10, 20, 40, 60, 60 ... plus up to 25% jitter, never below base.
+        assert 10 <= backoff_seconds(1, 10, 60) <= 12.5
+        assert 60 <= backoff_seconds(5, 10, 60) <= 75  # capped, then jittered
+
+
+class TestDataprocQuotaRetry:
+    def _wrap(self, fake_submit, attempts=3):
+        return make_dataproc_quota_retry(
+            fake_submit, attempts, base=1, max_delay=1, sleep=_NO_SLEEP
+        )
+
+    def test_retries_quota_error_then_succeeds(self):
+        calls = []
+
+        def fake_submit(self, code):
+            calls.append(code)
+            if len(calls) < 3:
+                raise Exception(_QUOTA_ERR)
+            return "OK"
+
+        assert self._wrap(fake_submit)(SimpleNamespace(), "code") == "OK"
+        assert len(calls) == 3
+
+    def test_non_quota_error_is_not_retried(self):
+        calls = []
+
+        def fake_submit(self, code):
+            calls.append(code)
+            raise ValueError(_MODEL_ERR)
+
+        with pytest.raises(ValueError):
+            self._wrap(fake_submit)(SimpleNamespace(), "code")
+        assert len(calls) == 1
+
+    def test_exhausts_attempts_then_raises(self):
+        calls = []
+
+        def fake_submit(self, code):
+            calls.append(code)
+            raise Exception(_QUOTA_ERR)
+
+        with pytest.raises(Exception, match="quota"):
+            self._wrap(fake_submit, attempts=4)(SimpleNamespace(), "code")
+        assert len(calls) == 4
+
+    def test_deletes_orphaned_batch_before_each_quota_retry(self):
+        """The prior batch must be cleared before re-submitting, else the retry 409s."""
+        calls = []
+
+        def fake_submit(self, code):
+            calls.append(code)
+            if len(calls) < 3:
+                raise Exception(_QUOTA_ERR)
+            return "OK"
+
+        helper = _fake_helper()
+        assert self._wrap(fake_submit)(helper, "code") == "OK"
+        # One delete before each of the two retries; none after the successful submit.
+        expected = "projects/proj/locations/us-central1/batches/custom-abc-python"
+        assert helper._batch_controller_client.deleted == [expected, expected]
+
+    def test_no_delete_on_409_already_exists(self):
+        """A 409 isn't a quota error: re-raised immediately, batch never deleted —
+        preserving TestPythonDuplicateBatchIdModels' expected run #2 failure."""
+        calls = []
+
+        def fake_submit(self, code):
+            calls.append(code)
+            raise Exception(_ALREADY_EXISTS)
+
+        helper = _fake_helper()
+        with pytest.raises(Exception, match="Already exists"):
+            self._wrap(fake_submit)(helper, "code")
+        assert len(calls) == 1
+        assert helper._batch_controller_client.deleted == []
+
+    def test_delete_failure_does_not_break_retry(self):
+        """Cleanup is best-effort: a delete that raises must not abort the retry loop."""
+        calls = []
+
+        def fake_submit(self, code):
+            calls.append(code)
+            if len(calls) < 2:
+                raise Exception(_QUOTA_ERR)
+            return "OK"
+
+        helper = _fake_helper()
+        helper._batch_controller_client.delete_batch = lambda name: (_ for _ in ()).throw(
+            RuntimeError("FailedPrecondition: batch not in terminal state")
+        )
+        assert self._wrap(fake_submit)(helper, "code") == "OK"
+        assert len(calls) == 2

--- a/dbt-bigquery/tests/unit/test_python_model_retry.py
+++ b/dbt-bigquery/tests/unit/test_python_model_retry.py
@@ -1,6 +1,7 @@
 """Unit tests for the retry wrapper in ``tests/_python_model_retry``: a fake ``submit``
 raises, and we assert how often it is re-invoked. ``sleep`` is stubbed for speed."""
 
+import uuid
 from types import SimpleNamespace
 
 import pytest
@@ -40,6 +41,20 @@ def _fake_helper(batch_id="custom-abc-python"):
         _region="us-central1",
         _get_batch_id=lambda: batch_id,
     )
+
+
+def _realistic_helper(config=None):
+    """Helper whose _get_batch_id reads config like the real adapter: a fresh uuid per
+    call when batch_id is unset, otherwise the pinned/explicit value."""
+    model = {"config": config or {}}
+    helper = SimpleNamespace(
+        _batch_controller_client=_FakeBatchClient(),
+        _project="proj",
+        _region="us-central1",
+        _parsed_model=model,
+    )
+    helper._get_batch_id = lambda: model["config"].get("batch_id", str(uuid.uuid4()))
+    return helper
 
 
 class TestPredicates:
@@ -141,3 +156,39 @@ class TestDataprocQuotaRetry:
         )
         assert self._wrap(fake_submit)(helper, "code") == "OK"
         assert len(calls) == 2
+
+
+class TestBatchIdPinning:
+    """The adapter mints a fresh uuid per _get_batch_id() call when batch_id is unset, so
+    the wrapper pins a stable id up front to keep create and the pre-retry delete aligned."""
+
+    def _wrap(self, fake_submit, attempts=3):
+        return make_dataproc_quota_retry(
+            fake_submit, attempts, base=1, max_delay=1, sleep=_NO_SLEEP
+        )
+
+    def test_unset_batch_id_is_pinned_so_delete_matches_create(self):
+        """Without pinning, each _get_batch_id() call yields a new uuid and the delete
+        targets a batch that was never created, leaking it."""
+        created, calls = [], []
+
+        def fake_submit(self, code):
+            created.append(self._get_batch_id())  # what create_batch would claim
+            calls.append(code)
+            if len(calls) < 2:
+                raise Exception(_QUOTA_ERR)
+            return "OK"
+
+        helper = _realistic_helper()
+        assert self._wrap(fake_submit)(helper, "code") == "OK"
+
+        # The id stayed stable across the create -> delete -> recreate cycle...
+        assert created[0] == created[1]
+        # ...and the deleted batch is exactly the one the first (failed) submit created.
+        deleted = helper._batch_controller_client.deleted
+        assert deleted == [f"projects/proj/locations/us-central1/batches/{created[0]}"]
+
+    def test_explicit_batch_id_is_never_overridden(self):
+        helper = _realistic_helper(config={"batch_id": "custom-abc"})
+        self._wrap(lambda self, code: "OK", attempts=1)(helper, "code")
+        assert helper._parsed_model["config"]["batch_id"] == "custom-abc"


### PR DESCRIPTION
## What
Cuts the BigQuery integration suite from **~4h30m to ~20m**.

- Retry transient Python-model infra failures (test-only): Dataproc **CPU-quota** rejections with backoff.
- **Less flaky batch ids** — unique `uuid4` per run, and delete the orphaned batch before a quota retry so it doesn't `409`.
- **Grouped all Dataproc tests under `@pytest.mark.flaky`** so they run together in the isolated flaky job.
- **Sharded CI** with `pytest-split` and raised xdist workers (flaky `-n1 → -n8`).
- GCP: raised the Dataproc `CPUS` quota to **400** in `us-central1` for parallel runs.(This is sufficient for 4 parallel runs)

## Why
The [suite](https://github.com/dbt-labs/dbt-adapters/actions/runs/27003699895) took ~4h30m, bottlenecked by serial Python-model tests that flaked on the shared, project-wide CPU quota and reused batch ids — so they couldn't just be parallelized as-is.

## How
Raise the quota for headroom → absorb spikes with retry/backoff and fix the batch-id collisions → then group as flaky, shard, and parallelize. **Result: ~20 minutes.**

### Data
3 runs triggered in parallel:
- https://github.com/dbt-labs/dbt-adapters/actions/runs/27157930543
- https://github.com/dbt-labs/dbt-adapters/actions/runs/27157926542
- https://github.com/dbt-labs/dbt-adapters/actions/runs/27157922741


🤖 Generated with [Claude Code](https://claude.com/claude-code)