### PR TITLE
Fix Snowflake WIF (OIDC) auth tripping token/user profile validation

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20260618-120000.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260618-120000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Allow Workload Identity Federation (e.g. OIDC) auth to use a token without a
+  user by exempting the workload_identity authenticator from the token/user profile
+  validation
+time: 2026-06-18T12:00:00.000000-05:00
+custom:
+  Author: tauhid621
+  Issue: ""

--- a/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
@@ -147,19 +147,25 @@ class SnowflakeCredentials(Credentials):
                 )
             )
 
-        if self.authenticator not in ["oauth", "jwt", "programmatic_access_token"]:
+        if self.authenticator not in [
+            "oauth",
+            "jwt",
+            "programmatic_access_token",
+            "workload_identity",
+        ]:
             if self.token:
                 warn_or_error(
                     AdapterEventWarning(
                         base_msg=(
-                            "The token parameter was set, but the authenticator was "
-                            "not set to 'oauth', 'jwt', or 'programmatic_access_token'."
+                            "The token parameter was set, but the authenticator was not set "
+                            "to 'oauth', 'jwt', 'programmatic_access_token', or 'workload_identity'."
                         )
                     )
                 )
 
             if not self.user:
-                # The user attribute is only optional if 'authenticator' is 'jwt' or 'oauth'
+                # The user attribute is only optional if 'authenticator' is
+                # 'jwt', 'oauth', 'programmatic_access_token', or 'workload_identity'
                 warn_or_error(
                     AdapterEventError(base_msg="Invalid profile: 'user' is a required property.")
                 )

--- a/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
@@ -139,11 +139,7 @@ class SnowflakeCredentials(Credentials):
     )
 
     def __post_init__(self):
-        # normalize once so authenticator comparisons are case-insensitive and
-        # consistent with auth_args() (e.g. accept 'WORKLOAD_IDENTITY')
-        authenticator = (self.authenticator or "").lower()
-
-        if authenticator != "oauth" and (self.oauth_client_secret or self.oauth_client_id):
+        if self.authenticator != "oauth" and (self.oauth_client_secret or self.oauth_client_id):
             # the user probably forgot to set 'authenticator' like I keep doing
             warn_or_error(
                 AdapterEventWarning(
@@ -151,12 +147,13 @@ class SnowflakeCredentials(Credentials):
                 )
             )
 
-        if authenticator not in [
-            "oauth",
-            "jwt",
-            "programmatic_access_token",
-            "workload_identity",
-        ]:
+        # workload_identity is matched case-insensitively to mirror auth_args(); the
+        # other authenticators stay case-sensitive to preserve existing behavior
+        is_workload_identity = (self.authenticator or "").lower() == "workload_identity"
+        if (
+            self.authenticator not in ["oauth", "jwt", "programmatic_access_token"]
+            and not is_workload_identity
+        ):
             if self.token:
                 warn_or_error(
                     AdapterEventWarning(
@@ -243,10 +240,8 @@ class SnowflakeCredentials(Credentials):
         if self.protocol:
             result["protocol"] = self.protocol
         if self.authenticator:
-            # match case-insensitively so e.g. 'OAuth' or 'WORKLOAD_IDENTITY' work
-            authenticator = self.authenticator.lower()
             result["authenticator"] = self.authenticator
-            if authenticator == "oauth":
+            if self.authenticator == "oauth":
                 token = self.token
                 # if we have a client ID/client secret, the token is a refresh
                 # token, not an access token
@@ -267,20 +262,20 @@ class SnowflakeCredentials(Credentials):
 
                 result["token"] = token
 
-            elif authenticator == "jwt":
+            elif self.authenticator == "jwt":
                 # If authenticator is 'jwt', then the 'token' value should be used
                 # unmodified. We expose this as 'jwt' in the profile, but the value
                 # passed into the snowflake.connect method should still be 'oauth'
                 result["token"] = self.token
                 result["authenticator"] = "oauth"
 
-            elif authenticator == "programmatic_access_token":
+            elif self.authenticator == "programmatic_access_token":
                 # Snowflake Programmatic Access Tokens (PATs) are passed directly
                 # to the connector via the `token` field. The connector handles
                 # PAT auth natively since snowflake-connector-python v3.12.0.
                 result["token"] = self.token
 
-            elif authenticator == "workload_identity":
+            elif self.authenticator.lower() == "workload_identity":
                 result["authenticator"] = WORKLOAD_IDENTITY_AUTHENTICATOR
 
                 if (

--- a/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
@@ -147,7 +147,8 @@ class SnowflakeCredentials(Credentials):
                 )
             )
 
-        if self.authenticator not in [
+        authenticator = (self.authenticator or "").lower()
+        if authenticator not in [
             "oauth",
             "jwt",
             "programmatic_access_token",

--- a/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/connections.py
@@ -139,7 +139,11 @@ class SnowflakeCredentials(Credentials):
     )
 
     def __post_init__(self):
-        if self.authenticator != "oauth" and (self.oauth_client_secret or self.oauth_client_id):
+        # normalize once so authenticator comparisons are case-insensitive and
+        # consistent with auth_args() (e.g. accept 'WORKLOAD_IDENTITY')
+        authenticator = (self.authenticator or "").lower()
+
+        if authenticator != "oauth" and (self.oauth_client_secret or self.oauth_client_id):
             # the user probably forgot to set 'authenticator' like I keep doing
             warn_or_error(
                 AdapterEventWarning(
@@ -147,7 +151,6 @@ class SnowflakeCredentials(Credentials):
                 )
             )
 
-        authenticator = (self.authenticator or "").lower()
         if authenticator not in [
             "oauth",
             "jwt",
@@ -240,8 +243,10 @@ class SnowflakeCredentials(Credentials):
         if self.protocol:
             result["protocol"] = self.protocol
         if self.authenticator:
+            # match case-insensitively so e.g. 'OAuth' or 'WORKLOAD_IDENTITY' work
+            authenticator = self.authenticator.lower()
             result["authenticator"] = self.authenticator
-            if self.authenticator == "oauth":
+            if authenticator == "oauth":
                 token = self.token
                 # if we have a client ID/client secret, the token is a refresh
                 # token, not an access token
@@ -262,20 +267,20 @@ class SnowflakeCredentials(Credentials):
 
                 result["token"] = token
 
-            elif self.authenticator == "jwt":
+            elif authenticator == "jwt":
                 # If authenticator is 'jwt', then the 'token' value should be used
                 # unmodified. We expose this as 'jwt' in the profile, but the value
                 # passed into the snowflake.connect method should still be 'oauth'
                 result["token"] = self.token
                 result["authenticator"] = "oauth"
 
-            elif self.authenticator == "programmatic_access_token":
+            elif authenticator == "programmatic_access_token":
                 # Snowflake Programmatic Access Tokens (PATs) are passed directly
                 # to the connector via the `token` field. The connector handles
                 # PAT auth natively since snowflake-connector-python v3.12.0.
                 result["token"] = self.token
 
-            elif self.authenticator.lower() == "workload_identity":
+            elif authenticator == "workload_identity":
                 result["authenticator"] = WORKLOAD_IDENTITY_AUTHENTICATOR
 
                 if (

--- a/dbt-snowflake/tests/unit/test_connections.py
+++ b/dbt-snowflake/tests/unit/test_connections.py
@@ -297,6 +297,28 @@ def test_connnections_credentials_passes_through_wif_params():
     assert auth_args["token"] == "test_token"
 
 
+def test_connnections_credentials_wif_oidc_token_and_no_user_no_warning():
+    """OIDC workload identity uses a token and no user; neither should trigger
+    the 'token set but authenticator wrong' warning nor the 'user required' error.
+
+    If 'workload_identity' is ever removed from the allowlist in __post_init__,
+    warn_or_error would be called and this assertion would fail.
+    """
+    credentials = {
+        "account": "test_account",
+        "database": "database",
+        "warehouse": "warehouse",
+        "schema": "schema",
+        "authenticator": "workload_identity",
+        "workload_identity_provider": "OIDC",
+        "token": "oidc_jwt_token",
+        # intentionally no 'user' — not required for workload identity
+    }
+    with patch("dbt.adapters.snowflake.connections.warn_or_error") as mock_warn:
+        connections.SnowflakeCredentials(**credentials)
+        mock_warn.assert_not_called()
+
+
 def test_connnections_credentials_wif_authenticator_fails_without_provider():
     credentials = {
         "account": "account_id_with_underscores",

--- a/dbt-snowflake/tests/unit/test_connections.py
+++ b/dbt-snowflake/tests/unit/test_connections.py
@@ -319,9 +319,9 @@ def test_connnections_credentials_wif_oidc_token_and_no_user_no_warning():
         mock_warn.assert_not_called()
 
 
-def test_connnections_credentials_authenticator_is_case_insensitive():
-    """The authenticator value should be matched case-insensitively in both
-    __post_init__ validation and auth_args (e.g. 'WORKLOAD_IDENTITY')."""
+def test_connnections_credentials_workload_identity_authenticator_is_case_insensitive():
+    """workload_identity is matched case-insensitively in both __post_init__ validation
+    and auth_args (e.g. 'WORKLOAD_IDENTITY'). Other authenticators stay case-sensitive."""
     credentials = {
         "account": "test_account",
         "database": "database",

--- a/dbt-snowflake/tests/unit/test_connections.py
+++ b/dbt-snowflake/tests/unit/test_connections.py
@@ -319,6 +319,27 @@ def test_connnections_credentials_wif_oidc_token_and_no_user_no_warning():
         mock_warn.assert_not_called()
 
 
+def test_connnections_credentials_authenticator_is_case_insensitive():
+    """The authenticator value should be matched case-insensitively in both
+    __post_init__ validation and auth_args (e.g. 'WORKLOAD_IDENTITY')."""
+    credentials = {
+        "account": "test_account",
+        "database": "database",
+        "warehouse": "warehouse",
+        "schema": "schema",
+        "authenticator": "WORKLOAD_IDENTITY",
+        "workload_identity_provider": "OIDC",
+        "token": "oidc_jwt_token",
+        # no 'user' — must not trip validation despite the uppercase authenticator
+    }
+    with patch("dbt.adapters.snowflake.connections.warn_or_error") as mock_warn:
+        creds = connections.SnowflakeCredentials(**credentials)
+        mock_warn.assert_not_called()
+    auth_args = creds.auth_args()
+    assert auth_args["authenticator"] == "WORKLOAD_IDENTITY"
+    assert auth_args["token"] == "oidc_jwt_token"
+
+
 def test_connnections_credentials_wif_authenticator_fails_without_provider():
     credentials = {
         "account": "account_id_with_underscores",


### PR DESCRIPTION
Workload Identity Federation was missing from the `authenticator` allowlist in `SnowflakeCredentials.__post_init__`, so OIDC profiles (which pass a `token` and no `user`) hit a spurious token warning and the hard `'user' is a required property` error.

Adds `workload_identity` to the allowlist and a unit test guarding the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)