### PR TITLE
[Backport stable] mutate copy for TestQueryTimeout to avoid spilling query_timeout (#1880)

### DIFF
--- a/dbt-spark/tests/functional/adapter/test_query_timeout.py
+++ b/dbt-spark/tests/functional/adapter/test_query_timeout.py
@@ -4,6 +4,7 @@ NOTE: These tests only work with PyHive-based connections (http/thrift methods).
 ODBC connections use PyodbcConnectionWrapper which doesn't have timeout/retry support yet.
 """
 
+import copy
 import pytest
 from dbt.tests.util import run_dbt, run_dbt_and_capture
 from dbt_common.exceptions import DbtRuntimeError
@@ -56,11 +57,17 @@ class TestQueryTimeout:
 
     @pytest.fixture(scope="class")
     def dbt_profile_target(self, dbt_profile_target):
-        """Override profile to add timeout configuration."""
-        dbt_profile_target["query_timeout"] = 1  # 1 second timeout
-        dbt_profile_target["poll_interval"] = 1  # Poll every second for faster test
-        dbt_profile_target["query_retries"] = 0  # Disable retries for clearer errors
-        return dbt_profile_target
+        """Override profile to add timeout configuration.
+
+        Copy before mutating — the parent fixture is session-scoped, so
+        in-place mutation leaks query_timeout=1 into every later test on
+        the same worker and makes their seeds/queries time out.
+        """
+        overrides = copy.deepcopy(dbt_profile_target)
+        overrides["query_timeout"] = 1  # 1 second timeout
+        overrides["poll_interval"] = 1  # Poll every second for faster test
+        overrides["query_retries"] = 0  # Disable retries for clearer errors
+        return overrides
 
     def test_query_timeout_exceeded(self, project):
         """Test that queries exceeding timeout raise appropriate error."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Closing — superseded.** This backport is no longer needed.

The fix from #1880 (`616a8d3c`) was promoted to `stable` via the **Promote Commits** workflow (run `28014645170`, success) by adding the `promote stable` label to the original PR. It now exists on `stable` as commit `f156ebfd`.

This PR and its branch are being closed/deleted to avoid applying the same change twice.

---

### Problem (original)

The daily Scheduled tests `stable` leg of `integration-tests-spark (databricks_http_cluster)` was failing because `TestQueryTimeout` mutated the session-scoped `dbt_profile_target` fixture in place, leaking `query_timeout=1` into later tests on the same xdist worker. Fixed on `main` in #1880 but not yet promoted to `stable`.

### Solution (original)

Cherry-pick `616a8d3c` onto `stable` (deepcopy the fixture before mutating). Superseded by the automated promotion described above.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8be0391f-8299-491a-bcfb-24d2477d1979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8be0391f-8299-491a-bcfb-24d2477d1979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

