### PR TITLE
fix(redshift): serialize rename swap to avoid losing __dbt_tmp on conflict

### DIFF
--- a/dbt-redshift/.changes/unreleased/Fixes-20260703-221316.yaml
+++ b/dbt-redshift/.changes/unreleased/Fixes-20260703-221316.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix relation swap discarding the intermediate table when a rename hits a concurrent transaction conflict
+time: 2026-07-03T22:13:16.406388+05:30
+custom:
+    Author: namangoyal
+    Issue: "626"

--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -178,6 +178,26 @@ class RedshiftAdapter(SQLAdapter):
         with self.connections.fresh_transaction():
             return super().drop_relation(relation)
 
+    def rename_relation(self, from_relation, to_relation):
+        """
+        The table materialization's target<->backup<->intermediate swap issues
+        two RENAMEs inside one build transaction. If Redshift aborts that
+        transaction on a "conflict with concurrent transaction" error during
+        the first rename, the intermediate relation created earlier in the
+        same transaction is rolled back with it. execute()'s retry then
+        resends only the failed RENAME statement, so the second RENAME
+        (intermediate -> target) fails with "relation ... does not exist",
+        masking the original conflict.
+
+        Wrapping the rename in fresh_transaction() commits the in-progress
+        transaction (and the intermediate relation with it) before attempting
+        the rename, so a conflict here can no longer take the intermediate
+        relation down with it. Mirrors the CASCADE handling in drop_relation
+        above.
+        """
+        with self.connections.fresh_transaction():
+            return super().rename_relation(from_relation, to_relation)
+
     @classmethod
     def convert_text_type(cls, agate_table: "agate.Table", col_idx):
         column = agate_table.columns[col_idx]

--- a/dbt-redshift/tests/unit/test_rename_relation.py
+++ b/dbt-redshift/tests/unit/test_rename_relation.py
@@ -1,0 +1,75 @@
+from contextlib import contextmanager
+from multiprocessing import get_context
+from unittest import TestCase, mock
+
+from dbt.adapters.sql import SQLAdapter
+
+from dbt.adapters.redshift import (
+    Plugin as RedshiftPlugin,
+    RedshiftAdapter,
+)
+from tests.unit.utils import (
+    config_from_parts_or_dicts,
+    inject_adapter,
+)
+
+BASE_OUTPUT = {
+    "type": "redshift",
+    "dbname": "redshift",
+    "user": "root",
+    "host": "thishostshouldnotexist.test.us-east-1",
+    "pass": "password",
+    "port": 5439,
+    "schema": "public",
+}
+
+PROJECT_CFG = {
+    "name": "X",
+    "version": "0.1",
+    "profile": "test",
+    "project-root": "/tmp/dbt/does-not-exist",
+    "quoting": {
+        "identifier": False,
+        "schema": True,
+    },
+    "config-version": 2,
+}
+
+
+def make_adapter(extra_credentials=None):
+    output = {**BASE_OUTPUT, **(extra_credentials or {})}
+    profile_cfg = {"outputs": {"test": output}, "target": "test"}
+    config = config_from_parts_or_dicts(PROJECT_CFG, profile_cfg)
+    adapter = RedshiftAdapter(config, get_context("spawn"))
+    inject_adapter(adapter, RedshiftPlugin)
+    return adapter
+
+
+class TestRenameRelationLock(TestCase):
+    """Regression test for CORE-724.
+
+    A conflict on the target->backup rename rolls back the build transaction,
+    discarding the intermediate (__dbt_tmp) relation created earlier in that
+    same transaction. Wrapping rename_relation in fresh_transaction(), like
+    drop_relation already does for DROP...CASCADE, commits the intermediate
+    relation before the risky rename is attempted, so a conflict there can no
+    longer take the intermediate relation down with it.
+    """
+
+    def test_rename_relation_uses_fresh_transaction(self):
+        adapter = make_adapter()
+        from_relation = mock.MagicMock()
+        to_relation = mock.MagicMock()
+
+        fresh_txn_entered = []
+
+        @contextmanager
+        def fake_fresh_transaction():
+            fresh_txn_entered.append(True)
+            yield
+
+        with mock.patch.object(adapter.connections, "fresh_transaction", fake_fresh_transaction):
+            with mock.patch.object(SQLAdapter, "rename_relation", return_value=None):
+                adapter.rename_relation(from_relation, to_relation)
+
+        self.assertTrue(fresh_txn_entered, "fresh_transaction() should have been entered")


### PR DESCRIPTION
## Summary
- Adds a `rename_relation` override to `RedshiftAdapter` that wraps the rename in `fresh_transaction()`, mirroring the existing `drop_relation()` CASCADE-lock pattern from #626.
- Commits the intermediate (`__dbt_tmp`) relation before the target->backup rename is attempted, so a `conflict with concurrent transaction` error there can no longer discard it and mask itself as `relation ... does not exist` on the follow-up rename.
- Fixes CORE-724.

## Test plan
- [x] New regression test `test_rename_relation.py::TestRenameRelationLock::test_rename_relation_uses_fresh_transaction` (written RED-first, now GREEN)
- [x] Full `dbt-redshift` unit suite passes (170/170), no regressions
- [x] Validated against a live Redshift cluster: baseline `table` materialization builds and full-refreshes succeed with the fix; forced real timing overlap between a concurrent `VACUUM` and the rename step twice with no corruption