### PR TITLE
Updated dbt-core dependency to <2.0

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Dependencies-20260609-053034.yaml
+++ b/dbt-bigquery/.changes/unreleased/Dependencies-20260609-053034.yaml
@@ -3,4 +3,4 @@ body: Add upper bound `<2.0` on `dbt-core` to prevent pip from resolving to dbt-
 time: 2026-06-09T05:30:34+00:00
 custom:
   Author: sriramr98
-  PR: "TBD"
+  PR: "2012"

--- a/dbt-bigquery/.changes/unreleased/Dependencies-20260609-053034.yaml
+++ b/dbt-bigquery/.changes/unreleased/Dependencies-20260609-053034.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Add upper bound `<2.0` on `dbt-core` to prevent pip from resolving to dbt-core 2.0 (Fusion engine), which is incompatible with the python adapter
+time: 2026-06-09T05:30:34+00:00
+custom:
+  Author: sriramr98
+  PR: "TBD"

--- a/dbt-bigquery/pyproject.toml
+++ b/dbt-bigquery/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "google-api-core>=2.11.0",
     "google-auth>=2.29.0",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-    "dbt-core>=1.10.0rc0",
+    "dbt-core>=1.10.0rc0,<2.0",
     "nbformat>=5.10.4",
     "google-cloud-aiplatform>=1.72.0",
 ]

--- a/dbt-postgres/.changes/unreleased/Dependencies-20260609-053034.yaml
+++ b/dbt-postgres/.changes/unreleased/Dependencies-20260609-053034.yaml
@@ -3,4 +3,4 @@ body: Add upper bound `<2.0` on `dbt-core` to prevent pip from resolving to dbt-
 time: 2026-06-09T05:30:34+00:00
 custom:
   Author: sriramr98
-  PR: "TBD"
+  PR: "2012"

--- a/dbt-postgres/.changes/unreleased/Dependencies-20260609-053034.yaml
+++ b/dbt-postgres/.changes/unreleased/Dependencies-20260609-053034.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Add upper bound `<2.0` on `dbt-core` to prevent pip from resolving to dbt-core 2.0 (Fusion engine), which is incompatible with the python adapter
+time: 2026-06-09T05:30:34+00:00
+custom:
+  Author: sriramr98
+  PR: "TBD"

--- a/dbt-postgres/pyproject.toml
+++ b/dbt-postgres/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "psycopg2-binary>=2.9,<3.0",
     "dbt-adapters>=1.24.1,<2.0",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-    "dbt-core>=1.8.0rc1",
+    "dbt-core>=1.8.0rc1,<2.0",
     # installed via dbt-adapters but used directly
     "dbt-common>=1.0.4,<2.0",
     "agate>=1.0,<2.0",

--- a/dbt-redshift/.changes/unreleased/Dependencies-20260609-053034.yaml
+++ b/dbt-redshift/.changes/unreleased/Dependencies-20260609-053034.yaml
@@ -3,4 +3,4 @@ body: Add upper bound `<2.0` on `dbt-core` to prevent pip from resolving to dbt-
 time: 2026-06-09T05:30:34+00:00
 custom:
   Author: sriramr98
-  PR: "TBD"
+  PR: "2012"

--- a/dbt-redshift/.changes/unreleased/Dependencies-20260609-053034.yaml
+++ b/dbt-redshift/.changes/unreleased/Dependencies-20260609-053034.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Add upper bound `<2.0` on `dbt-core` to prevent pip from resolving to dbt-core 2.0 (Fusion engine), which is incompatible with the python adapter
+time: 2026-06-09T05:30:34+00:00
+custom:
+  Author: sriramr98
+  PR: "TBD"

--- a/dbt-redshift/pyproject.toml
+++ b/dbt-redshift/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
     "redshift-connector>=2.1.8,<2.2",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-    "dbt-core>=1.8.0b3",
+    "dbt-core>=1.8.0b3,<2.0",
     # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
     "sqlparse>=0.5.0,<0.6.0",
     "agate",

--- a/dbt-snowflake/.changes/unreleased/Dependencies-20260609-053034.yaml
+++ b/dbt-snowflake/.changes/unreleased/Dependencies-20260609-053034.yaml
@@ -3,4 +3,4 @@ body: Add upper bound `<2.0` on `dbt-core` to prevent pip from resolving to dbt-
 time: 2026-06-09T05:30:34+00:00
 custom:
   Author: sriramr98
-  PR: "TBD"
+  PR: "2012"

--- a/dbt-snowflake/.changes/unreleased/Dependencies-20260609-053034.yaml
+++ b/dbt-snowflake/.changes/unreleased/Dependencies-20260609-053034.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Add upper bound `<2.0` on `dbt-core` to prevent pip from resolving to dbt-core 2.0 (Fusion engine), which is incompatible with the python adapter
+time: 2026-06-09T05:30:34+00:00
+custom:
+  Author: sriramr98
+  PR: "TBD"

--- a/dbt-snowflake/pyproject.toml
+++ b/dbt-snowflake/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "snowflake-connector-python[secure-local-storage]>=4.2.0,<5.0.0",
     "certifi<2025.4.26",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-    "dbt-core>=1.10.0rc0",
+    "dbt-core>=1.10.0rc0,<2.0",
     # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
     "agate",
 ]

--- a/dbt-spark/.changes/unreleased/Dependencies-20260609-053034.yaml
+++ b/dbt-spark/.changes/unreleased/Dependencies-20260609-053034.yaml
@@ -3,4 +3,4 @@ body: Add upper bound `<2.0` on `dbt-core` to prevent pip from resolving to dbt-
 time: 2026-06-09T05:30:34+00:00
 custom:
   Author: sriramr98
-  PR: "TBD"
+  PR: "2012"

--- a/dbt-spark/.changes/unreleased/Dependencies-20260609-053034.yaml
+++ b/dbt-spark/.changes/unreleased/Dependencies-20260609-053034.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Add upper bound `<2.0` on `dbt-core` to prevent pip from resolving to dbt-core 2.0 (Fusion engine), which is incompatible with the python adapter
+time: 2026-06-09T05:30:34+00:00
+custom:
+  Author: sriramr98
+  PR: "TBD"

--- a/dbt-spark/pyproject.toml
+++ b/dbt-spark/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "dbt-common>=1.10,<2.0",
     "dbt-adapters>=1.24.1,<2.0",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-    "dbt-core>=1.8.0rc1",
+    "dbt-core>=1.8.0rc1,<2.0",
     "sqlparams>=3.0.0",
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
resolves #2010

[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

Adapter packages declare `dbt-core` with no upper bound, so `pip install dbt-<adapter>` now resolves to `dbt-core 2.0.0-alpha.1` (Fusion) and breaks installs. See #<issue>.

## Solution

Add `,<2.0` to the `dbt-core` line in `pyproject.toml` for `dbt-snowflake`, `dbt-bigquery`, `dbt-redshift`, `dbt-postgres`, and `dbt-spark`.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
