### PR TITLE
perf(bigquery): set relation descriptions via DDL instead of the BigQuery API

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Under the Hood-20260609-000000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Under the Hood-20260609-000000.yaml
@@ -1,0 +1,10 @@
+kind: Under the Hood
+body: Set relation descriptions via `ALTER ... SET OPTIONS(description=...)` DDL instead
+  of the BigQuery API. This replaces the prior get-then-update API round trip with a
+  single atomic statement, which is more performant and avoids a race when a concurrent
+  update lands between the get and update calls. The `adapter.update_table_description`
+  method is deprecated in favor of the `alter_relation_comment` macro.
+time: 2026-06-09T00:00:00.000000+00:00
+custom:
+  Author: yaroslav-borodaienko
+  Issue: "1568"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
@@ -780,7 +780,7 @@ class BigQueryAdapter(BaseAdapter):
         new_table = google.cloud.bigquery.Table(table_ref, schema=new_schema)
         conn.handle.update_table(new_table, ["schema"])
 
-    @available.parse_none
+    @available.deprecated("alter_relation_comment", lambda *a, **k: None)
     def update_table_description(
         self, database: str, schema: str, identifier: str, description: str
     ):

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/adapters.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/adapters.sql
@@ -136,7 +136,15 @@
       in DDL (e.g. OPTIONS(description=...)).
     -#}
   {%- else -%}
-    {% do adapter.update_table_description(relation.database, relation.schema, relation.identifier, relation_comment) %}
+    {%- if relation.type == 'materialized_view' -%}
+      {%- set relation_type = 'materialized view' -%}
+    {%- else -%}
+      {%- set relation_type = relation.type -%}
+    {%- endif -%}
+    {%- set alter_comment_sql -%}
+      alter {{ relation_type }} {{ relation.render() }} set options(description={{ relation_comment | tojson }});
+    {%- endset -%}
+    {% do run_query(alter_comment_sql) %}
   {%- endif -%}
 {% endmacro %}
 

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/seed.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/seed.sql
@@ -23,12 +23,10 @@
   {{ adapter.load_dataframe(model['database'], model['schema'], model['alias'],
   							agate_table, column_override, model['config']['delimiter']) }}
 
+  {# bigquery_table_options already renders OPTIONS(description=...) when
+     persist_relation_docs is enabled, so the description is set as part of this
+     single ALTER statement. No separate update_table_description call needed. #}
   {% call statement() %}
     alter table {{ this.render() }} set {{ bigquery_table_options(config, model) }}
   {% endcall %}
-
-  {% if config.persist_relation_docs() and 'description' in model %}
-
-  	{{ adapter.update_table_description(model['database'], model['schema'], model['alias'], model['description']) }}
-  {% endif %}
 {% endmacro %}

--- a/dbt-bigquery/tests/functional/adapter/test_noop_alter_relation_comment_behavior_flag.py
+++ b/dbt-bigquery/tests/functional/adapter/test_noop_alter_relation_comment_behavior_flag.py
@@ -1,7 +1,5 @@
 import pytest
-from unittest import mock
 
-from dbt.adapters.bigquery.impl import BigQueryAdapter
 from dbt.tests.util import run_dbt
 
 
@@ -40,10 +38,8 @@ class TestNoopAlterRelationCommentBehaviorFlag:
             },
         }
 
-    def test_relation_description_set_without_update_call(self, project):
-        with mock.patch.object(BigQueryAdapter, "update_table_description") as mock_update:
-            run_dbt(["run"])
-            assert mock_update.call_count == 0
+    def test_relation_description_set_via_create_options(self, project):
+        run_dbt(["run"])
 
         with project.adapter.connection_named("_test"):
             client = project.adapter.connections.get_thread_connection().handle

--- a/dbt-bigquery/tests/unit/test_noop_alter_relation_comment_behavior_flag.py
+++ b/dbt-bigquery/tests/unit/test_noop_alter_relation_comment_behavior_flag.py
@@ -1,5 +1,4 @@
 from types import SimpleNamespace
-from unittest import mock
 
 from dbt_common.behavior_flags import BehaviorFlagRendered
 from dbt.adapters.bigquery.impl import BIGQUERY_NOOP_ALTER_RELATION_COMMENT
@@ -11,8 +10,14 @@ def _load_bigquery_adapters_macros(adapter):
         loader=jinja2.FileSystemLoader("src/dbt/include/bigquery/macros"),
         extensions=["jinja2.ext.do"],
     )
+    # alter_relation_comment now emits DDL via run_query; capture what it is handed
+    # and expose it on the module as `captured_sql` for assertions.
+    captured_sql = []
+    env.globals["run_query"] = captured_sql.append
     template = env.get_template("adapters.sql")
-    return template.make_module({"adapter": adapter})
+    module = template.make_module({"adapter": adapter})
+    module.captured_sql = captured_sql
+    return module
 
 
 def test_alter_relation_comment_noop_when_behavior_flag_true():
@@ -23,30 +28,38 @@ def test_alter_relation_comment_noop_when_behavior_flag_true():
                 {BIGQUERY_NOOP_ALTER_RELATION_COMMENT["name"]: True},
             )
         ),
-        update_table_description=mock.Mock(),
     )
     assert adapter.behavior.bigquery_noop_alter_relation_comment.no_warn is True
-    relation = SimpleNamespace(database="db", schema="sch", identifier="ident")
+    relation = SimpleNamespace(type="table", render=lambda: "`db`.`sch`.`ident`")
 
     macros = _load_bigquery_adapters_macros(adapter)
     macros.bigquery__alter_relation_comment(relation, "desc")
 
-    adapter.update_table_description.assert_not_called()
+    assert macros.captured_sql == []
 
 
-def test_alter_relation_comment_calls_update_when_behavior_flag_false():
+def test_alter_relation_comment_emits_ddl_when_behavior_flag_false():
     adapter = SimpleNamespace(
         behavior=SimpleNamespace(
             bigquery_noop_alter_relation_comment=BehaviorFlagRendered(
                 BIGQUERY_NOOP_ALTER_RELATION_COMMENT, {}
             )
         ),
-        update_table_description=mock.Mock(),
     )
     assert adapter.behavior.bigquery_noop_alter_relation_comment.no_warn is False
-    relation = SimpleNamespace(database="db", schema="sch", identifier="ident")
 
-    macros = _load_bigquery_adapters_macros(adapter)
-    macros.bigquery__alter_relation_comment(relation, "desc")
+    # relation.type "materialized_view" maps to the "materialized view" SQL keyword.
+    for relation_type, keyword in [
+        ("table", "table"),
+        ("view", "view"),
+        ("materialized_view", "materialized view"),
+    ]:
+        relation = SimpleNamespace(type=relation_type, render=lambda: "`db`.`sch`.`ident`")
+        macros = _load_bigquery_adapters_macros(adapter)
+        macros.bigquery__alter_relation_comment(relation, "desc")
 
-    adapter.update_table_description.assert_called_once_with("db", "sch", "ident", "desc")
+        assert len(macros.captured_sql) == 1
+        assert (
+            macros.captured_sql[0].strip()
+            == f'alter {keyword} `db`.`sch`.`ident` set options(description="desc");'
+        )


### PR DESCRIPTION
Resolves #1568.

### Problem

`bigquery__alter_relation_comment` called `adapter.update_table_description`, which does a get-then-update round trip (two API calls) and can fail when a concurrent update lands between the get and the update.

### Change

- Used single `ALTER {table|view|materialized view} ... SET OPTIONS(description=...)` DDL statement as [per suggestion](https://github.com/dbt-labs/dbt-adapters/issues/1568#issuecomment-3899166702).
- Deprecated `adapter.update_table_description` (via `@available.deprecated`).

### Testing

- Updated init tests assert the generated DDL and the no-op `bigquery_noop_alter_relation_comment` behavior-flag path.
- Rerun existing functional persist_docs + seed tests cover the description being applied end-to-end.