### PR TITLE
fix(athena): support boolean partition columns on Iceberg in batch path

### DIFF
--- a/dbt-athena/.changes/unreleased/Fixes-20260616-222646.yaml
+++ b/dbt-athena/.changes/unreleased/Fixes-20260616-222646.yaml
@@ -1,0 +1,9 @@
+kind: Fixes
+body: Support boolean partition columns on Iceberg tables in the partition-batching
+    fallback path (force_batch or TOO_MANY_OPEN_PARTITIONS), which previously raised
+    "Unsupported column type: boolean". Hive tables still raise, since Hive does not
+    support boolean partition columns (HIVE-6590).
+time: 2026-06-16T22:26:46-07:00
+custom:
+    Author: bxm156
+    Issue: "2025"

--- a/dbt-athena/src/dbt/adapters/athena/impl.py
+++ b/dbt-athena/src/dbt/adapters/athena/impl.py
@@ -1614,8 +1614,16 @@ class AthenaAdapter(SQLAdapter):
         return int((hash_value & self.INTEGER_MAX_VALUE_32_BIT_SIGNED) % num_buckets)
 
     @available
-    def format_value_for_partition(self, value: Any, column_type: str) -> Tuple[str, str]:
-        """Formats a value based on its column type for inclusion in a SQL query."""
+    def format_value_for_partition(
+        self, value: Any, column_type: str, table_type: str = "hive"
+    ) -> Tuple[str, str]:
+        """Formats a value based on its column type for inclusion in a SQL query.
+
+        ``table_type`` defaults to ``"hive"`` so existing two-argument callers keep
+        their current behavior. Boolean partition columns are only valid on Iceberg
+        (Hive rejects them, see HIVE-6590), so booleans are formatted only when
+        ``table_type == "iceberg"`` and otherwise fall through to the error below.
+        """
         comp_func = "="  # Default comparison function
         if value is None:
             return "null", " is "
@@ -1629,6 +1637,10 @@ class AthenaAdapter(SQLAdapter):
             return f"DATE'{value}'", comp_func
         elif column_type == "timestamp":
             return f"TIMESTAMP'{value}'", comp_func
+        elif column_type == "boolean" and table_type == "iceberg":
+            # Athena/Presto accepts bare boolean literals (true/false, unquoted).
+            # The distinct partition query returns Python True/False, so lowercase.
+            return str(value).lower(), comp_func
         else:
             # Raise an error for unsupported column types
             raise ValueError(f"Unsupported column type: {column_type}")

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/helpers/get_partition_batches.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/helpers/get_partition_batches.sql
@@ -1,6 +1,7 @@
 {% macro get_partition_batches(sql, as_subquery=True) -%}
     {# Retrieve partition configuration and set default partition limit #}
     {%- set partitioned_by = config.get('partitioned_by') -%}
+    {%- set table_type = config.get('table_type', default='hive') | lower -%}
     {%- set athena_partitions_limit = [1, config.get('partitions_limit', 100) | int] | max -%}
     {%- set partitioned_keys = adapter.format_partition_keys(partitioned_by) -%}
     {% do log('PARTITIONED KEYS: ' ~ partitioned_keys) %}
@@ -27,14 +28,14 @@
         {# Loop through each column in the row #}
         {%- for col, partition_key in zip(row, partitioned_by) -%}
             {# Process bucketed columns using the new macro with the index #}
-            {%- do process_bucket_column(col, partition_key, table, ns, counter.value) -%}
+            {%- do process_bucket_column(col, partition_key, table, ns, counter.value, table_type) -%}
 
             {# Logic for non-bucketed columns #}
             {%- set bucket_match = modules.re.search('bucket\((.+?),\s*(\d+)\)', partition_key) -%}
             {%- if not bucket_match -%}
                 {# For non-bucketed columns, format partition key and value #}
                 {%- set column_type = adapter.convert_type(table, counter.value) -%}
-                {%- set value, comp_func = adapter.format_value_for_partition(col, column_type) -%}
+                {%- set value, comp_func = adapter.format_value_for_partition(col, column_type, table_type) -%}
                 {%- set partition_key_formatted = adapter.format_one_partition_key(partitioned_by[counter.value]) -%}
                 {%- do single_partition.append(partition_key_formatted + comp_func + value) -%}
             {%- endif -%}

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/helpers/process_bucket_column.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/helpers/process_bucket_column.sql
@@ -1,4 +1,4 @@
-{% macro process_bucket_column(col, partition_key, table, ns, col_index) %}
+{% macro process_bucket_column(col, partition_key, table, ns, col_index, table_type='hive') %}
     {# Extract bucket information from the partition key #}
     {%- set bucket_match = modules.re.search('bucket\((.+?),\s*(\d+)\)', partition_key) -%}
 
@@ -8,7 +8,7 @@
         {%- set ns.is_bucketed = true -%}
         {%- set ns.bucket_column = bucket_match[1] -%}
         {%- set bucket_num = adapter.murmur3_hash(col, bucket_match[2] | int) -%}
-        {%- set formatted_value, comp_func = adapter.format_value_for_partition(col, column_type) -%}
+        {%- set formatted_value, comp_func = adapter.format_value_for_partition(col, column_type, table_type) -%}
 
         {%- if bucket_num not in ns.bucket_numbers %}
             {%- do ns.bucket_numbers.append(bucket_num) %}

--- a/dbt-athena/tests/unit/test_adapter.py
+++ b/dbt-athena/tests/unit/test_adapter.py
@@ -1639,6 +1639,30 @@ class TestAthenaAdapter:
     def test_format_value_for_partition(self, value, column_type, expected_result):
         assert self.adapter.format_value_for_partition(value, column_type) == expected_result
 
+    @pytest.mark.parametrize(
+        "value, expected_result",
+        [
+            (True, ("true", "=")),
+            (False, ("false", "=")),
+        ],
+    )
+    def test_format_boolean_partition_iceberg(self, value, expected_result):
+        # Boolean partition columns are valid on Iceberg only.
+        assert (
+            self.adapter.format_value_for_partition(value, "boolean", "iceberg") == expected_result
+        )
+
+    @pytest.mark.parametrize("table_type", ["hive", "unknown"])
+    def test_format_boolean_partition_non_iceberg_raises(self, table_type):
+        # Hive (the default) does not support boolean partition columns (HIVE-6590).
+        with pytest.raises(ValueError, match="Unsupported column type: boolean"):
+            self.adapter.format_value_for_partition(True, "boolean", table_type)
+
+    def test_format_boolean_partition_defaults_to_hive(self):
+        # Two-argument callers keep the pre-existing behavior (raise on boolean).
+        with pytest.raises(ValueError, match="Unsupported column type: boolean"):
+            self.adapter.format_value_for_partition(True, "boolean")
+
     def test_format_unsupported_type(self):
         with pytest.raises(ValueError):
             self.adapter.format_value_for_partition("test", "unsupported_type")

--- a/dbt-athena/tests/unit/test_get_partition_batches.py
+++ b/dbt-athena/tests/unit/test_get_partition_batches.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import jinja2
+import pytest
 
 # Directory containing the macro files
 _HELPERS_DIR = os.path.normpath(
@@ -72,10 +73,12 @@ def _format_one_partition_key(key):
     return f'"{key}"'
 
 
-def _format_value_for_partition(value, column_type):
+def _format_value_for_partition(value, column_type, table_type="hive"):
     """Stub for adapter.format_value_for_partition.
 
-    Returns (formatted_value, comparison_operator).
+    Returns (formatted_value, comparison_operator). Mirrors the real method:
+    booleans are only valid on iceberg (Hive rejects them, HIVE-6590), and
+    unsupported column types raise.
     """
     if value is None:
         return ("''", " IS NULL -- ")
@@ -83,7 +86,11 @@ def _format_value_for_partition(value, column_type):
         return (f"DATE'{value}'", "=")
     if column_type == "integer" or column_type == "bigint":
         return (str(value), "=")
-    return (f"'{value}'", "=")
+    if column_type in ("string", "varchar"):
+        return (f"'{value}'", "=")
+    if column_type == "boolean" and table_type == "iceberg":
+        return (str(value).lower(), "=")
+    raise ValueError(f"Unsupported column type: {column_type}")
 
 
 def _render_macro(config, rows, column_types):
@@ -198,6 +205,65 @@ class TestNonBucketedBatching:
             "\"date_col\"=DATE'2024-01-01' and \"region\"='us-east-1' or "
             "\"date_col\"=DATE'2024-01-01' and \"region\"='eu-west-1'",
         ]
+
+
+class TestBooleanPartition:
+    """Boolean partition columns are valid on Iceberg but not on Hive (HIVE-6590).
+
+    The batch path (get_partition_batches) is shared by both table types, so it
+    formats booleans only when table_type='iceberg'; for hive it falls through to
+    format_value_for_partition, which raises the clear early error.
+    """
+
+    def test_iceberg_boolean_partition(self):
+        result = _render_macro(
+            config={
+                "partitioned_by": ["is_current"],
+                "partitions_limit": 100,
+                "table_type": "iceberg",
+            },
+            rows=[[True], [False]],
+            column_types=["boolean"],
+        )
+        assert result == [
+            '"is_current"=true or "is_current"=false',
+        ]
+
+    def test_iceberg_boolean_with_other_partition(self):
+        result = _render_macro(
+            config={
+                "partitioned_by": ["is_current", "region"],
+                "partitions_limit": 100,
+                "table_type": "iceberg",
+            },
+            rows=[[True, "us-east-1"], [False, "eu-west-1"]],
+            column_types=["boolean", "varchar"],
+        )
+        assert result == [
+            '"is_current"=true and "region"=\'us-east-1\' or '
+            '"is_current"=false and "region"=\'eu-west-1\'',
+        ]
+
+    def test_hive_boolean_partition_raises(self):
+        with pytest.raises(ValueError, match="Unsupported column type: boolean"):
+            _render_macro(
+                config={
+                    "partitioned_by": ["is_current"],
+                    "partitions_limit": 100,
+                    "table_type": "hive",
+                },
+                rows=[[True], [False]],
+                column_types=["boolean"],
+            )
+
+    def test_default_table_type_boolean_raises(self):
+        """table_type defaults to hive, so a boolean partition still raises."""
+        with pytest.raises(ValueError, match="Unsupported column type: boolean"):
+            _render_macro(
+                config={"partitioned_by": ["is_current"], "partitions_limit": 100},
+                rows=[[True], [False]],
+                column_types=["boolean"],
+            )
 
 
 class TestPartitionsLimitClamping:


### PR DESCRIPTION
resolves #2025

Docs: N/A — no user-facing docs change.

### Problem

dbt-athena cannot write to an **Iceberg** table partitioned by a **boolean** column once the write is large enough to hit the partition-batching fallback — even though boolean partitions are valid on Iceberg. The run fails with:

```
ValueError: Unsupported column type: boolean
```

The error is raised by dbt (in Python, before any SQL reaches Athena) on the partition-batching fallback path — the path dbt-athena takes when a single write opens more than `partitions_limit` (default 100) partitions. `get_partition_batches` (and `process_bucket_column`) call `format_value_for_partition` for each distinct partition value, and that method has no `boolean` branch, so it hits the `else` and raises.

Because the crash only happens on the batch path, a boolean-partitioned Iceberg model can build fine for a while and then fail the first time a single write crosses the 100-partition limit (large backfill, a high-fan-out `bucket(N, ...)` write, `force_batch=true`, etc.).

Boolean partition columns are **valid on Iceberg** but **not on Hive** (Athena rejects them at DDL time, see [HIVE-6590](https://issues.apache.org/jira/browse/HIVE-6590)) — which is likely why boolean was never handled here. The batch path is shared by both table types, so the fix must add boolean support for Iceberg while leaving Hive to raise a clear error.

### Solution

Add a backward-compatible `table_type` parameter (default `"hive"`) to `format_value_for_partition`. For `table_type="iceberg"`, a boolean partition value is formatted as a bare `true`/`false` literal; for hive (the default), it still raises the existing clear error. `table_type` is threaded from `get_partition_batches` into both the non-bucketed call site and `process_bucket_column`. Existing two-argument callers are unaffected.

Tests are added at both levels: the Python method (`test_adapter.py` — iceberg formats; hive/unknown/default raise) and the macro end-to-end (`test_get_partition_batches.py` — iceberg formats, hive/default raise).

#### Alternatives considered

| # | Approach | Pros | Cons |
|---|----------|------|------|
| 1 | **Unconditional `boolean` branch in `format_value_for_partition`** (format boolean for every table type) | Smallest change (one branch); no signature change | Formats boolean for Hive too, which then fails *later* at Athena with a cryptic Hive DDL error — masks that Hive genuinely can't partition by boolean (HIVE-6590). Loses the clear early error. |
| 2 | **Scope the fix in Jinja only** — branch on `table_type` inside `get_partition_batches.sql`, format boolean inline for Iceberg, else fall through to `format_value_for_partition` | No Python signature change at all; Hive keeps the clear early raise | Splits partition-value formatting across two places — boolean logic lives in Jinja while `integer`/`string`/`date`/`timestamp` stay in Python. Harder to find/test; the bucketed call site (`process_bucket_column`) isn't covered by the same branch. |
| 3 | **`table_type` parameter on `format_value_for_partition` with a default** *(this PR)* | All partition-value formatting stays in one place (Python), directly unit-testable; Iceberg formats, Hive/default raises the clear error; the default keeps every existing 2-arg caller behaving exactly as before (boolean already raised) | Adds one optional parameter to an `@available` method (a minimal, backward-compatible interface change) |

**Why #3:** #1 hides a real Hive limitation behind a worse downstream error. #2 avoids touching Python but scatters the type-handling logic and leaves the bucketed path inconsistent. #3 keeps all type formatting cohesive in the single method that owns it, preserves the clear Hive error, and — thanks to the `"hive"` default — is non-breaking for any other caller, since boolean already raised under the old two-argument signature.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
