### PR TITLE
feat(redshift): support Apache Iceberg tables via AWS Glue Data Catalog

### DIFF
--- a/dbt-redshift/.changes/unreleased/Features-20260609-204019.yaml
+++ b/dbt-redshift/.changes/unreleased/Features-20260609-204019.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support Apache Iceberg tables on Redshift via the AWS Glue Data Catalog (table, incremental, and view materializations)
+time: 2026-06-09T20:40:19.518272+05:30
+custom:
+    Author: aahel
+    Issue: "2014"

--- a/dbt-redshift/src/dbt/adapters/redshift/catalogs/__init__.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/catalogs/__init__.py
@@ -1,0 +1,4 @@
+from dbt.adapters.redshift.catalogs._glue import (
+    GlueCatalogIntegration,
+    GlueCatalogRelation,
+)

--- a/dbt-redshift/src/dbt/adapters/redshift/catalogs/_glue.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/catalogs/_glue.py
@@ -16,8 +16,10 @@ class GlueCatalogRelation:
     catalog_name: Optional[str] = constants.DEFAULT_GLUE_CATALOG.name
     table_format: Optional[str] = constants.ICEBERG_TABLE_FORMAT
     file_format: Optional[str] = None
-    # maps to the Iceberg ``LOCATION`` clause (the S3 prefix table data is written to)
+    # the user-provided S3 base prefix
     external_volume: Optional[str] = None
+    # the fully-qualified, per-table Iceberg ``LOCATION`` (derived from external_volume)
+    location: Optional[str] = None
     partition_by: Optional[Union[List[str], str]] = None
     table_properties: Optional[Dict[str, Any]] = None
 
@@ -46,10 +48,32 @@ class GlueCatalogIntegration(CatalogIntegration):
         Args:
             model: `config.model` (not `model`) from the jinja context
         """
+        # model-level `external_volume`/`location` overrides the integration default
+        external_volume = parse_model.external_volume(model) or self.external_volume
         return GlueCatalogRelation(
             catalog_name=self.name,
-            # model-level `external_volume`/`location` overrides the integration default
-            external_volume=parse_model.external_volume(model) or self.external_volume,
+            external_volume=external_volume,
+            location=self._build_location(model, external_volume),
             partition_by=parse_model.partition_by(model),
             table_properties=parse_model.table_properties(model),
         )
+
+    @staticmethod
+    def _build_location(model: RelationConfig, external_volume: Optional[str]) -> Optional[str]:
+        """Derive a unique Iceberg ``LOCATION`` per table.
+
+        Redshift requires ``LOCATION`` to be an empty, unique S3 prefix, so a single
+        catalog-level ``external_volume`` shared across models would collide. We
+        namespace each table under
+        ``{external_volume}/{base_location_root}/{schema}/{identifier}[/{base_location_subpath}]``,
+        mirroring dbt-snowflake's ``base_location`` behavior. ``base_location_root``
+        defaults to ``_dbt``.
+        """
+        if not external_volume:
+            return None
+        root = parse_model.base_location_root(model) or "_dbt"
+        segments = [root, model.schema, model.identifier]
+        if subpath := parse_model.base_location_subpath(model):
+            segments.append(subpath)
+        suffix = "/".join(segment.strip("/") for segment in segments if segment)
+        return f"{external_volume.rstrip('/')}/{suffix}"

--- a/dbt-redshift/src/dbt/adapters/redshift/catalogs/_glue.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/catalogs/_glue.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
+
+from dbt.adapters.catalogs import (
+    CatalogIntegration,
+    CatalogIntegrationConfig,
+)
+from dbt.adapters.contracts.relation import RelationConfig
+
+from dbt.adapters.redshift import constants, parse_model
+
+
+@dataclass
+class GlueCatalogRelation:
+    catalog_type: str = constants.GLUE_CATALOG_TYPE
+    catalog_name: Optional[str] = constants.DEFAULT_GLUE_CATALOG.name
+    table_format: Optional[str] = constants.ICEBERG_TABLE_FORMAT
+    file_format: Optional[str] = None
+    # maps to the Iceberg ``LOCATION`` clause (the S3 prefix table data is written to)
+    external_volume: Optional[str] = None
+    partition_by: Optional[Union[List[str], str]] = None
+    table_properties: Optional[Dict[str, Any]] = None
+
+
+class GlueCatalogIntegration(CatalogIntegration):
+    """Apache Iceberg tables backed by the AWS Glue Data Catalog.
+
+    Redshift creates these tables in an external schema mapped to a Glue database
+    (the model's ``schema``), so no database-name override is required here. The
+    external volume maps to the Iceberg ``LOCATION``.
+    """
+
+    catalog_type = constants.GLUE_CATALOG_TYPE
+    table_format = constants.ICEBERG_TABLE_FORMAT
+    file_format = None
+    allows_writes = True
+
+    def __init__(self, config: CatalogIntegrationConfig) -> None:
+        # the base provides more config than Redshift's Glue integration needs
+        self.name: str = config.name
+        self.catalog_name: Optional[str] = config.catalog_name
+        self.external_volume: Optional[str] = config.external_volume
+
+    def build_relation(self, model: RelationConfig) -> GlueCatalogRelation:
+        """
+        Args:
+            model: `config.model` (not `model`) from the jinja context
+        """
+        return GlueCatalogRelation(
+            catalog_name=self.name,
+            # model-level `external_volume`/`location` overrides the integration default
+            external_volume=parse_model.external_volume(model) or self.external_volume,
+            partition_by=parse_model.partition_by(model),
+            table_properties=parse_model.table_properties(model),
+        )

--- a/dbt-redshift/src/dbt/adapters/redshift/constants.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/constants.py
@@ -1,0 +1,23 @@
+from types import SimpleNamespace
+
+ADAPTER_TYPE = "redshift"
+
+# table formats
+DEFAULT_TABLE_FORMAT = "default"
+ICEBERG_TABLE_FORMAT = "iceberg"
+
+# catalog types
+GLUE_CATALOG_TYPE = "glue"
+
+# Redshift Iceberg tables are created in an external schema mapped to an AWS Glue
+# Data Catalog database. The external volume maps to the Iceberg ``LOCATION`` (the
+# S3 prefix the table data is written to).
+DEFAULT_GLUE_CATALOG = SimpleNamespace(
+    name="glue",
+    catalog_type=GLUE_CATALOG_TYPE,
+    catalog_name="glue",
+    external_volume=None,
+    table_format=ICEBERG_TABLE_FORMAT,
+    file_format=None,
+    adapter_properties={},
+)

--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -7,7 +7,7 @@ import agate
 from dbt_common.behavior_flags import BehaviorFlag
 from dbt_common.contracts.constraints import ConstraintType
 from datetime import datetime, timezone
-from typing import List, Optional, Set, Any, Dict, Tuple, Type, Mapping
+from typing import ClassVar, List, Optional, Set, Any, Dict, Tuple, Type, Mapping
 from collections import namedtuple
 from dbt.adapters.base import PythonJobHelper
 from dbt.adapters.base.impl import AdapterConfig, ConstraintSupport, FreshnessResponse
@@ -27,7 +27,9 @@ from dbt.adapters.events.logging import AdapterLogger
 
 import dbt_common.exceptions
 
-from dbt.adapters.redshift import RedshiftConnectionManager, RedshiftRelation
+from dbt.adapters.catalogs import CatalogV2
+from dbt.adapters.redshift import RedshiftConnectionManager, RedshiftRelation, constants
+from dbt.adapters.redshift.catalogs import GlueCatalogIntegration
 
 logger = AdapterLogger("Redshift")
 packages = ["redshift_connector", "redshift_connector.core"]
@@ -41,6 +43,10 @@ for package in packages:
 
 GET_RELATIONS_MACRO_NAME = "redshift__get_relations"
 SHOW_TABLES_FROM_SCHEMA_MACRO_NAME = "redshift__show_tables_from_schema"
+
+# Guard against older dbt-adapters that don't have Capability.CatalogsV2 yet.
+# Remove once the dbt-adapters lower bound is bumped to the version that adds it.
+_CATALOGS_V2_CAPABILITY = getattr(Capability, "CatalogsV2", None)  # type: ignore[attr-defined]
 
 REDSHIFT_SKIP_AUTOCOMMIT_TRANSACTION_STATEMENTS = BehaviorFlag(
     name="redshift_skip_autocommit_transaction_statements",
@@ -117,6 +123,8 @@ class RedshiftAdapter(SQLAdapter):
 
     AdapterSpecificConfigs = RedshiftConfig
 
+    CATALOG_INTEGRATIONS = [GlueCatalogIntegration]
+
     CONSTRAINT_SUPPORT = {
         ConstraintType.check: ConstraintSupport.NOT_SUPPORTED,
         ConstraintType.not_null: ConstraintSupport.ENFORCED,
@@ -130,8 +138,18 @@ class RedshiftAdapter(SQLAdapter):
             Capability.SchemaMetadataByRelations: CapabilitySupport(support=Support.Full),
             Capability.TableLastModifiedMetadata: CapabilitySupport(support=Support.Full),
             Capability.TableLastModifiedMetadataBatch: CapabilitySupport(support=Support.Full),
+            **(
+                {_CATALOGS_V2_CAPABILITY: CapabilitySupport(support=Support.Full)}
+                if _CATALOGS_V2_CAPABILITY is not None
+                else {}
+            ),
         }
     )
+
+    # maps the v2 catalogs.yml `type` to this adapter's catalog integration type
+    _V2_TO_V1_TYPE: ClassVar[Dict[str, str]] = {
+        "glue": constants.GLUE_CATALOG_TYPE,
+    }
 
     def __init__(self, config, mp_context: SpawnContext) -> None:
         super().__init__(config, mp_context)
@@ -139,6 +157,13 @@ class RedshiftAdapter(SQLAdapter):
         self.connections.set_skip_transactions_checker(
             lambda: self.behavior.redshift_skip_autocommit_transaction_statements.no_warn
         )
+        self.add_catalog_integration(constants.DEFAULT_GLUE_CATALOG)
+
+    def _v2_to_v1_type(self, catalog_type: str) -> str:
+        return self._V2_TO_V1_TYPE.get(catalog_type, catalog_type)
+
+    def _v2_table_format(self, catalog: CatalogV2) -> str:
+        return catalog.table_format.value.lower()
 
     @property
     def _behavior_flags(self) -> List[BehaviorFlag]:

--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -5,6 +5,7 @@ from multiprocessing.context import SpawnContext
 from urllib.parse import urlparse
 
 import boto3
+from botocore.exceptions import NoCredentialsError, PartialCredentialsError
 
 import agate
 from dbt_common.behavior_flags import BehaviorFlag
@@ -177,8 +178,15 @@ class RedshiftAdapter(SQLAdapter):
         return catalog.table_format.value.lower()
 
     def _boto3_session(self) -> "boto3.session.Session":
-        """Build a boto3 session from the adapter credentials, falling back to the
-        default credential chain (env vars, shared config, instance profile)."""
+        """Build a boto3 session for S3 operations.
+
+        AWS credentials are sourced independently of the Redshift connection auth
+        (which may be username/password and carry no AWS identity), in order:
+          1. explicit ``access_key_id`` + ``secret_access_key`` from the profile,
+          2. a named ``iam_profile`` from the profile,
+          3. the standard AWS credential chain (``AWS_PROFILE`` / ``~/.aws`` /
+             environment variables / instance role).
+        """
         creds = self.config.credentials
         kwargs: Dict[str, Any] = {}
         if getattr(creds, "region", None):
@@ -198,8 +206,11 @@ class RedshiftAdapter(SQLAdapter):
         Data Catalog entry; it leaves the data/metadata files in S3. Since
         ``CREATE TABLE ... USING ICEBERG`` requires an empty ``LOCATION``, we purge
         the prefix here before re-creating the table (mirrors dbt-athena's
-        ``delete_from_s3``). The dbt client must have AWS credentials with delete
-        access to the bucket.
+        ``delete_from_s3``).
+
+        This needs AWS credentials with ``s3:DeleteObject``/``s3:ListBucket`` on the
+        bucket, resolved via ``_boto3_session`` (profile keys / ``iam_profile`` / the
+        default AWS chain) -- separate from the Redshift connection auth.
         """
         if not s3_path:
             return
@@ -213,8 +224,18 @@ class RedshiftAdapter(SQLAdapter):
         if prefix and not prefix.endswith("/"):
             prefix += "/"
         logger.debug(f"Purging Iceberg S3 location: s3://{bucket}/{prefix}")
-        s3 = self._boto3_session().resource("s3")
-        s3.Bucket(bucket).objects.filter(Prefix=prefix).delete()
+        try:
+            s3 = self._boto3_session().resource("s3")
+            s3.Bucket(bucket).objects.filter(Prefix=prefix).delete()
+        except (NoCredentialsError, PartialCredentialsError) as exc:
+            raise dbt_common.exceptions.DbtRuntimeError(
+                "Could not find AWS credentials to clean up the Iceberg table's S3 "
+                f"location (s3://{bucket}/{prefix}). Redshift Iceberg models need AWS "
+                "credentials for S3 cleanup, separate from the database connection. "
+                "Provide `access_key_id`/`secret_access_key` or `iam_profile` in your "
+                "profile, or configure the standard AWS credential chain (AWS_PROFILE / "
+                "~/.aws / environment variables)."
+            ) from exc
 
     @property
     def _behavior_flags(self) -> List[BehaviorFlag]:

--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -2,12 +2,15 @@ import os
 from contextlib import contextmanager
 from dataclasses import dataclass
 from multiprocessing.context import SpawnContext
+from urllib.parse import urlparse
+
+import boto3
 
 import agate
 from dbt_common.behavior_flags import BehaviorFlag
 from dbt_common.contracts.constraints import ConstraintType
 from datetime import datetime, timezone
-from typing import ClassVar, List, Optional, Set, Any, Dict, Tuple, Type, Mapping
+from typing import ClassVar, List, Optional, Set, Any, Dict, Tuple, Type, Mapping, Union
 from collections import namedtuple
 from dbt.adapters.base import PythonJobHelper
 from dbt.adapters.base.impl import AdapterConfig, ConstraintSupport, FreshnessResponse
@@ -115,6 +118,14 @@ class RedshiftConfig(AdapterConfig):
     auto_refresh: Optional[bool] = False
     query_group: Optional[str] = None
 
+    # Apache Iceberg (AWS Glue Data Catalog) configs
+    table_format: Optional[str] = None
+    external_volume: Optional[str] = None
+    base_location_root: Optional[str] = None
+    base_location_subpath: Optional[str] = None
+    partition_by: Optional[Union[str, List[str]]] = None
+    table_properties: Optional[Dict[str, Any]] = None
+
 
 class RedshiftAdapter(SQLAdapter):
     Relation = RedshiftRelation
@@ -164,6 +175,46 @@ class RedshiftAdapter(SQLAdapter):
 
     def _v2_table_format(self, catalog: CatalogV2) -> str:
         return catalog.table_format.value.lower()
+
+    def _boto3_session(self) -> "boto3.session.Session":
+        """Build a boto3 session from the adapter credentials, falling back to the
+        default credential chain (env vars, shared config, instance profile)."""
+        creds = self.config.credentials
+        kwargs: Dict[str, Any] = {}
+        if getattr(creds, "region", None):
+            kwargs["region_name"] = creds.region
+        if getattr(creds, "access_key_id", None) and getattr(creds, "secret_access_key", None):
+            kwargs["aws_access_key_id"] = creds.access_key_id
+            kwargs["aws_secret_access_key"] = creds.secret_access_key
+        elif getattr(creds, "iam_profile", None):
+            kwargs["profile_name"] = creds.iam_profile
+        return boto3.session.Session(**kwargs)
+
+    @available
+    def delete_from_s3(self, s3_path: Optional[str]) -> None:
+        """Delete every object under an ``s3://bucket/prefix`` location.
+
+        Redshift's ``DROP TABLE`` on an Iceberg table only removes the AWS Glue
+        Data Catalog entry; it leaves the data/metadata files in S3. Since
+        ``CREATE TABLE ... USING ICEBERG`` requires an empty ``LOCATION``, we purge
+        the prefix here before re-creating the table (mirrors dbt-athena's
+        ``delete_from_s3``). The dbt client must have AWS credentials with delete
+        access to the bucket.
+        """
+        if not s3_path:
+            return
+        parsed = urlparse(s3_path)
+        bucket = parsed.netloc
+        prefix = parsed.path.lstrip("/")
+        if not bucket:
+            return
+        # scope deletion to this table's own folder so a prefix like ".../orders"
+        # does not also match a sibling ".../orders_partitioned"
+        if prefix and not prefix.endswith("/"):
+            prefix += "/"
+        logger.debug(f"Purging Iceberg S3 location: s3://{bucket}/{prefix}")
+        s3 = self._boto3_session().resource("s3")
+        s3.Bucket(bucket).objects.filter(Prefix=prefix).delete()
 
     @property
     def _behavior_flags(self) -> List[BehaviorFlag]:

--- a/dbt-redshift/src/dbt/adapters/redshift/parse_model.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/parse_model.py
@@ -36,10 +36,10 @@ def partition_by(model: RelationConfig) -> Optional[Union[str, List[str]]]:
 
 
 def external_volume(model: RelationConfig) -> Optional[str]:
-    """The S3 ``LOCATION`` prefix the Iceberg table data is written to."""
+    """The S3 base prefix the Iceberg table data is written to (the ``LOCATION`` root)."""
     if not model.config:
         return None
-    return model.config.get("external_volume") or model.config.get("location")
+    return model.config.get("external_volume")
 
 
 def table_properties(model: RelationConfig) -> Optional[Dict[str, Any]]:

--- a/dbt-redshift/src/dbt/adapters/redshift/parse_model.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/parse_model.py
@@ -1,0 +1,49 @@
+from typing import Any, Dict, Iterable, List, Optional, Union
+
+from dbt_common.exceptions import DbtConfigError
+
+from dbt.adapters.contracts.relation import RelationConfig
+
+
+def table_format(model: RelationConfig) -> Optional[str]:
+    if not model.config:
+        return None
+
+    # we don't know what the table format is if it's not on the model;
+    # for catalog-driven models this is derived from the catalog integration
+    if _table_format := model.config.get("table_format"):
+        # make table_format case-insensitive
+        return _table_format.lower()
+    return None
+
+
+def partition_by(model: RelationConfig) -> Optional[Union[str, List[str]]]:
+    """Iceberg partition spec: a single transform string or a list of them.
+
+    Redshift supports identity, bucket[N], truncate[W], year, month, day, hour.
+    """
+    if not model.config:
+        return None
+
+    fields = model.config.get("partition_by")
+    if isinstance(fields, str):
+        return fields
+    if isinstance(fields, Iterable):
+        return list(fields)
+    if fields is not None:
+        raise DbtConfigError(f"Unexpected partition_by configuration: {fields}")
+    return None
+
+
+def external_volume(model: RelationConfig) -> Optional[str]:
+    """The S3 ``LOCATION`` prefix the Iceberg table data is written to."""
+    if not model.config:
+        return None
+    return model.config.get("external_volume") or model.config.get("location")
+
+
+def table_properties(model: RelationConfig) -> Optional[Dict[str, Any]]:
+    """Iceberg ``TABLE PROPERTIES`` (Redshift currently supports ``compression_type``)."""
+    if not model.config:
+        return None
+    return model.config.get("table_properties")

--- a/dbt-redshift/src/dbt/adapters/redshift/parse_model.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/parse_model.py
@@ -47,3 +47,17 @@ def table_properties(model: RelationConfig) -> Optional[Dict[str, Any]]:
     if not model.config:
         return None
     return model.config.get("table_properties")
+
+
+def base_location_root(model: RelationConfig) -> Optional[str]:
+    """Root path under ``external_volume`` used when deriving a per-table LOCATION."""
+    if not model.config:
+        return None
+    return model.config.get("base_location_root")
+
+
+def base_location_subpath(model: RelationConfig) -> Optional[str]:
+    """Optional extra path segment appended to the derived per-table LOCATION."""
+    if not model.config:
+        return None
+    return model.config.get("base_location_subpath")

--- a/dbt-redshift/src/dbt/adapters/redshift/relation.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/relation.py
@@ -11,6 +11,7 @@ from dbt.adapters.relation_configs import (
 from dbt.adapters.base import RelationType
 from dbt_common.exceptions import DbtRuntimeError
 
+from dbt.adapters.redshift import constants
 from dbt.adapters.redshift.relation_configs import (
     RedshiftMaterializedViewConfig,
     RedshiftMaterializedViewConfigChangeset,
@@ -28,6 +29,7 @@ class RedshiftRelation(BaseRelation):
     include_policy = RedshiftIncludePolicy  # type: ignore
     quote_policy = RedshiftQuotePolicy  # type: ignore
     require_alias: bool = False
+    table_format: str = constants.DEFAULT_TABLE_FORMAT
     relation_configs = {
         RelationType.MaterializedView.value: RedshiftMaterializedViewConfig,  # type:ignore
     }
@@ -62,6 +64,17 @@ class RedshiftRelation(BaseRelation):
 
     def relation_max_name_length(self):
         return MAX_CHARACTERS_IN_IDENTIFIER
+
+    @property
+    def is_iceberg_format(self) -> bool:
+        return self.table_format == constants.ICEBERG_TABLE_FORMAT
+
+    @property
+    def can_be_renamed(self) -> bool:
+        # Iceberg tables don't support rename; replacing one requires DROP + CREATE.
+        # Returning False here routes the standard materialization cleanup branches
+        # to drop the existing relation instead of renaming it.
+        return self.type in self.renameable_relations and not self.is_iceberg_format
 
     @classmethod
     def from_config(cls, config: RelationConfig) -> RelationConfigBase:

--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
@@ -33,6 +33,11 @@
 
 {% macro redshift__create_table_as(temporary, relation, sql) -%}
 
+  {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
+  {%- if not temporary and catalog_relation is not none and catalog_relation.table_format == 'iceberg' -%}
+    {{ return(redshift__create_table_iceberg_sql(relation, sql, catalog_relation)) }}
+  {%- endif -%}
+
   {%- set _dist = config.get('dist') -%}
   {%- set _sort_type = config.get(
           'sort_type',

--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
@@ -308,6 +308,16 @@
       from information_schema.views
       where table_schema ilike '{{ schema_relation.schema }}'
       union all
+      -- external (e.g. Apache Iceberg / Glue) tables are not in information_schema;
+      -- include them so they land in the relation cache (get_relation, is_incremental)
+      select
+        '{{ schema_relation.database }}' as database,
+        tablename as name,
+        schemaname as schema,
+        'table' as type
+      from svv_external_tables
+      where schemaname ilike '{{ schema_relation.schema }}'
+      union all
       select distinct
         '{{ schema_relation.database }}' as database,
         proname as name,

--- a/dbt-redshift/src/dbt/include/redshift/macros/materializations/incremental.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/materializations/incremental.sql
@@ -38,21 +38,38 @@
   {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}
   {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(context, incremental_strategy) %}
 
-  {% if existing_relation is none %}
+  {% if is_iceberg %}
+    {#-- Iceberg: No CREATE OR REPLACE / rename, and DROP does not clear S3, so we
+        CTAS when absent and otherwise mutate in place. Existence comes from the
+        relation cache (external tables are now listed in list_relations). --#}
+    {% if existing_relation is none or should_full_refresh() %}
+        {#-- (re)create: drop the Glue entry if present, purge S3, then CTAS --#}
+        {% if existing_relation is not none %}
+          {% call statement('drop_iceberg_target') -%}
+            drop table if exists {{ target_relation }}
+          {%- endcall %}
+        {% endif %}
+        {% do adapter.delete_from_s3(catalog_relation.location) %}
+        {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}
+        {% set relation_for_indexes = target_relation %}
+    {% else %}
+        {#-- incremental: stage to a normal temp table, then run the strategy DML against
+            the Iceberg target. `append` is a single INSERT; merge/delete+insert emit
+            multiple statements and are not yet validated for Iceberg. --#}
+        {% do run_query(get_create_table_as_sql(True, temp_relation, sql)) %}
+        {% set relation_for_indexes = temp_relation %}
+        {% set dest_columns = adapter.get_columns_in_relation(temp_relation) %}
+        {% set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) %}
+        {% set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': temp_relation, 'unique_key': unique_key, 'dest_columns': dest_columns, 'incremental_predicates': incremental_predicates }) %}
+        {% set build_sql = strategy_sql_macro_func(strategy_arg_dict) %}
+    {% endif %}
+  {% elif existing_relation is none %}
       {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}
       {% set relation_for_indexes = target_relation %}
   {% elif full_refresh_mode %}
-      {% if is_iceberg %}
-          -- Iceberg tables can't be renamed and don't support CREATE OR REPLACE,
-          -- so drop the existing relation and rebuild directly into the target.
-          {{ drop_relation_if_exists(existing_relation) }}
-          {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}
-          {% set relation_for_indexes = target_relation %}
-      {% else %}
-          {% set build_sql = get_create_table_as_sql(False, intermediate_relation, sql) %}
-          {% set relation_for_indexes = intermediate_relation %}
-          {% set need_swap = true %}
-      {% endif %}
+      {% set build_sql = get_create_table_as_sql(False, intermediate_relation, sql) %}
+      {% set relation_for_indexes = intermediate_relation %}
+      {% set need_swap = true %}
   {% else %}
     {% do run_query(get_create_table_as_sql(True, temp_relation, sql)) %}
     {% set relation_for_indexes = temp_relation %}

--- a/dbt-redshift/src/dbt/include/redshift/macros/materializations/incremental.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/materializations/incremental.sql
@@ -1,0 +1,113 @@
+{% materialization incremental, adapter='redshift' -%}
+
+  -- relations
+  {%- set existing_relation = load_cached_relation(this) -%}
+  {%- set target_relation = this.incorporate(type='table') -%}
+  {%- set temp_relation = make_temp_relation(target_relation)-%}
+  {%- set intermediate_relation = make_intermediate_relation(target_relation)-%}
+  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}
+  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
+
+  -- catalog / iceberg detection
+  {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
+  {%- set is_iceberg = (catalog_relation is not none and catalog_relation.table_format == 'iceberg') -%}
+
+  -- configs
+  {%- set unique_key = config.get('unique_key') -%}
+  {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}
+  {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
+
+  -- the temp_ and backup_ relations should not already exist in the database; get_relation
+  -- will return None in that case. Otherwise, we get a relation that we can drop
+  -- later, before we try to use this name for the current operation. This has to happen before
+  -- BEGIN, in a separate transaction
+  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation)-%}
+  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
+   -- grab current tables grants config for comparision later on
+  {% set grant_config = config.get('grants') %}
+  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
+  {{ drop_relation_if_exists(preexisting_backup_relation) }}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% set to_drop = [] %}
+
+  {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}
+  {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(context, incremental_strategy) %}
+
+  {% if existing_relation is none %}
+      {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}
+      {% set relation_for_indexes = target_relation %}
+  {% elif full_refresh_mode %}
+      {% if is_iceberg %}
+          -- Iceberg tables can't be renamed and don't support CREATE OR REPLACE,
+          -- so drop the existing relation and rebuild directly into the target.
+          {{ drop_relation_if_exists(existing_relation) }}
+          {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}
+          {% set relation_for_indexes = target_relation %}
+      {% else %}
+          {% set build_sql = get_create_table_as_sql(False, intermediate_relation, sql) %}
+          {% set relation_for_indexes = intermediate_relation %}
+          {% set need_swap = true %}
+      {% endif %}
+  {% else %}
+    {% do run_query(get_create_table_as_sql(True, temp_relation, sql)) %}
+    {% set relation_for_indexes = temp_relation %}
+    {% set contract_config = config.get('contract') %}
+    {% if not contract_config or not contract_config.enforced %}
+      {% do adapter.expand_target_column_types(
+               from_relation=temp_relation,
+               to_relation=target_relation) %}
+    {% endif %}
+    {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}
+    {% set dest_columns = process_schema_changes(on_schema_change, temp_relation, existing_relation) %}
+    {% if not dest_columns %}
+      {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}
+    {% endif %}
+
+    {#-- Get the incremental_strategy, the macro to use for the strategy, and build the sql --#}
+    {% set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) %}
+    {% set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': temp_relation, 'unique_key': unique_key, 'dest_columns': dest_columns, 'incremental_predicates': incremental_predicates }) %}
+    {% set build_sql = strategy_sql_macro_func(strategy_arg_dict) %}
+
+  {% endif %}
+
+  {% call statement("main") %}
+      {{ build_sql }}
+  {% endcall %}
+
+  {% if (existing_relation is none or existing_relation.is_view or should_full_refresh()) and not is_iceberg %}
+    {% do create_indexes(relation_for_indexes) %}
+  {% endif %}
+
+  {% if need_swap %}
+      {% do adapter.rename_relation(target_relation, backup_relation) %}
+      {% do adapter.rename_relation(intermediate_relation, target_relation) %}
+      {% do to_drop.append(backup_relation) %}
+  {% endif %}
+
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {# Iceberg external tables don't support column comments / persist_docs #}
+  {% if not is_iceberg %}
+    {% do persist_docs(target_relation, model) %}
+  {% endif %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  -- `COMMIT` happens here
+  {% do adapter.commit() %}
+
+  {% for rel in to_drop %}
+      {% do adapter.drop_relation(rel) %}
+  {% endfor %}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{%- endmaterialization %}

--- a/dbt-redshift/src/dbt/include/redshift/macros/materializations/table.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/materializations/table.sql
@@ -31,12 +31,16 @@
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
   {% if is_iceberg %}
-    -- Iceberg tables can't be renamed and don't support CREATE OR REPLACE, so we
-    -- drop any existing relation and build directly into the target relation.
+    -- Redshift Iceberg has no CREATE OR REPLACE and can't rename. DROP TABLE only
+    -- removes the Glue catalog entry (S3 data is left behind), and CTAS requires an
+    -- empty LOCATION, so we: drop the catalog entry (if any), purge the S3 prefix,
+    -- then CTAS.
     {% if existing_relation is not none %}
-      {{ drop_relation_if_exists(existing_relation) }}
+      {% call statement('drop_iceberg_target') -%}
+        drop table if exists {{ target_relation }}
+      {%- endcall %}
     {% endif %}
-
+    {% do adapter.delete_from_s3(catalog_relation.location) %}
     {% call statement('main') -%}
       {{ get_create_table_as_sql(False, target_relation, sql) }}
     {%- endcall %}

--- a/dbt-redshift/src/dbt/include/redshift/macros/materializations/table.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/materializations/table.sql
@@ -2,6 +2,10 @@
 
   {%- set existing_relation = load_cached_relation(this) -%}
   {%- set target_relation = this.incorporate(type='table') %}
+
+  {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
+  {%- set is_iceberg = (catalog_relation is not none and catalog_relation.table_format == 'iceberg') -%}
+
   {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}
   -- the intermediate_relation should not already exist in the database; get_relation
   -- will return None in that case. Otherwise, we get a relation that we can drop
@@ -26,42 +30,59 @@
   -- `BEGIN` happens here:
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-  -- build model
-  {% call statement('main') -%}
-    {{ get_create_table_as_sql(False, intermediate_relation, sql) }}
-  {%- endcall %}
-
-  -- cleanup
-  {% if existing_relation is not none %}
-     /* Do the equivalent of rename_if_exists. 'existing_relation' could have been dropped
-        since the variable was first set. */
-    {% set existing_relation = load_cached_relation(existing_relation) %}
+  {% if is_iceberg %}
+    -- Iceberg tables can't be renamed and don't support CREATE OR REPLACE, so we
+    -- drop any existing relation and build directly into the target relation.
     {% if existing_relation is not none %}
-        {% if existing_relation.can_be_renamed %}
-            {{ adapter.rename_relation(existing_relation, backup_relation) }}
-        {% else  %}
-            {{ drop_relation_if_exists(existing_relation) }}
-        {% endif %}
+      {{ drop_relation_if_exists(existing_relation) }}
     {% endif %}
+
+    {% call statement('main') -%}
+      {{ get_create_table_as_sql(False, target_relation, sql) }}
+    {%- endcall %}
+  {% else %}
+    -- build model
+    {% call statement('main') -%}
+      {{ get_create_table_as_sql(False, intermediate_relation, sql) }}
+    {%- endcall %}
+
+    -- cleanup
+    {% if existing_relation is not none %}
+       /* Do the equivalent of rename_if_exists. 'existing_relation' could have been dropped
+          since the variable was first set. */
+      {% set existing_relation = load_cached_relation(existing_relation) %}
+      {% if existing_relation is not none %}
+          {% if existing_relation.can_be_renamed %}
+              {{ adapter.rename_relation(existing_relation, backup_relation) }}
+          {% else  %}
+              {{ drop_relation_if_exists(existing_relation) }}
+          {% endif %}
+      {% endif %}
+    {% endif %}
+
+
+    {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+
+    {% do create_indexes(target_relation) %}
   {% endif %}
-
-
-  {{ adapter.rename_relation(intermediate_relation, target_relation) }}
-
-  {% do create_indexes(target_relation) %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
   {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
   {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
-  {% do persist_docs(target_relation, model) %}
+  {# Iceberg external tables don't support column comments / persist_docs #}
+  {% if not is_iceberg %}
+    {% do persist_docs(target_relation, model) %}
+  {% endif %}
 
   -- `COMMIT` happens here
   {{ adapter.commit() }}
 
   -- finally, drop the existing/backup relation after the commit
-  {{ drop_relation_if_exists(backup_relation) }}
+  {% if not is_iceberg %}
+    {{ drop_relation_if_exists(backup_relation) }}
+  {% endif %}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 

--- a/dbt-redshift/src/dbt/include/redshift/macros/relations/table/create_iceberg.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/relations/table/create_iceberg.sql
@@ -19,6 +19,19 @@
     ) %}
   {%- endif -%}
 
+  {# Warn about native Redshift table configs that have no effect on Iceberg tables #}
+  {%- set ignored_configs = [] -%}
+  {%- if config.get('dist') -%}{%- do ignored_configs.append('dist') -%}{%- endif -%}
+  {%- if config.get('sort') -%}{%- do ignored_configs.append('sort') -%}{%- endif -%}
+  {%- if config.get('backup') == false -%}{%- do ignored_configs.append('backup') -%}{%- endif -%}
+  {%- if ignored_configs -%}
+    {% do exceptions.warn(
+      "The following configs have no effect on Redshift Iceberg tables and are ignored: "
+      ~ ignored_configs | join(", ")
+      ~ ". Iceberg uses `partition_by` instead of `dist`/`sort`, and external storage instead of `backup`."
+    ) %}
+  {%- endif -%}
+
   {%- set sql_header = config.get('sql_header', none) -%}
   {{ sql_header if sql_header is not none }}
 
@@ -51,7 +64,7 @@
 
   create table {{ relation }}
     using iceberg
-    {{ optional('location', catalog_relation.external_volume, "'") }}
+    {{ optional('location', catalog_relation.location, "'") }}
     {% if partition_by_string -%} partitioned by ({{ partition_by_string }}) {%- endif %}
     {% if table_properties_string -%} table properties ({{ table_properties_string }}) {%- endif %}
   as (

--- a/dbt-redshift/src/dbt/include/redshift/macros/relations/table/create_iceberg.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/relations/table/create_iceberg.sql
@@ -1,0 +1,60 @@
+{% macro redshift__create_table_iceberg_sql(relation, sql, catalog_relation) -%}
+{#-
+    Creates an Apache Iceberg table backed by the AWS Glue Data Catalog using
+    CREATE TABLE ... USING ICEBERG AS SELECT.
+    https://docs.aws.amazon.com/redshift/latest/dg/iceberg-writes-sql-syntax.html
+
+    Limitations (per AWS docs):
+    - Iceberg does not support CREATE OR REPLACE, so we DROP first for idempotency.
+    - Iceberg tables cannot be renamed, so the materialization builds directly into
+      the target relation rather than using an intermediate + rename swap.
+    - Iceberg tables do not support column constraints / attributes, so model
+      contracts are not supported.
+-#}
+
+  {%- set contract_config = config.get('contract') -%}
+  {%- if contract_config.enforced -%}
+    {% do exceptions.raise_compiler_error(
+      "Model contracts are not supported for Redshift Iceberg tables (Iceberg tables do not support column constraints)."
+    ) %}
+  {%- endif -%}
+
+  {%- set sql_header = config.get('sql_header', none) -%}
+  {{ sql_header if sql_header is not none }}
+
+  {%- set partition_by = catalog_relation.partition_by -%}
+  {%- if partition_by is string -%}
+    {%- set partition_by_string = partition_by -%}
+  {%- elif partition_by -%}
+    {%- set partition_by_string = partition_by | join(", ") -%}
+  {%- else -%}
+    {%- set partition_by_string = none -%}
+  {%- endif -%}
+
+  {%- set table_properties = catalog_relation.table_properties -%}
+  {%- if table_properties -%}
+    {%- set tbl_props = [] -%}
+    {%- for key, value in table_properties.items() -%}
+      {%- do tbl_props.append("'" ~ key ~ "'='" ~ value ~ "'") -%}
+    {%- endfor -%}
+    {%- set table_properties_string = tbl_props | join(", ") -%}
+  {%- else -%}
+    {%- set table_properties_string = none -%}
+  {%- endif -%}
+
+  {# Iceberg has no CREATE OR REPLACE and tables can't be renamed; drop first for idempotency #}
+  {%- set existing_relation = adapter.get_relation(
+        database=relation.database, schema=relation.schema, identifier=relation.identifier) -%}
+  {% if existing_relation is not none %}
+    drop table if exists {{ existing_relation }};
+  {% endif %}
+
+  create table {{ relation }}
+    using iceberg
+    {{ optional('location', catalog_relation.external_volume, "'") }}
+    {% if partition_by_string -%} partitioned by ({{ partition_by_string }}) {%- endif %}
+    {% if table_properties_string -%} table properties ({{ table_properties_string }}) {%- endif %}
+  as (
+    {{ sql }}
+  );
+{%- endmacro %}

--- a/dbt-redshift/src/dbt/include/redshift/macros/relations/table/create_iceberg.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/relations/table/create_iceberg.sql
@@ -5,7 +5,10 @@
     https://docs.aws.amazon.com/redshift/latest/dg/iceberg-writes-sql-syntax.html
 
     Limitations (per AWS docs):
-    - Iceberg does not support CREATE OR REPLACE, so we DROP first for idempotency.
+    - Iceberg DDL cannot run inside a multi-statement transaction, so this macro
+      emits a SINGLE statement (just the CREATE). Dropping any existing relation is
+      handled separately by the materialization, and the connection must run with
+      autocommit so dbt does not wrap it in BEGIN/COMMIT.
     - Iceberg tables cannot be renamed, so the materialization builds directly into
       the target relation rather than using an intermediate + rename swap.
     - Iceberg tables do not support column constraints / attributes, so model
@@ -55,19 +58,15 @@
     {%- set table_properties_string = none -%}
   {%- endif -%}
 
-  {# Iceberg has no CREATE OR REPLACE and tables can't be renamed; drop first for idempotency #}
-  {%- set existing_relation = adapter.get_relation(
-        database=relation.database, schema=relation.schema, identifier=relation.identifier) -%}
-  {% if existing_relation is not none %}
-    drop table if exists {{ existing_relation }};
-  {% endif %}
-
+  {#- Single statement only: Iceberg DDL can't run in a multi-statement transaction.
+      Any existing relation is dropped separately by the materialization. -#}
   create table {{ relation }}
     using iceberg
-    {{ optional('location', catalog_relation.location, "'") }}
+    {# Redshift uses `location '...'` (no `=`), so pass an empty equals_char #}
+    {{ optional('location', catalog_relation.location, "'", '') }}
     {% if partition_by_string -%} partitioned by ({{ partition_by_string }}) {%- endif %}
     {% if table_properties_string -%} table properties ({{ table_properties_string }}) {%- endif %}
   as (
     {{ sql }}
-  );
+  )
 {%- endmacro %}

--- a/dbt-redshift/src/dbt/include/redshift/macros/utils/optional.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/utils/optional.sql
@@ -1,0 +1,16 @@
+{% macro optional(name, value, quote_char = '', equals_char = '= ') %}
+{#-
+--  Insert optional DDL parameters only when their value is provided; makes DDL statements more readable
+--
+--  Args:
+--  - name: the name of the DDL option
+--  - value: the value of the DDL option, may be None
+--  - quote_char: the quote character to use (e.g. '"', '(', etc.), leave blank if unnecessary
+--  - equals_char: the equals character to use (e.g. '= ')
+--  Returns:
+--      If the value is not None (e.g. provided by the user), return the option setting DDL
+--      If the value is None, return an empty string
+-#}
+{%- set quote_char_right = ')' if quote_char == '(' else quote_char -%}
+{% if value is not none %}{{ name }} {{ equals_char }}{{ quote_char }}{{ value }}{{ quote_char_right }}{% endif %}
+{% endmacro %}

--- a/dbt-redshift/test.env.example
+++ b/dbt-redshift/test.env.example
@@ -16,6 +16,12 @@ REDSHIFT_TEST_CROSS_DBNAME=
 # Must be a Redshift database whose name contains a hyphen, e.g. "my-hyphen-db"
 REDSHIFT_TEST_DBNAME_W_HYPHEN=
 
+# Apache Iceberg / AWS Glue tests (optional — tests are skipped when not set)
+# An existing Redshift external schema mapped to an AWS Glue Data Catalog database,
+# and an empty S3 prefix the cluster can write to (same region as the cluster).
+REDSHIFT_TEST_ICEBERG_EXTERNAL_SCHEMA=
+REDSHIFT_TEST_ICEBERG_LOCATION=
+
 # IAM Methods
 REDSHIFT_TEST_CLUSTER_ID=
 

--- a/dbt-redshift/tests/functional/adapter/iceberg/models.py
+++ b/dbt-redshift/tests/functional/adapter/iceberg/models.py
@@ -1,0 +1,58 @@
+SEED_BASE = """
+{{
+  config(materialized="table")
+}}
+select 1 as id, 'a' as name
+union all
+select 2 as id, 'b' as name
+"""
+
+# Basic Iceberg table via the default-registered `glue` catalog integration.
+# `external_volume` maps to the Iceberg LOCATION clause.
+ICEBERG_TABLE = """
+{{
+  config(
+    materialized="table",
+    catalog_name="glue",
+    external_volume=var("iceberg_location"),
+  )
+}}
+select * from {{ ref('base_table') }}
+"""
+
+ICEBERG_TABLE_PARTITIONED = """
+{{
+  config(
+    materialized="table",
+    catalog_name="glue",
+    external_volume=var("iceberg_location"),
+    partition_by=["bucket(16, id)"],
+    table_properties={"compression_type": "zstd"},
+  )
+}}
+select * from {{ ref('base_table') }}
+"""
+
+ICEBERG_INCREMENTAL = """
+{{
+  config(
+    materialized="incremental",
+    catalog_name="glue",
+    external_volume=var("iceberg_location"),
+    incremental_strategy="append",
+    unique_key="id",
+  )
+}}
+select * from {{ ref('base_table') }}
+{% if is_incremental() %}
+where id > (select max(id) from {{ this }})
+{% endif %}
+"""
+
+# A normal Redshift view that reads from an Iceberg table.
+VIEW_ON_ICEBERG = """
+{{
+  config(materialized="view")
+}}
+select * from {{ ref('iceberg_table') }}
+"""

--- a/dbt-redshift/tests/functional/adapter/iceberg/models.py
+++ b/dbt-redshift/tests/functional/adapter/iceberg/models.py
@@ -1,18 +1,27 @@
-SEED_BASE = """
-{{
-  config(materialized="table")
-}}
+# A normal Redshift table that the Iceberg models read from.
+BASE_TABLE = """
+{{ config(materialized="table") }}
 select 1 as id, 'a' as name
 union all
 select 2 as id, 'b' as name
 """
 
-# Basic Iceberg table via the default-registered `glue` catalog integration.
-# `external_volume` maps to the Iceberg LOCATION clause.
+BASE_TABLE_WITH_NEW_ROW = """
+{{ config(materialized="table") }}
+select 1 as id, 'a' as name
+union all
+select 2 as id, 'b' as name
+union all
+select 3 as id, 'c' as name
+"""
+
+# Iceberg table via the default-registered `glue` catalog. `external_volume` is the
+# S3 base prefix (LOCATION); the schema must be an existing Glue-backed external schema.
 ICEBERG_TABLE = """
 {{
   config(
     materialized="table",
+    schema=var("iceberg_external_schema"),
     catalog_name="glue",
     external_volume=var("iceberg_location"),
   )
@@ -24,10 +33,12 @@ ICEBERG_TABLE_PARTITIONED = """
 {{
   config(
     materialized="table",
+    schema=var("iceberg_external_schema"),
     catalog_name="glue",
     external_volume=var("iceberg_location"),
     partition_by=["bucket(16, id)"],
     table_properties={"compression_type": "zstd"},
+    base_location_subpath="v1",
   )
 }}
 select * from {{ ref('base_table') }}
@@ -37,6 +48,7 @@ ICEBERG_INCREMENTAL = """
 {{
   config(
     materialized="incremental",
+    schema=var("iceberg_external_schema"),
     catalog_name="glue",
     external_volume=var("iceberg_location"),
     incremental_strategy="append",
@@ -49,10 +61,20 @@ where id > (select max(id) from {{ this }})
 {% endif %}
 """
 
-# A normal Redshift view that reads from an Iceberg table.
+# A view over an Iceberg table must be late-binding (bind=false) on Redshift.
 VIEW_ON_ICEBERG = """
-{{
-  config(materialized="view")
-}}
+{{ config(materialized="view", bind=false) }}
 select * from {{ ref('iceberg_table') }}
+"""
+
+# Iceberg models land in the configured external schema; everything else uses the
+# default test schema.
+GENERATE_SCHEMA_NAME = """
+{% macro generate_schema_name(custom_schema_name, node) -%}
+  {%- if custom_schema_name is none -%}
+    {{ target.schema }}
+  {%- else -%}
+    {{ custom_schema_name | trim }}
+  {%- endif -%}
+{%- endmacro %}
 """

--- a/dbt-redshift/tests/functional/adapter/iceberg/test_iceberg.py
+++ b/dbt-redshift/tests/functional/adapter/iceberg/test_iceberg.py
@@ -1,0 +1,96 @@
+"""Functional tests for Apache Iceberg (AWS Glue Data Catalog) support on Redshift.
+
+These require a live Redshift cluster with a pre-provisioned external schema mapped
+to an AWS Glue Data Catalog database, plus an empty S3 prefix the cluster can write
+to. They are skipped unless both env vars are set:
+
+    REDSHIFT_TEST_ICEBERG_EXTERNAL_SCHEMA
+    REDSHIFT_TEST_ICEBERG_LOCATION
+"""
+
+import os
+
+import pytest
+
+from dbt.tests.util import run_dbt, check_relations_equal
+
+from tests.functional.adapter.iceberg import models
+
+
+ICEBERG_EXTERNAL_SCHEMA = os.getenv("REDSHIFT_TEST_ICEBERG_EXTERNAL_SCHEMA")
+ICEBERG_LOCATION = os.getenv("REDSHIFT_TEST_ICEBERG_LOCATION")
+
+pytestmark = pytest.mark.skipif(
+    not (ICEBERG_EXTERNAL_SCHEMA and ICEBERG_LOCATION),
+    reason="Requires REDSHIFT_TEST_ICEBERG_EXTERNAL_SCHEMA and REDSHIFT_TEST_ICEBERG_LOCATION",
+)
+
+
+# Route only catalog-backed (Iceberg) models to the external Glue schema; everything
+# else keeps the default test-schema behavior.
+_GENERATE_SCHEMA_NAME = """
+{% macro generate_schema_name(custom_schema_name, node) -%}
+  {%- if node.config.get('catalog_name') == 'glue' -%}
+    {{ var('iceberg_external_schema') }}
+  {%- else -%}
+    {{ default__generate_schema_name(custom_schema_name, node) }}
+  {%- endif -%}
+{%- endmacro %}
+"""
+
+
+class IcebergSetup:
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"generate_schema_name.sql": _GENERATE_SCHEMA_NAME}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "vars": {
+                "iceberg_external_schema": ICEBERG_EXTERNAL_SCHEMA,
+                "iceberg_location": ICEBERG_LOCATION,
+            }
+        }
+
+
+class TestIcebergTable(IcebergSetup):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "base_table.sql": models.SEED_BASE,
+            "iceberg_table.sql": models.ICEBERG_TABLE,
+            "iceberg_table_partitioned.sql": models.ICEBERG_TABLE_PARTITIONED,
+            "view_on_iceberg.sql": models.VIEW_ON_ICEBERG,
+        }
+
+    def test_build_and_idempotent_rerun(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 4
+
+        # Iceberg has no CREATE OR REPLACE; a rerun must drop-then-create cleanly.
+        results = run_dbt(["run"])
+        assert len(results) == 4
+
+        check_relations_equal(project.adapter, ["base_table", "iceberg_table"])
+
+
+class TestIcebergIncremental(IcebergSetup):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "base_table.sql": models.SEED_BASE,
+            "iceberg_incremental.sql": models.ICEBERG_INCREMENTAL,
+        }
+
+    def test_incremental_append_and_full_refresh(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 2
+
+        # incremental run (append strategy) against the Iceberg target
+        results = run_dbt(["run", "--select", "iceberg_incremental"])
+        assert len(results) == 1
+
+        # full-refresh must rebuild via drop + CTAS (no rename)
+        results = run_dbt(["run", "--select", "iceberg_incremental", "--full-refresh"])
+        assert len(results) == 1

--- a/dbt-redshift/tests/functional/adapter/iceberg/test_iceberg.py
+++ b/dbt-redshift/tests/functional/adapter/iceberg/test_iceberg.py
@@ -1,18 +1,21 @@
 """Functional tests for Apache Iceberg (AWS Glue Data Catalog) support on Redshift.
 
-These require a live Redshift cluster with a pre-provisioned external schema mapped
-to an AWS Glue Data Catalog database, plus an empty S3 prefix the cluster can write
-to. They are skipped unless both env vars are set:
+These require a live Redshift cluster with:
+  - a pre-provisioned external schema mapped to an AWS Glue Data Catalog database
+    (set REDSHIFT_TEST_ICEBERG_EXTERNAL_SCHEMA), and
+  - an empty, writable S3 prefix in the cluster's region
+    (set REDSHIFT_TEST_ICEBERG_LOCATION).
+The dbt client must also have AWS credentials with S3 delete access to that prefix
+(used to purge the location on re-create, since Redshift DROP leaves S3 data behind).
 
-    REDSHIFT_TEST_ICEBERG_EXTERNAL_SCHEMA
-    REDSHIFT_TEST_ICEBERG_LOCATION
+The tests are skipped unless both env vars are set.
 """
 
 import os
 
 import pytest
 
-from dbt.tests.util import run_dbt, check_relations_equal
+from dbt.tests.util import run_dbt, write_file
 
 from tests.functional.adapter.iceberg import models
 
@@ -26,23 +29,26 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-# Route only catalog-backed (Iceberg) models to the external Glue schema; everything
-# else keeps the default test-schema behavior.
-_GENERATE_SCHEMA_NAME = """
-{% macro generate_schema_name(custom_schema_name, node) -%}
-  {%- if node.config.get('catalog_name') == 'glue' -%}
-    {{ var('iceberg_external_schema') }}
-  {%- else -%}
-    {{ default__generate_schema_name(custom_schema_name, node) }}
-  {%- endif -%}
-{%- endmacro %}
-"""
-
-
 class IcebergSetup:
     @pytest.fixture(scope="class")
+    def dbt_profile_target(self):
+        # Iceberg DDL cannot run inside a multi-statement transaction, so the
+        # connection must use autocommit.
+        return {
+            "type": "redshift",
+            "host": os.getenv("REDSHIFT_TEST_HOST"),
+            "port": int(os.getenv("REDSHIFT_TEST_PORT", "5439")),
+            "dbname": os.getenv("REDSHIFT_TEST_DBNAME"),
+            "user": os.getenv("REDSHIFT_TEST_USER"),
+            "pass": os.getenv("REDSHIFT_TEST_PASS"),
+            "region": os.getenv("REDSHIFT_TEST_REGION"),
+            "threads": 1,
+            "autocommit": True,
+        }
+
+    @pytest.fixture(scope="class")
     def macros(self):
-        return {"generate_schema_name.sql": _GENERATE_SCHEMA_NAME}
+        return {"generate_schema_name.sql": models.GENERATE_SCHEMA_NAME}
 
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -50,47 +56,68 @@ class IcebergSetup:
             "vars": {
                 "iceberg_external_schema": ICEBERG_EXTERNAL_SCHEMA,
                 "iceberg_location": ICEBERG_LOCATION,
-            }
+            },
+            "flags": {"redshift_skip_autocommit_transaction_statements": True},
+            # Redshift Iceberg CREATE TABLE requires case-insensitive identifiers.
+            "models": {"+pre-hook": "set enable_case_sensitive_identifier to off"},
         }
+
+    def _count(self, project, identifier):
+        result = project.run_sql(
+            f"select count(*) from {ICEBERG_EXTERNAL_SCHEMA}.{identifier}", fetch="one"
+        )
+        return result[0]
 
 
 class TestIcebergTable(IcebergSetup):
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "base_table.sql": models.SEED_BASE,
+            "base_table.sql": models.BASE_TABLE,
             "iceberg_table.sql": models.ICEBERG_TABLE,
             "iceberg_table_partitioned.sql": models.ICEBERG_TABLE_PARTITIONED,
             "view_on_iceberg.sql": models.VIEW_ON_ICEBERG,
         }
 
     def test_build_and_idempotent_rerun(self, project):
-        results = run_dbt(["run"])
-        assert len(results) == 4
+        assert len(run_dbt(["run"])) == 4
+        assert self._count(project, "iceberg_table") == 2
+        assert self._count(project, "iceberg_table_partitioned") == 2
 
-        # Iceberg has no CREATE OR REPLACE; a rerun must drop-then-create cleanly.
-        results = run_dbt(["run"])
-        assert len(results) == 4
-
-        check_relations_equal(project.adapter, ["base_table", "iceberg_table"])
+        # Re-run: Iceberg has no CREATE OR REPLACE, so each table is dropped, its S3
+        # prefix purged, and re-created. Counts must stay stable (no errors, no dupes).
+        assert len(run_dbt(["run"])) == 4
+        assert self._count(project, "iceberg_table") == 2
+        assert self._count(project, "iceberg_table_partitioned") == 2
 
 
 class TestIcebergIncremental(IcebergSetup):
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "base_table.sql": models.SEED_BASE,
+            "base_table.sql": models.BASE_TABLE,
             "iceberg_incremental.sql": models.ICEBERG_INCREMENTAL,
         }
 
-    def test_incremental_append_and_full_refresh(self, project):
-        results = run_dbt(["run"])
-        assert len(results) == 2
+    def test_incremental_append(self, project):
+        assert len(run_dbt(["run"])) == 2
+        assert self._count(project, "iceberg_incremental") == 2
 
-        # incremental run (append strategy) against the Iceberg target
-        results = run_dbt(["run", "--select", "iceberg_incremental"])
-        assert len(results) == 1
+        # Re-run with no new source rows: is_incremental() must engage (external
+        # tables are in the relation cache) so nothing is duplicated.
+        run_dbt(["run", "--select", "iceberg_incremental"])
+        assert self._count(project, "iceberg_incremental") == 2
 
-        # full-refresh must rebuild via drop + CTAS (no rename)
-        results = run_dbt(["run", "--select", "iceberg_incremental", "--full-refresh"])
-        assert len(results) == 1
+        # Add a new source row -> only it should be appended.
+        write_file(
+            models.BASE_TABLE_WITH_NEW_ROW,
+            project.project_root,
+            "models",
+            "base_table.sql",
+        )
+        run_dbt(["run"])
+        assert self._count(project, "iceberg_incremental") == 3
+
+        # Full refresh rebuilds in place (drop + purge S3 + CTAS).
+        run_dbt(["run", "--select", "iceberg_incremental", "--full-refresh"])
+        assert self._count(project, "iceberg_incremental") == 3

--- a/dbt-redshift/tests/unit/test_delete_from_s3.py
+++ b/dbt-redshift/tests/unit/test_delete_from_s3.py
@@ -1,0 +1,71 @@
+from contextlib import contextmanager  # noqa: F401
+from multiprocessing import get_context
+from unittest import TestCase, mock
+
+from dbt.adapters.redshift import (
+    Plugin as RedshiftPlugin,
+    RedshiftAdapter,
+)
+from tests.unit.utils import (
+    config_from_parts_or_dicts,
+    inject_adapter,
+)
+
+BASE_OUTPUT = {
+    "type": "redshift",
+    "dbname": "redshift",
+    "user": "root",
+    "host": "thishostshouldnotexist.test.us-east-1",
+    "pass": "password",
+    "port": 5439,
+    "schema": "public",
+}
+
+PROJECT_CFG = {
+    "name": "X",
+    "version": "0.1",
+    "profile": "test",
+    "project-root": "/tmp/dbt/does-not-exist",
+    "config-version": 2,
+}
+
+
+def make_adapter(extra_credentials=None):
+    output = {**BASE_OUTPUT, **(extra_credentials or {})}
+    profile_cfg = {"outputs": {"test": output}, "target": "test"}
+    config = config_from_parts_or_dicts(PROJECT_CFG, profile_cfg)
+    adapter = RedshiftAdapter(config, get_context("spawn"))
+    inject_adapter(adapter, RedshiftPlugin)
+    return adapter
+
+
+class TestDeleteFromS3(TestCase):
+    def _run(self, s3_path):
+        """Call delete_from_s3 with a mocked boto3 session; return (bucket, prefix used)."""
+        adapter = make_adapter()
+        mock_bucket = mock.MagicMock()
+        mock_s3 = mock.MagicMock()
+        mock_s3.Bucket.return_value = mock_bucket
+        mock_session = mock.MagicMock()
+        mock_session.resource.return_value = mock_s3
+        with mock.patch.object(adapter, "_boto3_session", return_value=mock_session):
+            adapter.delete_from_s3(s3_path)
+        return mock_s3, mock_bucket
+
+    def test_parses_bucket_and_scopes_prefix_with_trailing_slash(self):
+        mock_s3, mock_bucket = self._run("s3://my-bucket/iceberg/_dbt/schema/orders")
+        mock_s3.Bucket.assert_called_once_with("my-bucket")
+        # prefix must end with "/" so it doesn't also match a sibling like ".../orders_x"
+        mock_bucket.objects.filter.assert_called_once_with(Prefix="iceberg/_dbt/schema/orders/")
+        mock_bucket.objects.filter.return_value.delete.assert_called_once()
+
+    def test_keeps_existing_trailing_slash(self):
+        _, mock_bucket = self._run("s3://my-bucket/prefix/")
+        mock_bucket.objects.filter.assert_called_once_with(Prefix="prefix/")
+
+    def test_noop_on_empty_path(self):
+        adapter = make_adapter()
+        with mock.patch.object(adapter, "_boto3_session") as session:
+            adapter.delete_from_s3(None)
+            adapter.delete_from_s3("")
+            session.assert_not_called()

--- a/dbt-redshift/tests/unit/test_delete_from_s3.py
+++ b/dbt-redshift/tests/unit/test_delete_from_s3.py
@@ -1,6 +1,8 @@
-from contextlib import contextmanager  # noqa: F401
 from multiprocessing import get_context
 from unittest import TestCase, mock
+
+from botocore.exceptions import NoCredentialsError
+from dbt_common.exceptions import DbtRuntimeError
 
 from dbt.adapters.redshift import (
     Plugin as RedshiftPlugin,
@@ -69,3 +71,15 @@ class TestDeleteFromS3(TestCase):
             adapter.delete_from_s3(None)
             adapter.delete_from_s3("")
             session.assert_not_called()
+
+    def test_raises_clear_error_when_no_aws_credentials(self):
+        adapter = make_adapter()
+        mock_bucket = mock.MagicMock()
+        mock_bucket.objects.filter.return_value.delete.side_effect = NoCredentialsError()
+        mock_s3 = mock.MagicMock()
+        mock_s3.Bucket.return_value = mock_bucket
+        mock_session = mock.MagicMock()
+        mock_session.resource.return_value = mock_s3
+        with mock.patch.object(adapter, "_boto3_session", return_value=mock_session):
+            with self.assertRaises(DbtRuntimeError):
+                adapter.delete_from_s3("s3://bucket/prefix/")

--- a/dbt-redshift/tests/unit/test_glue_catalog_integration.py
+++ b/dbt-redshift/tests/unit/test_glue_catalog_integration.py
@@ -1,0 +1,72 @@
+from types import SimpleNamespace
+
+import pytest
+
+from dbt.adapters.redshift import constants
+from dbt.adapters.redshift.catalogs import GlueCatalogIntegration, GlueCatalogRelation
+
+
+def _config(**kwargs) -> SimpleNamespace:
+    base = dict(
+        name="my_glue_catalog",
+        catalog_name="my_glue_catalog",
+        catalog_type=constants.GLUE_CATALOG_TYPE,
+        table_format=constants.ICEBERG_TABLE_FORMAT,
+        external_volume=None,
+        file_format=None,
+        adapter_properties={},
+    )
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+def _model(config: dict) -> SimpleNamespace:
+    return SimpleNamespace(config=config)
+
+
+def test_integration_class_attributes():
+    assert GlueCatalogIntegration.catalog_type == constants.GLUE_CATALOG_TYPE
+    assert GlueCatalogIntegration.table_format == constants.ICEBERG_TABLE_FORMAT
+    assert GlueCatalogIntegration.allows_writes is True
+
+
+def test_build_relation_reads_model_config():
+    integration = GlueCatalogIntegration(_config())
+    model = _model(
+        {
+            "partition_by": ["day(event_ts)", "identity(region)"],
+            "table_properties": {"compression_type": "zstd"},
+            "external_volume": "s3://my-bucket/prefix/",
+        }
+    )
+
+    relation = integration.build_relation(model)
+
+    assert isinstance(relation, GlueCatalogRelation)
+    assert relation.table_format == constants.ICEBERG_TABLE_FORMAT
+    assert relation.catalog_name == "my_glue_catalog"
+    assert relation.partition_by == ["day(event_ts)", "identity(region)"]
+    assert relation.table_properties == {"compression_type": "zstd"}
+    assert relation.external_volume == "s3://my-bucket/prefix/"
+
+
+def test_build_relation_falls_back_to_integration_external_volume():
+    integration = GlueCatalogIntegration(_config(external_volume="s3://default-volume/"))
+    relation = integration.build_relation(_model({}))
+
+    assert relation.external_volume == "s3://default-volume/"
+    assert relation.partition_by is None
+    assert relation.table_properties is None
+
+
+def test_build_relation_location_alias():
+    integration = GlueCatalogIntegration(_config())
+    relation = integration.build_relation(_model({"location": "s3://aliased/"}))
+    assert relation.external_volume == "s3://aliased/"
+
+
+@pytest.mark.parametrize("partition_by", ["day(event_ts)", ["day(event_ts)"]])
+def test_partition_by_accepts_string_or_list(partition_by):
+    integration = GlueCatalogIntegration(_config())
+    relation = integration.build_relation(_model({"partition_by": partition_by}))
+    assert relation.partition_by == partition_by

--- a/dbt-redshift/tests/unit/test_glue_catalog_integration.py
+++ b/dbt-redshift/tests/unit/test_glue_catalog_integration.py
@@ -20,8 +20,8 @@ def _config(**kwargs) -> SimpleNamespace:
     return SimpleNamespace(**base)
 
 
-def _model(config: dict) -> SimpleNamespace:
-    return SimpleNamespace(config=config)
+def _model(config: dict, schema: str = "analytics", identifier: str = "orders") -> SimpleNamespace:
+    return SimpleNamespace(config=config, schema=schema, identifier=identifier)
 
 
 def test_integration_class_attributes():
@@ -47,6 +47,7 @@ def test_build_relation_reads_model_config():
     assert relation.catalog_name == "my_glue_catalog"
     assert relation.partition_by == ["day(event_ts)", "identity(region)"]
     assert relation.table_properties == {"compression_type": "zstd"}
+    # external_volume stays the raw base; location is derived per-table
     assert relation.external_volume == "s3://my-bucket/prefix/"
 
 
@@ -70,3 +71,46 @@ def test_partition_by_accepts_string_or_list(partition_by):
     integration = GlueCatalogIntegration(_config())
     relation = integration.build_relation(_model({"partition_by": partition_by}))
     assert relation.partition_by == partition_by
+
+
+# ---- LOCATION derivation (unique per-table prefix) ----
+
+
+def test_location_is_derived_per_table():
+    integration = GlueCatalogIntegration(_config())
+    model = _model(
+        {"external_volume": "s3://my-bucket/prefix/"}, schema="sales", identifier="orders"
+    )
+    relation = integration.build_relation(model)
+    # default base_location_root is "_dbt"; trailing slash on the volume is normalized
+    assert relation.location == "s3://my-bucket/prefix/_dbt/sales/orders"
+
+
+def test_location_is_unique_across_models_sharing_a_volume():
+    integration = GlueCatalogIntegration(_config(external_volume="s3://shared/"))
+    a = integration.build_relation(_model({}, schema="s", identifier="model_a"))
+    b = integration.build_relation(_model({}, schema="s", identifier="model_b"))
+    assert a.location != b.location
+    assert a.location == "s3://shared/_dbt/s/model_a"
+    assert b.location == "s3://shared/_dbt/s/model_b"
+
+
+def test_location_respects_base_location_root_and_subpath():
+    integration = GlueCatalogIntegration(_config())
+    model = _model(
+        {
+            "external_volume": "s3://my-bucket/",
+            "base_location_root": "warehouse",
+            "base_location_subpath": "v2",
+        },
+        schema="sales",
+        identifier="orders",
+    )
+    relation = integration.build_relation(model)
+    assert relation.location == "s3://my-bucket/warehouse/sales/orders/v2"
+
+
+def test_location_is_none_without_external_volume():
+    integration = GlueCatalogIntegration(_config())
+    relation = integration.build_relation(_model({}))
+    assert relation.location is None

--- a/dbt-redshift/tests/unit/test_glue_catalog_integration.py
+++ b/dbt-redshift/tests/unit/test_glue_catalog_integration.py
@@ -60,12 +60,6 @@ def test_build_relation_falls_back_to_integration_external_volume():
     assert relation.table_properties is None
 
 
-def test_build_relation_location_alias():
-    integration = GlueCatalogIntegration(_config())
-    relation = integration.build_relation(_model({"location": "s3://aliased/"}))
-    assert relation.external_volume == "s3://aliased/"
-
-
 @pytest.mark.parametrize("partition_by", ["day(event_ts)", ["day(event_ts)"]])
 def test_partition_by_accepts_string_or_list(partition_by):
     integration = GlueCatalogIntegration(_config())

--- a/dbt-redshift/tests/unit/test_relation.py
+++ b/dbt-redshift/tests/unit/test_relation.py
@@ -27,6 +27,31 @@ def test_renameable_relation():
     )
 
 
+def test_default_relation_is_not_iceberg_and_can_be_renamed():
+    relation = RedshiftRelation.create(
+        database="my_db",
+        schema="my_schema",
+        identifier="my_table",
+        type=RelationType.Table,
+    )
+    assert relation.table_format == "default"
+    assert relation.is_iceberg_format is False
+    assert relation.can_be_renamed is True
+
+
+def test_iceberg_relation_cannot_be_renamed():
+    relation = RedshiftRelation.create(
+        database="my_db",
+        schema="my_schema",
+        identifier="my_table",
+        type=RelationType.Table,
+        table_format="iceberg",
+    )
+    assert relation.is_iceberg_format is True
+    # Iceberg tables can't be renamed; replacing requires DROP + CREATE
+    assert relation.can_be_renamed is False
+
+
 @pytest.fixture
 def materialized_view_without_sort_key_from_db():
     materialized_view = agate.Table.from_object(


### PR DESCRIPTION
resolves N/A — no separate tracking issue; this PR is the tracking artifact (per maintainer direction)
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A — docs to follow

### Problem

dbt-redshift could not materialize models as Apache Iceberg tables. Redshift gained
Iceberg **write** support (via the AWS Glue Data Catalog) in late 2025, and
dbt-snowflake / dbt-bigquery already expose Iceberg through the shared
`dbt.adapters.catalogs` framework — but dbt-redshift had no catalog-integration code
at all.

### Solution

Wire dbt-redshift into the shared catalog-integration framework and add the Iceberg
DDL/DML paths for the `table`, `incremental`, and `view` materializations.

- **Catalog integration:** `GlueCatalogIntegration` / `GlueCatalogRelation` (catalog
  type `glue`, table format `iceberg`), a default `glue` catalog registered in
  `__init__`, the `CatalogsV2` capability, and v2 bridge hooks. Works with both v1
  (`write_integrations`) and v2 (`type: glue`) `catalogs.yml` (verified via `dbt parse`).
- **Create:** `CREATE TABLE … USING ICEBERG … AS SELECT` with a unique per-table
  `LOCATION` derived from `external_volume` + `base_location_root`/`schema`/`identifier`
  /`base_location_subpath`. Supports `partition_by` and `table_properties`.
- **Idempotency:** Redshift `DROP TABLE` only removes the Glue entry (S3 files remain)
  and CTAS requires an empty `LOCATION`, so a new boto3-backed `@available
  delete_from_s3()` purges the prefix before re-creating (mirrors dbt-athena). The
  dbt client needs AWS credentials with S3 delete on the bucket.
- **Relation listing:** external Glue tables are unioned into
  `redshift__list_relations_without_caching` (legacy path) via `svv_external_tables`,
  so the relation cache surfaces them and `is_incremental()` / `get_relation` work.
- **Relation:** `table_format` + `is_iceberg_format`; Iceberg relations are not
  renameable.

Validated end-to-end against a live Redshift cluster + Glue + S3: table, partitioned
table (bucket transform + zstd), incremental append (with correct `is_incremental()`
filtering), and a late-binding view over an Iceberg table — plus idempotent re-runs.

**Cluster requirements for Iceberg writes** (documented in the functional test):
autocommit connection, `enable_case_sensitive_identifier = off`, a pre-existing
Glue-backed external schema, and `bind=false` for views over Iceberg tables.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes — it DOES add interface (new model configs,
      catalog integration, `delete_from_s3`); pending Product/DX feedback
