### PR TITLE
docs: note that this repo hosts v1 adapters; v2 developed in dbt-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 # dbt
 
+> [!NOTE]
+> This repository hosts the **v1** generation of dbt adapters. The **v2** adapters are developed in the [dbt-core](https://github.com/dbt-labs/dbt-core) repository.
+
 **[dbt](https://www.getdbt.com/)** enables data analysts and engineers to transform their data using the same practices that software engineers use to build applications.
 
 dbt is the T in ELT. Organize, cleanse, denormalize, filter, rename, and pre-aggregate the raw data in your warehouse so that it's ready for analysis.
-
-> [!NOTE]
-> This repository hosts the **v1** generation of dbt adapters. The **v2** adapters are developed in the [dbt-core](https://github.com/dbt-labs/dbt-core) repository.
 
 ## Adapters
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
 
 dbt is the T in ELT. Organize, cleanse, denormalize, filter, rename, and pre-aggregate the raw data in your warehouse so that it's ready for analysis.
 
+> [!NOTE]
+> This repository hosts the **v1** generation of dbt adapters. The **v2** adapters are developed in the [dbt-core](https://github.com/dbt-labs/dbt-core) repository.
+
 ## Adapters
 
 This repository is a monorepo containing the following packages:


### PR DESCRIPTION
## What

Adds a note to the top-level README clarifying that this repository hosts the **v1** generation of dbt adapters, and that the **v2** adapters are developed in the [dbt-core](https://github.com/dbt-labs/dbt-core) repository.

## Why

dbt Core has moved v2 to `main`, and v2 adapters are now developed in the dbt-core repo itself. This note helps contributors land in the right place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)