### PR TITLE
Add dynamic workload identity token providers for Snowflake WIF/OIDC

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Features-20260617-191644.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260617-191644.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Add dynamic workload identity token providers for Snowflake WIF/OIDC; the first
+  provider, `github_actions`, mints a fresh OIDC token immediately before each Snowflake
+  connection is opened
+time: 2026-06-17T19:16:44+02:00
+custom:
+    Author: Daniel-Wiszowaty
+    Issue: "2030"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
@@ -59,6 +59,11 @@ from dbt.adapters.snowflake.record import SnowflakeRecordReplayHandle
 
 from dbt.adapters.snowflake.auth import private_key_from_file, private_key_from_string
 from dbt.adapters.snowflake.query_headers import SnowflakeMacroQueryStringSetter
+from dbt.adapters.snowflake.workload_identity import (
+    mint_workload_identity_token,
+    SUPPORTED_PROVIDERS as WORKLOAD_IDENTITY_TOKEN_PROVIDERS,
+    WorkloadIdentityTokenConfig,
+)
 
 if TYPE_CHECKING:
     import agate
@@ -132,6 +137,9 @@ class SnowflakeCredentials(Credentials):
     s3_stage_vpce_dns_name: Optional[str] = None
     workload_identity_provider: Optional[str] = None
     workload_identity_entra_resource: Optional[str] = None
+    # When set, dbt mints a fresh workload identity token before each connection
+    # open instead of using a static `token`. Mutually exclusive with `token`.
+    workload_identity_token: Optional[WorkloadIdentityTokenConfig] = None
     # Setting this to 0.0 will disable platform detection which adds query latency
     # this should only be set to a non-zero value if you are using WIF authentication
     platform_detection_timeout_seconds: Optional[float] = (
@@ -175,6 +183,42 @@ class SnowflakeCredentials(Credentials):
         if self.client_session_keep_alive is False and self.reuse_connections is None:
             self.reuse_connections = True
 
+        self._validate_workload_identity_token()
+
+    def _validate_workload_identity_token(self) -> None:
+        if self.workload_identity_token is None:
+            return
+
+        if self.token:
+            raise DbtConfigError(
+                "Invalid Snowflake profile: `token` and `workload_identity_token` cannot both "
+                "be configured. Use `token` for static token mode, or `workload_identity_token` "
+                "for dynamic token mode."
+            )
+
+        if not self.authenticator or self.authenticator.lower() != "workload_identity":
+            raise DbtConfigError(
+                "Invalid Snowflake profile: `workload_identity_token` requires "
+                "`authenticator: workload_identity`."
+            )
+
+        provider = self.workload_identity_token.provider
+        if provider not in WORKLOAD_IDENTITY_TOKEN_PROVIDERS:
+            raise DbtConfigError(
+                f"Invalid Snowflake profile: unknown workload identity token provider "
+                f"`{provider}`. Supported providers: "
+                f"{', '.join(sorted(WORKLOAD_IDENTITY_TOKEN_PROVIDERS))}."
+            )
+
+        if provider == "github_actions" and (
+            not self.workload_identity_provider
+            or self.workload_identity_provider.upper() != "OIDC"
+        ):
+            raise DbtConfigError(
+                "Invalid Snowflake profile: `workload_identity_token.provider: github_actions` "
+                "requires `workload_identity_provider: OIDC`."
+            )
+
     @property
     def type(self):
         return "snowflake"
@@ -211,6 +255,7 @@ class SnowflakeCredentials(Credentials):
             "s3_stage_vpce_dns_name",
             "workload_identity_provider",
             "workload_identity_entra_resource",
+            "workload_identity_token",
             "platform_detection_timeout_seconds",
         )
 
@@ -285,7 +330,12 @@ class SnowflakeCredentials(Credentials):
 
                 result["workload_identity_provider"] = self.workload_identity_provider
 
-                if self.token:
+                if self.workload_identity_token:
+                    # Mint a fresh token right before connecting. auth_args() runs
+                    # inside SnowflakeConnectionManager.open()'s connect() closure,
+                    # so every (re)connect and retry gets a newly minted token.
+                    result["token"] = mint_workload_identity_token(self.workload_identity_token)
+                elif self.token:
                     result["token"] = self.token
 
                 if self.workload_identity_entra_resource:

--- a/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
@@ -189,6 +189,12 @@ class SnowflakeCredentials(Credentials):
         if self.workload_identity_token is None:
             return
 
+        if not isinstance(self.workload_identity_token, WorkloadIdentityTokenConfig):
+            raise DbtConfigError(
+                "Invalid Snowflake profile: `workload_identity_token` must be a mapping with a "
+                "`provider` (and optional `audience`)."
+            )
+
         if self.token:
             raise DbtConfigError(
                 "Invalid Snowflake profile: `token` and `workload_identity_token` cannot both "
@@ -203,6 +209,15 @@ class SnowflakeCredentials(Credentials):
             )
 
         provider = self.workload_identity_token.provider
+        audience = self.workload_identity_token.audience
+        if not isinstance(provider, str) or (
+            audience is not None and not isinstance(audience, str)
+        ):
+            raise DbtConfigError(
+                "Invalid Snowflake profile: `workload_identity_token.provider` must be a string "
+                "and `workload_identity_token.audience` (if set) must be a string."
+            )
+
         if provider not in WORKLOAD_IDENTITY_TOKEN_PROVIDERS:
             raise DbtConfigError(
                 f"Invalid Snowflake profile: unknown workload identity token provider "
@@ -210,13 +225,17 @@ class SnowflakeCredentials(Credentials):
                 f"{', '.join(sorted(WORKLOAD_IDENTITY_TOKEN_PROVIDERS))}."
             )
 
-        if provider == "github_actions" and (
+        # dbt mints OIDC ID tokens, so every dynamic provider requires
+        # `workload_identity_provider: OIDC`. For other values (e.g. AWS/GCP/AZURE) the
+        # connector sources credentials from the runtime and ignores a supplied token, which
+        # would silently bypass the minted token -- reject that pairing for all providers.
+        if (
             not self.workload_identity_provider
             or self.workload_identity_provider.upper() != "OIDC"
         ):
             raise DbtConfigError(
-                "Invalid Snowflake profile: `workload_identity_token.provider: github_actions` "
-                "requires `workload_identity_provider: OIDC`."
+                "Invalid Snowflake profile: `workload_identity_token` requires "
+                "`workload_identity_provider: OIDC`."
             )
 
     @property

--- a/dbt-snowflake/src/dbt/adapters/snowflake/workload_identity.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/workload_identity.py
@@ -109,14 +109,25 @@ def _mint_github_actions_oidc_token(audience: str) -> str:
 
 
 def _github_oidc_url_with_audience(request_url: str, audience: str) -> str:
+    # urllib.parse and the HTTP client (urllib3) disagree on where the host ends when the
+    # URL contains a backslash, whitespace, or control character: urlparse can read
+    # "evil.com\\.actions.githubusercontent.com" as one trusted-looking host while urllib3
+    # dials "evil.com". Reject such URLs outright so a tampered request URL can never smuggle
+    # the bearer request token (which can itself mint identity tokens) to another host.
+    if any(ch == "\\" or ch.isspace() or ord(ch) < 0x20 for ch in request_url):
+        raise DbtRuntimeError("The GitHub Actions OIDC request URL contains invalid characters.")
     parsed = urllib.parse.urlparse(request_url)
     if parsed.scheme != "https":
         raise DbtRuntimeError("The GitHub Actions OIDC request URL must use HTTPS.")
     hostname = (parsed.hostname or "").lower()
-    if hostname != _GITHUB_OIDC_ALLOWED_HOST and not hostname.endswith(
+    is_allowed_host = hostname == _GITHUB_OIDC_ALLOWED_HOST or hostname.endswith(
         "." + _GITHUB_OIDC_ALLOWED_HOST
-    ):
-        # Fail closed rather than send the bearer request token to an unknown host.
+    )
+    has_empty_label = "" in hostname.split(".")
+    if not is_allowed_host or has_empty_label:
+        # Fail closed rather than send the bearer request token to an unknown host. The
+        # empty-label check rejects ".actions.githubusercontent.com" / trailing-dot hosts
+        # that slip past the suffix match but are not real GitHub hosts.
         raise DbtRuntimeError(
             "The GitHub Actions OIDC request URL host is not a recognized GitHub Actions host."
         )

--- a/dbt-snowflake/src/dbt/adapters/snowflake/workload_identity.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/workload_identity.py
@@ -41,6 +41,10 @@ class WorkloadIdentityTokenConfig(dbtClassMixin):
 
     This is intentionally *not* a token value -- it names the provider dbt should
     request a token from and (optionally) the audience to request it for.
+
+    Prefer an account-scoped ``audience`` (e.g. your Snowflake account URL) matching the
+    Snowflake user's ``OIDC_AUDIENCE_LIST``; the bare ``snowflakecomputing.com`` default is
+    shared across all Snowflake accounts and is therefore cross-account replayable.
     """
 
     provider: str

--- a/dbt-snowflake/src/dbt/adapters/snowflake/workload_identity.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/workload_identity.py
@@ -1,8 +1,12 @@
 """Dynamic workload identity token providers for Snowflake WIF/OIDC auth.
 
 dbt-snowflake can mint a fresh workload identity token immediately before each
-connection is opened, instead of relying on a static ``token`` that may expire
-mid-run (e.g. short-lived CI OIDC tokens).
+connection is opened, instead of relying on a static ``token`` that can expire
+before dbt opens a *later* connection (e.g. short-lived CI OIDC tokens on long
+or highly-parallel runs, where late-starting threads, connection-pool misses, or
+reconnects open connections after the source token's TTL). The token is consumed
+only at connection open; an already-open connection is kept alive by Snowflake's
+own session/master tokens and does not need the source token re-minted.
 
 Adding a provider:
     1. write a ``_mint_<provider>(config) -> str`` function below

--- a/dbt-snowflake/src/dbt/adapters/snowflake/workload_identity.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/workload_identity.py
@@ -1,0 +1,130 @@
+"""Dynamic workload identity token providers for Snowflake WIF/OIDC auth.
+
+dbt-snowflake can mint a fresh workload identity token immediately before each
+connection is opened, instead of relying on a static ``token`` that may expire
+mid-run (e.g. short-lived CI OIDC tokens).
+
+Adding a provider:
+    1. write a ``_mint_<provider>(config) -> str`` function below
+    2. register it in ``_PROVIDERS``
+
+``connections.py`` never needs to change to add a provider. Each provider is
+responsible for returning a valid token string or raising a dbt error. Tokens
+and raw provider responses must never be logged.
+"""
+
+import os
+import urllib.parse
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+import requests
+
+from dbt_common.dataclass_schema import dbtClassMixin
+from dbt_common.exceptions import DbtConfigError, DbtRuntimeError
+
+
+GITHUB_OIDC_DEFAULT_AUDIENCE = "snowflakecomputing.com"
+# GitHub Actions OIDC tokens are only ever requested from this host family. The
+# request carries a bearer token that can itself mint identity tokens, so we
+# refuse to send it anywhere else even if the request-URL env var is tampered with.
+_GITHUB_OIDC_ALLOWED_HOST = "actions.githubusercontent.com"
+
+
+@dataclass
+class WorkloadIdentityTokenConfig(dbtClassMixin):
+    """How to mint a fresh workload identity token at connection-open time.
+
+    This is intentionally *not* a token value -- it names the provider dbt should
+    request a token from and (optionally) the audience to request it for.
+    """
+
+    provider: str
+    audience: Optional[str] = None
+
+
+def mint_workload_identity_token(config: WorkloadIdentityTokenConfig) -> str:
+    """Mint a fresh token for the configured provider. Fails closed."""
+    minter = _PROVIDERS.get(config.provider)
+    if minter is None:
+        raise DbtConfigError(
+            f"Unknown workload identity token provider `{config.provider}`. "
+            f"Supported providers: {', '.join(sorted(SUPPORTED_PROVIDERS))}."
+        )
+    return minter(config)
+
+
+def _github_actions_provider(config: WorkloadIdentityTokenConfig) -> str:
+    return _mint_github_actions_oidc_token(config.audience or GITHUB_OIDC_DEFAULT_AUDIENCE)
+
+
+def _mint_github_actions_oidc_token(audience: str) -> str:
+    """Request a fresh OIDC token from the GitHub Actions runtime.
+
+    Reads only the standard GitHub Actions OIDC environment variables. The token
+    value and the raw endpoint response are never logged or placed in error
+    messages, since the success response body is itself the token.
+    """
+    request_url = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL")
+    request_token = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+    if not request_url or not request_token:
+        raise DbtConfigError(
+            "Minting a GitHub Actions OIDC token requires the "
+            "ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN "
+            "environment variables. Ensure the workflow grants the "
+            "`id-token: write` permission."
+        )
+
+    url = _github_oidc_url_with_audience(request_url, audience)
+    try:
+        response = requests.get(
+            url,
+            headers={"Authorization": f"bearer {request_token}"},
+            timeout=30,
+            allow_redirects=False,
+        )
+    except requests.RequestException as exc:
+        raise DbtRuntimeError("Failed to reach the GitHub Actions OIDC token endpoint.") from exc
+
+    if response.status_code != 200:
+        raise DbtRuntimeError(
+            f"The GitHub Actions OIDC token endpoint returned status {response.status_code}."
+        )
+
+    try:
+        value = response.json().get("value")
+    except ValueError:
+        # `from None`: the response body is the token on success; never echo it.
+        raise DbtRuntimeError(
+            "The GitHub Actions OIDC token endpoint returned a non-JSON response."
+        ) from None
+
+    if not value:
+        raise DbtRuntimeError("The GitHub Actions OIDC token endpoint returned no token value.")
+    return value
+
+
+def _github_oidc_url_with_audience(request_url: str, audience: str) -> str:
+    parsed = urllib.parse.urlparse(request_url)
+    if parsed.scheme != "https":
+        raise DbtRuntimeError("The GitHub Actions OIDC request URL must use HTTPS.")
+    hostname = (parsed.hostname or "").lower()
+    if hostname != _GITHUB_OIDC_ALLOWED_HOST and not hostname.endswith(
+        "." + _GITHUB_OIDC_ALLOWED_HOST
+    ):
+        # Fail closed rather than send the bearer request token to an unknown host.
+        raise DbtRuntimeError(
+            "The GitHub Actions OIDC request URL host is not a recognized GitHub Actions host."
+        )
+    query = dict(urllib.parse.parse_qsl(parsed.query))
+    query["audience"] = audience
+    return urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(query)))
+
+
+# provider name -> callable that mints a token from a WorkloadIdentityTokenConfig.
+# Add new providers here; connection handling does not change.
+_PROVIDERS: Dict[str, Callable[[WorkloadIdentityTokenConfig], str]] = {
+    "github_actions": _github_actions_provider,
+}
+
+SUPPORTED_PROVIDERS = tuple(_PROVIDERS)

--- a/dbt-snowflake/tests/functional/auth_tests/test_workload_identity_federation_oidc.py
+++ b/dbt-snowflake/tests/functional/auth_tests/test_workload_identity_federation_oidc.py
@@ -11,61 +11,72 @@ Prerequisites for testing WIF with OIDC:
     WORKLOAD_IDENTITY = (
       TYPE = OIDC,
       ISSUER = 'https://token.actions.githubusercontent.com',
-      SUBJECT = 'repo:<REPO_OWNER>/dbt-adapters:ref:refs/heads/main',
-      OIDC_AUDIENCE_LIST = ('snowflakecomputing.com')
+      -- SUBJECT is the authorization boundary: any GitHub workflow whose OIDC `sub`
+      -- claim matches this string can authenticate as this Snowflake user.
+      SUBJECT = 'repo:<REPO_OWNER>/<REPO>:ref:refs/heads/main',
+      -- Use an ACCOUNT-SCOPED audience. The bare 'snowflakecomputing.com' default is
+      -- shared across every Snowflake account, so a leaked token is replayable against
+      -- any other tenant that also left the default.
+      OIDC_AUDIENCE_LIST = ('https://<orgname>-<account_name>.snowflakecomputing.com')
     );
   ```
 
-2. **Create a GitHub Actions that generates the OIDC token and runs the test **
+  Scoping the trust (read this). The Snowflake-side trust -- not dbt -- is the real
+  authorization boundary; dbt only fetches a token. Mis-scoping SUBJECT is a single point
+  of total compromise:
+    - DO pin to a specific branch (`:ref:refs/heads/main`) or, better, a protected GitHub
+      Environment (`:environment:prod`, gated by required reviewers / branch rules).
+    - DON'T trust `:pull_request` subjects -- anyone who can open a PR (incl. forks on a
+      public repo) could then authenticate as this user.
+    - DON'T use org-wide / any-branch / wildcard subjects.
+    - Back the service user with a least-privilege role. To revoke, run
+      `ALTER USER <username> UNSET WORKLOAD_IDENTITY` (or re-point SUBJECT) -- there is no
+      GitHub-side revocation for an already-minted token.
+
+2. **GitHub Actions workflow that mints the OIDC token and runs the test**
 
   ```yaml
+  name: Run Snowflake Workload Identity Federation (WIF) Test
+  on:
+    workflow_dispatch:
+    push:
+      branches: [ main ]
 
-name: Run Snowflake Workload Identity Federation (WIF) Test
-on:
-  workflow_dispatch:
-  push:
-    branches: [ main ]
+  # Grant id-token: write at the JOB level only (below), never at workflow level --
+  # workflow-level would let every job in the workflow mint identity tokens.
+  permissions: {}
 
-permissions:
-  contents: read
-  id-token: write
-
-jobs:
-  run-snowflake:
-    runs-on: ubuntu-latest
-    env:
-      SNOWFLAKE_TEST_ACCOUNT: <ACCOUNT_ID>
-      SNOWFLAKE_TEST_DATABASE: <DB_NAME>
-      SNOWFLAKE_TEST_WAREHOUSE: <WH_NAME>
-      SNOWFLAKE_TEST_ROLE: <ROLE_NAME>
-      SNOWFLAKE_TEST_USER: <USERNAME>
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get OIDC token for Snowflake
-        id: oidc
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const token = await core.getIDToken('snowflakecomputing.com');
-            core.setOutput('id_token', token);
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - uses: pypa/hatch@install
-
-      - run: hatch run setup
-        working-directory: ./dbt-snowflake
-
-      - run: hatch run python -m pytest tests/functional/auth_tests/test_workload_identity_federation_oidc.py
-        working-directory: ./dbt-snowflake
-        env:
-          ODIC_TOKEN: ${{ steps.oidc.outputs.id_token }}
+  jobs:
+    run-snowflake:
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        id-token: write
+      env:
+        SNOWFLAKE_TEST_ACCOUNT: <ACCOUNT_ID>
+        SNOWFLAKE_TEST_DATABASE: <DB_NAME>
+        SNOWFLAKE_TEST_WAREHOUSE: <WH_NAME>
+        SNOWFLAKE_TEST_ROLE: <ROLE_NAME>
+        SNOWFLAKE_TEST_WIF_USER: <USERNAME>
+        # Must match OIDC_AUDIENCE_LIST on the Snowflake user (account-scoped).
+        SNOWFLAKE_TEST_WIF_AUDIENCE: https://<orgname>-<account_name>.snowflakecomputing.com
+      steps:
+        # Pin third-party actions to a full commit SHA in production (tags shown for brevity).
+        - uses: actions/checkout@v4
+        - uses: actions/setup-python@v5
+          with:
+            python-version: '3.11'
+        - uses: pypa/hatch@install
+        - run: hatch run setup
+          working-directory: ./dbt-snowflake
+        # GitHub injects ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN into this job (id-token: write);
+        # both the static helper and dbt's dynamic provider mint from those automatically.
+        - run: hatch run python -m pytest tests/functional/auth_tests/test_workload_identity_federation_oidc.py
+          working-directory: ./dbt-snowflake
   ```
+
+  Do NOT run this on `pull_request_target` / `workflow_run` jobs that execute untrusted
+  (fork) code: such a job can mint a token for your Snowflake audience from attacker code.
 
 """
 
@@ -75,6 +86,12 @@ from time import sleep
 import requests
 from dbt.tests.util import run_dbt
 import pytest
+
+
+# Audience for the minted OIDC token. Use an account-scoped value (set via env) so it
+# matches the Snowflake user's OIDC_AUDIENCE_LIST; the bare default is shared across all
+# Snowflake accounts and is only a convenience fallback for local testing.
+_WIF_AUDIENCE = os.getenv("SNOWFLAKE_TEST_WIF_AUDIENCE", "snowflakecomputing.com")
 
 
 _MODELS__MODEL_1_SQL = """
@@ -96,7 +113,7 @@ def _mint_github_oidc_token():
         return os.getenv("OIDC_TOKEN")
 
     headers = {"Authorization": f"bearer {bearer}"}
-    target = f"{url}&audience=snowflakecomputing.com"
+    target = f"{url}&audience={_WIF_AUDIENCE}"
     for _ in range(5):
         result = requests.get(target, headers=headers)
         try:
@@ -166,7 +183,7 @@ class TestSnowflakeWorkloadIdentityFederationDynamicToken:
             "workload_identity_provider": "oidc",
             "workload_identity_token": {
                 "provider": "github_actions",
-                "audience": "snowflakecomputing.com",
+                "audience": _WIF_AUDIENCE,
             },
         }
 

--- a/dbt-snowflake/tests/functional/auth_tests/test_workload_identity_federation_oidc.py
+++ b/dbt-snowflake/tests/functional/auth_tests/test_workload_identity_federation_oidc.py
@@ -133,3 +133,49 @@ class TestSnowflakeWorkloadIdentityFederation:
     def test_snowflake_wif_basic_functionality(self, project):
         """Test basic dbt functionality with WIF authentication"""
         run_dbt()
+
+
+_HAS_GITHUB_ACTIONS_OIDC = bool(
+    os.getenv("ACTIONS_ID_TOKEN_REQUEST_URL") and os.getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+)
+
+
+@pytest.mark.skipif(
+    not _HAS_GITHUB_ACTIONS_OIDC,
+    reason="requires the GitHub Actions OIDC runtime "
+    "(ACTIONS_ID_TOKEN_REQUEST_URL / ACTIONS_ID_TOKEN_REQUEST_TOKEN)",
+)
+class TestSnowflakeWorkloadIdentityFederationDynamicToken:
+    """Dynamic-token WIF: dbt mints a fresh OIDC token before each connection open.
+
+    Unlike the static-token class above, no `token` is configured -- the
+    `github_actions` provider mints one at connection-open time.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def dbt_profile_target(self):
+        return {
+            "type": "snowflake",
+            "threads": 4,
+            "account": os.getenv("SNOWFLAKE_TEST_ACCOUNT"),
+            "user": os.getenv("SNOWFLAKE_TEST_WIF_USER"),
+            "database": os.getenv("SNOWFLAKE_TEST_DATABASE"),
+            "warehouse": os.getenv("SNOWFLAKE_TEST_WAREHOUSE"),
+            "role": os.getenv("SNOWFLAKE_TEST_ROLE"),
+            "authenticator": "workload_identity",
+            "workload_identity_provider": "oidc",
+            "workload_identity_token": {
+                "provider": "github_actions",
+                "audience": "snowflakecomputing.com",
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_1.sql": _MODELS__MODEL_1_SQL,
+        }
+
+    def test_snowflake_wif_dynamic_token(self, project):
+        """dbt mints a fresh GitHub Actions OIDC token per connection open."""
+        run_dbt()

--- a/dbt-snowflake/tests/unit/test_connections.py
+++ b/dbt-snowflake/tests/unit/test_connections.py
@@ -7,6 +7,7 @@ import multiprocessing
 from dbt.adapters.exceptions.connection import FailedToConnectError
 from dbt_common.exceptions import DbtConfigError
 import dbt.adapters.snowflake.connections as connections
+import dbt.adapters.snowflake.workload_identity as workload_identity
 import dbt.adapters.events.logging
 
 
@@ -347,3 +348,118 @@ def test_connnections_credentials_wif_authenticator_fails_with_entra_resource_an
         "workload_identity_entra_resource can only be set if workload_identity_provider is Azure"
         in str(excinfo)
     )
+
+
+# ---------------------------------------------------------------------------
+# Dynamic workload identity token (WIF/OIDC) provider config
+# ---------------------------------------------------------------------------
+
+_WIF_TOKEN_BASE = {
+    "account": "account",
+    "database": "database",
+    "warehouse": "warehouse",
+    "schema": "schema",
+    "user": "user",
+    "authenticator": "workload_identity",
+    "workload_identity_provider": "OIDC",
+}
+
+
+def _gha_response(value="minted_token", status_code=200, json_value=None):
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = {"value": value} if json_value is None else json_value
+    return response
+
+
+def test_wif_token_github_actions_parses():
+    creds = connections.SnowflakeCredentials.from_dict(
+        {
+            **_WIF_TOKEN_BASE,
+            "workload_identity_token": {
+                "provider": "github_actions",
+                "audience": "snowflakecomputing.com",
+            },
+        }
+    )
+    assert isinstance(creds.workload_identity_token, connections.WorkloadIdentityTokenConfig)
+    assert creds.workload_identity_token.provider == "github_actions"
+    assert creds.workload_identity_token.audience == "snowflakecomputing.com"
+
+
+def test_wif_token_default_audience_is_none_until_minted():
+    creds = connections.SnowflakeCredentials.from_dict(
+        {**_WIF_TOKEN_BASE, "workload_identity_token": {"provider": "github_actions"}}
+    )
+    assert creds.workload_identity_token.audience is None
+
+
+def test_wif_token_and_static_token_are_mutually_exclusive():
+    with pytest.raises(DbtConfigError) as excinfo:
+        connections.SnowflakeCredentials.from_dict(
+            {
+                **_WIF_TOKEN_BASE,
+                "token": "static-token",
+                "workload_identity_token": {"provider": "github_actions"},
+            }
+        )
+    assert "cannot both" in str(excinfo.value)
+
+
+def test_wif_token_requires_workload_identity_authenticator():
+    with pytest.raises(DbtConfigError) as excinfo:
+        connections.SnowflakeCredentials.from_dict(
+            {
+                **_WIF_TOKEN_BASE,
+                "authenticator": "snowflake",
+                "workload_identity_token": {"provider": "github_actions"},
+            }
+        )
+    assert "requires `authenticator: workload_identity`" in str(excinfo.value)
+
+
+def test_wif_token_github_actions_requires_oidc_provider():
+    with pytest.raises(DbtConfigError) as excinfo:
+        connections.SnowflakeCredentials.from_dict(
+            {
+                **_WIF_TOKEN_BASE,
+                "workload_identity_provider": "AWS",
+                "workload_identity_token": {"provider": "github_actions"},
+            }
+        )
+    assert "requires `workload_identity_provider: OIDC`" in str(excinfo.value)
+
+
+def test_wif_token_unknown_provider_rejected():
+    with pytest.raises(DbtConfigError) as excinfo:
+        connections.SnowflakeCredentials.from_dict(
+            {**_WIF_TOKEN_BASE, "workload_identity_token": {"provider": "random_ci"}}
+        )
+    assert "unknown workload identity token provider" in str(excinfo.value)
+    assert "github_actions" in str(excinfo.value)
+
+
+def test_wif_token_minted_fresh_per_auth_args(monkeypatch):
+    """Regression: each auth_args() (i.e. each connection open/retry) mints a new token."""
+    monkeypatch.setenv(
+        "ACTIONS_ID_TOKEN_REQUEST_URL",
+        "https://token.actions.githubusercontent.com/req?api-version=2.0",
+    )
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "bearer-secret")
+
+    creds = connections.SnowflakeCredentials.from_dict(
+        {**_WIF_TOKEN_BASE, "workload_identity_token": {"provider": "github_actions"}}
+    )
+
+    with patch.object(
+        workload_identity.requests,
+        "get",
+        side_effect=[_gha_response("token_1"), _gha_response("token_2")],
+    ):
+        first = creds.auth_args()
+        second = creds.auth_args()
+
+    assert first["authenticator"] == connections.WORKLOAD_IDENTITY_AUTHENTICATOR
+    assert first["workload_identity_provider"] == "OIDC"
+    assert first["token"] == "token_1"
+    assert second["token"] == "token_2"

--- a/dbt-snowflake/tests/unit/test_connections.py
+++ b/dbt-snowflake/tests/unit/test_connections.py
@@ -439,6 +439,42 @@ def test_wif_token_unknown_provider_rejected():
     assert "github_actions" in str(excinfo.value)
 
 
+def test_wif_token_non_string_provider_rejected():
+    # A malformed profile (provider as a nested mapping) must fail with a clear config
+    # error, not an AttributeError/TypeError leaking out of dispatch.
+    with pytest.raises(DbtConfigError) as excinfo:
+        connections.SnowflakeCredentials.from_dict(
+            {**_WIF_TOKEN_BASE, "workload_identity_token": {"provider": {"nested": "dict"}}}
+        )
+    assert "must be a string" in str(excinfo.value)
+
+
+def test_wif_token_non_string_audience_rejected():
+    with pytest.raises(DbtConfigError) as excinfo:
+        connections.SnowflakeCredentials.from_dict(
+            {
+                **_WIF_TOKEN_BASE,
+                "workload_identity_token": {"provider": "github_actions", "audience": ["a", "b"]},
+            }
+        )
+    assert "must be a string" in str(excinfo.value)
+
+
+def test_wif_token_requires_oidc_for_any_provider():
+    # The OIDC-provider requirement is general (not github_actions-specific): a dynamic
+    # token paired with a non-OIDC workload_identity_provider would be silently ignored by
+    # the connector in favor of ambient cloud credentials, so it must be rejected.
+    with pytest.raises(DbtConfigError) as excinfo:
+        connections.SnowflakeCredentials.from_dict(
+            {
+                **_WIF_TOKEN_BASE,
+                "workload_identity_provider": "GCP",
+                "workload_identity_token": {"provider": "github_actions"},
+            }
+        )
+    assert "requires `workload_identity_provider: OIDC`" in str(excinfo.value)
+
+
 def test_wif_token_minted_fresh_per_auth_args(monkeypatch):
     """Regression: each auth_args() (i.e. each connection open/retry) mints a new token."""
     monkeypatch.setenv(

--- a/dbt-snowflake/tests/unit/test_workload_identity.py
+++ b/dbt-snowflake/tests/unit/test_workload_identity.py
@@ -1,0 +1,119 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from dbt_common.exceptions import DbtConfigError, DbtRuntimeError
+import dbt.adapters.snowflake.workload_identity as wif
+
+
+_GHA_URL = "https://token.actions.githubusercontent.com/req"
+
+
+def _gha_response(value="minted_token", status_code=200, json_value=None):
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = {"value": value} if json_value is None else json_value
+    return response
+
+
+def _set_gha_env(monkeypatch, url=_GHA_URL, token="bearer-secret"):
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", url)
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", token)
+
+
+def test_mint_dispatch_unknown_provider_fails_closed():
+    config = wif.WorkloadIdentityTokenConfig(provider="random_ci")
+    with pytest.raises(DbtConfigError) as excinfo:
+        wif.mint_workload_identity_token(config)
+    assert "Unknown workload identity token provider" in str(excinfo.value)
+    assert "github_actions" in str(excinfo.value)
+
+
+def test_mint_dispatch_github_actions_uses_default_audience(monkeypatch):
+    _set_gha_env(monkeypatch)
+    config = wif.WorkloadIdentityTokenConfig(provider="github_actions")  # no audience
+    with patch.object(wif.requests, "get", return_value=_gha_response()) as get:
+        wif.mint_workload_identity_token(config)
+    assert f"audience={wif.GITHUB_OIDC_DEFAULT_AUDIENCE}" in get.call_args[0][0]
+
+
+def test_github_oidc_requires_env_vars(monkeypatch):
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
+    with pytest.raises(DbtConfigError) as excinfo:
+        wif._mint_github_actions_oidc_token("snowflakecomputing.com")
+    assert "id-token: write" in str(excinfo.value)
+
+
+def test_github_oidc_returns_token_value_and_hardened_request(monkeypatch):
+    _set_gha_env(monkeypatch)
+    with patch.object(wif.requests, "get", return_value=_gha_response("the-token")) as get:
+        token = wif._mint_github_actions_oidc_token("snowflakecomputing.com")
+    assert token == "the-token"
+    _, kwargs = get.call_args
+    assert kwargs["headers"]["Authorization"] == "bearer bearer-secret"
+    assert kwargs["allow_redirects"] is False
+    assert kwargs["timeout"] == 30
+
+
+def test_github_oidc_adds_audience_query_param(monkeypatch):
+    _set_gha_env(monkeypatch)
+    with patch.object(wif.requests, "get", return_value=_gha_response()) as get:
+        wif._mint_github_actions_oidc_token("snowflakecomputing.com")
+    assert "audience=snowflakecomputing.com" in get.call_args[0][0]
+
+
+def test_github_oidc_replaces_existing_audience():
+    url = wif._github_oidc_url_with_audience(
+        "https://token.actions.githubusercontent.com/req?audience=old&api-version=2.0",
+        "snowflakecomputing.com",
+    )
+    assert "audience=snowflakecomputing.com" in url
+    assert "audience=old" not in url
+    assert "api-version=2.0" in url
+
+
+def test_github_oidc_missing_value_errors(monkeypatch):
+    _set_gha_env(monkeypatch)
+    with patch.object(wif.requests, "get", return_value=_gha_response(json_value={})):
+        with pytest.raises(DbtRuntimeError) as excinfo:
+            wif._mint_github_actions_oidc_token("snowflakecomputing.com")
+    assert "no token value" in str(excinfo.value)
+
+
+def test_github_oidc_non_json_errors(monkeypatch):
+    _set_gha_env(monkeypatch)
+    response = Mock()
+    response.status_code = 200
+    response.json.side_effect = ValueError("not json")
+    with patch.object(wif.requests, "get", return_value=response):
+        with pytest.raises(DbtRuntimeError) as excinfo:
+            wif._mint_github_actions_oidc_token("snowflakecomputing.com")
+    assert "non-JSON" in str(excinfo.value)
+
+
+def test_github_oidc_non_200_does_not_leak_response_body(monkeypatch):
+    _set_gha_env(monkeypatch)
+    leaky = Mock()
+    leaky.status_code = 403
+    leaky.text = "SUPER_SECRET_TOKEN_BODY"
+    leaky.json.return_value = {"value": "SUPER_SECRET_TOKEN_BODY"}
+    with patch.object(wif.requests, "get", return_value=leaky):
+        with pytest.raises(DbtRuntimeError) as excinfo:
+            wif._mint_github_actions_oidc_token("snowflakecomputing.com")
+    message = str(excinfo.value)
+    assert "403" in message
+    assert "SUPER_SECRET_TOKEN_BODY" not in message
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "http://token.actions.githubusercontent.com/req",  # not https
+        "https://evil.example.com/req",  # wrong host
+        "https://token.actions.githubusercontent.com@evil.example.com/req",  # userinfo trick
+    ],
+)
+def test_github_oidc_url_rejects_untrusted_targets(bad_url):
+    with pytest.raises(DbtRuntimeError):
+        wif._github_oidc_url_with_audience(bad_url, "snowflakecomputing.com")

--- a/dbt-snowflake/tests/unit/test_workload_identity.py
+++ b/dbt-snowflake/tests/unit/test_workload_identity.py
@@ -112,6 +112,11 @@ def test_github_oidc_non_200_does_not_leak_response_body(monkeypatch):
         "http://token.actions.githubusercontent.com/req",  # not https
         "https://evil.example.com/req",  # wrong host
         "https://token.actions.githubusercontent.com@evil.example.com/req",  # userinfo trick
+        # parser-differential: urlparse sees a trusted suffix, urllib3 dials evil.com
+        "https://evil.com\\.actions.githubusercontent.com/req",
+        "https://evil.com\\x.actions.githubusercontent.com/req",
+        "https://.actions.githubusercontent.com/req",  # empty-label host
+        "https://token.actions.githubusercontent.com\t/req",  # control/whitespace char
     ],
 )
 def test_github_oidc_url_rejects_untrusted_targets(bad_url):


### PR DESCRIPTION
resolves #2030
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/# _(docs follow-up TBD)_

### Problem

`dbt-snowflake` supports Snowflake Workload Identity Federation (WIF) via #1316, but only with a **static** `token`:

```yaml
authenticator: workload_identity
workload_identity_provider: OIDC
token: "{{ env_var('SNOWFLAKE_TOKEN') }}"
```

The connector consumes this token only when a connection is **opened**. Snowflake then issues its own session/master tokens that keep an open connection alive (master token ~4h, auto-renewed), independent of the source OIDC token — so in-flight queries on already-open connections are unaffected by the source token expiring. The connector also does **not** re-mint OIDC tokens itself: for `workload_identity_provider: OIDC` it requires a caller-supplied `token` (unlike AWS/Azure/GCP, which it sources from the runtime).

So the failure mode is specific: with a short-lived CI OIDC token (e.g. GitHub Actions, ~5–15 min TTL), any connection dbt **opens or reopens after the token has expired** fails — late-starting threads, connection-pool misses, and reconnects on a long or highly-parallel run. A token minted once at workflow start cannot cover those later opens.

### When to use this (and when not to)

This is for teams that specifically want **keyless** WIF/OIDC — no long-lived secret at rest, federated trust to the CI identity. If you don't have that requirement, simpler options avoid the expiry window entirely:

- **Key-pair auth** sidesteps the problem with no new config behavior: the connector mints a fresh short-lived JWT from your private key on *every* connect and auto-renews the session. There is no caller-supplied token to expire. Prefer this unless a policy forbids storing a private key.
- **Static `token`** is sufficient for runs that comfortably finish within the OIDC TTL and don't open connections late.

dbt's default `reuse_connections: true` further narrows the window by pooling one open connection per thread, so dynamic minting earns its keep mainly on parallel/late-opening runs, reconnects, and `reuse_connections: false`.

### Solution

Add a `workload_identity_token` provider config. When set, dbt mints a **fresh** token immediately before each connection open:

```yaml
authenticator: workload_identity
workload_identity_provider: OIDC
workload_identity_token:
  provider: github_actions
  audience: snowflakecomputing.com   # defaults to snowflakecomputing.com
```

Minting happens inside `SnowflakeConnectionManager.open()`'s `connect()` closure, so every (re)connect and retry gets a newly minted token. Static `token` mode is unchanged and remains supported; the two modes are mutually exclusive.

The first provider is `github_actions`, which uses the standard GitHub Actions OIDC env vars (`ACTIONS_ID_TOKEN_REQUEST_URL`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN`; workflow needs `permissions: id-token: write`).

**Design.** Providers live in a dedicated `workload_identity.py` module with a small dict dispatch (`provider name -> _mint_<provider>(config)`). Adding a provider (GCP, Azure, Vault, …) is one function + one dict entry and never touches connection code. I deliberately avoided a `Protocol`/registry/factory abstraction for what is currently one provider. (Note: env-var-injected CI tokens such as GitLab CI `id_tokens` and CircleCI `CIRCLE_OIDC_TOKEN` are *not* candidates for a provider — they're pre-minted and already covered by static `token` mode.)

**Security.**
- No arbitrary command execution — providers are adapter-owned Python, not shell hooks from `profiles.yml`.
- Explicit opt-in — nothing is minted unless `workload_identity_token` is configured.
- `token` and `workload_identity_token` are mutually exclusive (validation fails fast with a clear error), so there is no ambiguous precedence.
- The GitHub OIDC request is pinned to the `*.actions.githubusercontent.com` host family (rejecting `http`, foreign hosts, and `user@host` tricks), with redirects disabled and a 30s timeout — the bearer request token can itself mint identity tokens, so it must never be sent elsewhere.
- Token values and raw endpoint responses are never logged or placed in error messages (the OIDC success body *is* the token).
- Fails closed: a minting failure aborts the connection; there is no stale-token fallback and no token cache in v1, so each open mints fresh (also keeps it thread-safe — no shared mutable state).
- Snowflake-side WIF trust (issuer/subject/audience) remains the real authorization boundary.

### Operational security (deployment hardening)

Because the Snowflake-side WIF trust is the real authorization boundary, most of this feature's security lives in how the operator configures it. The setup guide (the test docstring) now spells this out:

- **Account-scoped audience.** Use an account-scoped `OIDC_AUDIENCE_LIST` (e.g. `https://<org>-<account>.snowflakecomputing.com`), not the bare `snowflakecomputing.com` default — Snowflake shares that value across all accounts, making a leaked token cross-account replayable. (The code keeps `snowflakecomputing.com` as a back-compat default; the docs steer to account-scoping.)
- **Tight SUBJECT.** Pin to a specific branch or, better, a protected GitHub Environment; never `:pull_request`, org-wide, or wildcard subjects; never trust forks.
- **Job-level `id-token: write`** (not workflow level); pin third-party actions by SHA; don't run on `pull_request_target` / `workflow_run` of untrusted code.
- **Least-privilege role** on the service user; revoke via `ALTER USER ... UNSET WORKLOAD_IDENTITY` (there is no GitHub-side revocation of an already-minted token).

A 5-way security review also caught and fixed a host-allowlist bypass: a URL such as `https://evil.com\.actions.githubusercontent.com/...` parsed as a trusted host by `urllib.parse` while `requests` dialed `evil.com`. The validator now rejects backslash / whitespace / control-character URLs and empty-label hosts before the request is made, so the bearer request token cannot be smuggled off-host. The `*.actions.githubusercontent.com` suffix allowlist is retained (the real request-URL host varies within that zone).

### Tests

- Unit: nested config parsing; default audience; the four validation rules (mutual exclusivity, requires `authenticator: workload_identity`, `github_actions` requires `workload_identity_provider: OIDC`, unknown provider); GitHub minting (env-var requirement, audience add/replace, returns `value`, missing value, non-JSON, non-200 does not leak the body, SSRF host/scheme/userinfo rejection); dispatch fails closed; and a regression proving two opens mint two different tokens.
- Functional: a dynamic-mode WIF/OIDC test alongside the existing static one, skipped when not running on a GitHub Actions OIDC runner.

`black`, `flake8`, and `mypy` pass; all unit tests pass locally.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests
- [ ] This PR has interface changes (a new `workload_identity_token` profile config) and may need Product/DX feedback
