### PR TITLE
Feat/athena merge source as view

### DIFF
--- a/dbt-athena/.changes/unreleased/Features-20260705-144046.yaml
+++ b/dbt-athena/.changes/unreleased/Features-20260705-144046.yaml
@@ -1,9 +1,9 @@
 kind: Features
-body: Stage incremental merge models as a view instead of a temporary table, avoiding
-    writing the data twice. Merge defaults to a view like dbt-trino and dbt-snowflake,
-    with automatic fallback to a table when the model projects types Athena views
-    cannot hold. The staging type can be set explicitly with the `tmp_relation_type`
-    model config (`view` or `table`).
+body: Add `tmp_relation_type` model config for incremental models. Setting it to
+    `view` stages the model query as a view instead of a temporary table for the
+    merge and append strategies, avoiding writing the data twice. Defaults to
+    `table`, preserving existing behavior. The config name mirrors dbt-trino and
+    dbt-snowflake.
 time: 2026-07-05T14:40:46.000000+05:30
 custom:
     Author: Amar1404

--- a/dbt-athena/.changes/unreleased/Features-20260705-144046.yaml
+++ b/dbt-athena/.changes/unreleased/Features-20260705-144046.yaml
@@ -1,0 +1,10 @@
+kind: Features
+body: Stage incremental merge models as a view instead of a temporary table, avoiding
+    writing the data twice. Merge defaults to a view like dbt-trino and dbt-snowflake,
+    with automatic fallback to a table when the model projects types Athena views
+    cannot hold. The staging type can be set explicitly with the `tmp_relation_type`
+    model config (`view` or `table`).
+time: 2026-07-05T14:40:46.000000+05:30
+custom:
+    Author: Amar1404
+    Issue: "1962"

--- a/dbt-athena/README.md
+++ b/dbt-athena/README.md
@@ -241,6 +241,18 @@ athena:
     - For incremental models, it allows to define a schema to hold temporary create statements
       used in incremental model runs
     - Schema will be created in the model target database if does not exist
+- `tmp_relation_type` (`default=none`)
+    - For incremental models, controls whether the model query is staged as a `table` or a `view`
+      before being inserted/merged into the target table
+    - When unset, the `merge` strategy stages as a view (like dbt-trino and dbt-snowflake), so the
+      data is only written once by the merge itself instead of twice (temporary table, then merge);
+      all other strategies stage as a table
+    - If Athena rejects the view because the model projects column types views cannot hold
+      (e.g. `timestamp(6)` or `timestamp with time zone`), the default automatically falls back to
+      staging a table. Set `tmp_relation_type='table'` to skip the view attempt entirely, or cast
+      the offending columns (e.g. to `timestamp(3)`) to keep the view staging
+    - `view` cannot be combined with Python models, the `insert_overwrite` strategy or
+      `force_batch`, since those read the staged data more than once and require a stable snapshot
 - `lf_tags_config` (`default=none`)
     - [AWS Lake Formation](#aws-lake-formation-integration) tags to associate with the table and columns
     - `enabled` (`default=False`) whether LF tags management is enabled for a model
@@ -426,6 +438,13 @@ It is possible to use Iceberg in an incremental fashion, specifically two strate
         - `incremental_predicates`, `delete_condition`, `update_condition` and `insert_condition` can include any column of
           the incremental table (`src`) or the final table (`target`).
           Column names must be prefixed by either `src` or `target` to prevent a `Column is ambiguous` error.
+
+The `merge` strategy stages the model query as a view by default, so the data is only written once — by the
+merge into the target table — instead of twice (once into a temporary table, then again by the merge). This
+reduces both run time and Athena scan costs. If Athena rejects the view because the model projects column
+types views cannot hold (e.g. `timestamp(6)` or `timestamp with time zone`), dbt automatically falls back to
+staging a temporary table. Set `tmp_relation_type` to `table` or `view` to control this behavior explicitly
+(see [Table configuration](#table-configuration)).
 
 `delete_condition` example:
 

--- a/dbt-athena/README.md
+++ b/dbt-athena/README.md
@@ -241,16 +241,15 @@ athena:
     - For incremental models, it allows to define a schema to hold temporary create statements
       used in incremental model runs
     - Schema will be created in the model target database if does not exist
-- `tmp_relation_type` (`default=none`)
+- `tmp_relation_type` (`default='table'`)
     - For incremental models, controls whether the model query is staged as a `table` or a `view`
       before being inserted/merged into the target table
-    - When unset, the `merge` strategy stages as a view (like dbt-trino and dbt-snowflake), so the
-      data is only written once by the merge itself instead of twice (temporary table, then merge);
-      all other strategies stage as a table
-    - If Athena rejects the view because the model projects column types views cannot hold
-      (e.g. `timestamp(6)` or `timestamp with time zone`), the default automatically falls back to
-      staging a table. Set `tmp_relation_type='table'` to skip the view attempt entirely, or cast
-      the offending columns (e.g. to `timestamp(3)`) to keep the view staging
+    - `view` avoids writing the data twice (once into a temporary table, then again by the
+      merge/insert into the target), reducing both run time and Athena scan costs; the config name
+      mirrors dbt-trino and dbt-snowflake
+    - Athena views cannot hold some column types, e.g. `timestamp(6)` (the native Iceberg timestamp
+      precision) or `timestamp with time zone`; with `view`, models projecting such columns fail at
+      staging time — cast them (e.g. to `timestamp(3)`) or keep `table`
     - `view` cannot be combined with Python models, the `insert_overwrite` strategy or
       `force_batch`, since those read the staged data more than once and require a stable snapshot
 - `lf_tags_config` (`default=none`)
@@ -439,11 +438,10 @@ It is possible to use Iceberg in an incremental fashion, specifically two strate
           the incremental table (`src`) or the final table (`target`).
           Column names must be prefixed by either `src` or `target` to prevent a `Column is ambiguous` error.
 
-The `merge` strategy stages the model query as a view by default, so the data is only written once — by the
-merge into the target table — instead of twice (once into a temporary table, then again by the merge). This
-reduces both run time and Athena scan costs. If Athena rejects the view because the model projects column
-types views cannot hold (e.g. `timestamp(6)` or `timestamp with time zone`), dbt automatically falls back to
-staging a temporary table. Set `tmp_relation_type` to `table` or `view` to control this behavior explicitly
+By default the `merge` strategy stages the model query in a temporary table before merging it into the
+target. Setting `tmp_relation_type='view'` stages it as a view instead, so the data is only written once —
+by the merge itself — reducing both run time and Athena scan costs. Note that Athena views cannot hold some
+column types (e.g. `timestamp(6)` or `timestamp with time zone`); cast such columns or keep the default
 (see [Table configuration](#table-configuration)).
 
 `delete_condition` example:

--- a/dbt-athena/src/dbt/adapters/athena/impl.py
+++ b/dbt-athena/src/dbt/adapters/athena/impl.py
@@ -1579,20 +1579,6 @@ class AthenaAdapter(SQLAdapter):
         return f'{{"rowcount":{cursor.rowcount},"data_scanned_in_bytes":{cursor.data_scanned_in_bytes}}}'
 
     @available
-    def run_query_with_view_type_catching(self, sql: str) -> str:
-        """Athena views only hold Hive-compatible types; columns such as
-        timestamp(6) or timestamp with time zone are rejected at creation.
-        Returns a marker instead of raising so the caller can fall back to
-        staging the data as a table."""
-        try:
-            self._run_query(sql)
-        except AthenaError as e:
-            if "Invalid column type" in str(e) or "Unsupported Hive type" in str(e):
-                return "UNSUPPORTED_VIEW_COLUMN_TYPE"
-            raise e
-        return "SUCCESS"
-
-    @available
     def format_partition_keys(self, partition_keys: List[str]) -> str:
         return ", ".join([self.format_one_partition_key(k) for k in partition_keys])
 

--- a/dbt-athena/src/dbt/adapters/athena/impl.py
+++ b/dbt-athena/src/dbt/adapters/athena/impl.py
@@ -1579,6 +1579,20 @@ class AthenaAdapter(SQLAdapter):
         return f'{{"rowcount":{cursor.rowcount},"data_scanned_in_bytes":{cursor.data_scanned_in_bytes}}}'
 
     @available
+    def run_query_with_view_type_catching(self, sql: str) -> str:
+        """Athena views only hold Hive-compatible types; columns such as
+        timestamp(6) or timestamp with time zone are rejected at creation.
+        Returns a marker instead of raising so the caller can fall back to
+        staging the data as a table."""
+        try:
+            self._run_query(sql)
+        except AthenaError as e:
+            if "Invalid column type" in str(e) or "Unsupported Hive type" in str(e):
+                return "UNSUPPORTED_VIEW_COLUMN_TYPE"
+            raise e
+        return "SUCCESS"
+
+    @available
     def format_partition_keys(self, partition_keys: List[str]) -> str:
         return ", ".join([self.format_one_partition_key(k) for k in partition_keys])
 

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/helpers.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/helpers.sql
@@ -29,6 +29,96 @@
 {% endmacro %}
 
 
+{% macro validate_get_tmp_relation_type(strategy, table_type, force_batch, language) %}
+  {%- set tmp_relation_type = config.get('tmp_relation_type') -%}
+  {%- if tmp_relation_type is not none -%}
+    {%- set tmp_relation_type = tmp_relation_type | lower -%}
+  {%- endif -%}
+  /* {#
+       Staging the model query as a view avoids writing the data twice
+       (once into a temporary table, then again by the merge/insert into the
+       target). A view is only safe when the staged data is read by a single
+       statement; strategies or options that read it multiple times
+       (insert_overwrite, force_batch) require a physical table so every read
+       sees identical data.
+
+       Like dbt-trino and dbt-snowflake, the merge strategy defaults to a
+       view. Set tmp_relation_type to 'table' to opt out, e.g. for models
+       projecting types that Athena views cannot hold, such as
+       'timestamp with time zone'.
+  #} */
+
+  {% if tmp_relation_type is not none and tmp_relation_type not in ['table', 'view'] %}
+    {% do exceptions.raise_compiler_error(
+      "Invalid tmp_relation_type provided: " ~ tmp_relation_type ~ ". Expected one of: 'table', 'view'"
+    ) %}
+  {% endif %}
+
+  {% if tmp_relation_type == 'view' %}
+    {% if language != 'sql' %}
+      {% do exceptions.raise_compiler_error(
+        "Python models only support 'table' for tmp_relation_type, but 'view' was specified."
+      ) %}
+    {% endif %}
+    {% if strategy == 'insert_overwrite' %}
+      {% do exceptions.raise_compiler_error(
+        "The 'insert_overwrite' strategy runs multiple statements against the staged data
+        and only supports 'table' for tmp_relation_type, but 'view' was specified."
+      ) %}
+    {% endif %}
+    {% if force_batch %}
+      {% do exceptions.raise_compiler_error(
+        "force_batch processes the staged data in multiple statements
+        and only supports 'table' for tmp_relation_type, but 'view' was specified."
+      ) %}
+    {% endif %}
+  {% endif %}
+
+  {% if tmp_relation_type in ['table', 'view'] %}
+    {% do return(tmp_relation_type) %}
+  {% elif language == 'sql' and strategy == 'merge' and not force_batch %}
+    {% do return('view') %}
+  {% else %}
+    {% do return('table') %}
+  {% endif %}
+{% endmacro %}
+
+
+{% macro stage_incremental_tmp_relation(tmp_relation, tmp_relation_type, compiled_code, model_language, force_batch) %}
+  /* {#
+       Creates the staging relation for an incremental run and returns it.
+       When the resolved type is 'view' but the user did not request it
+       explicitly, an Athena rejection of the view's column types (e.g.
+       timestamp(6) or timestamp with time zone, which Glue views cannot
+       hold) falls back to staging a table. An explicitly configured view
+       fails loudly instead.
+  #} */
+  {% if tmp_relation_type == 'view' %}
+    {% if config.get('tmp_relation_type') is not none %}
+      {%- call statement('create_tmp_relation') -%}
+        {{ create_view_as(tmp_relation, compiled_code) }}
+      {%- endcall -%}
+      {% do return(tmp_relation) %}
+    {% else %}
+      {% set view_result = adapter.run_query_with_view_type_catching(create_view_as(tmp_relation, compiled_code)) %}
+      {% if view_result != 'UNSUPPORTED_VIEW_COLUMN_TYPE' %}
+        {% do return(tmp_relation) %}
+      {% endif %}
+      {% do log('Model columns are not supported in an Athena view, staging as a table instead') %}
+      {% set tmp_relation = tmp_relation.incorporate(type='table') %}
+    {% endif %}
+  {% endif %}
+
+  {% set query_result = safe_create_table_as(True, tmp_relation, compiled_code, model_language, force_batch) %}
+  {%- if model_language == 'python' -%}
+    {% call statement('create_table', language=model_language) %}
+      {{ query_result }}
+    {% endcall %}
+  {%- endif -%}
+  {% do return(tmp_relation) %}
+{% endmacro %}
+
+
 {% macro batch_incremental_insert(tmp_relation, target_relation, dest_cols_csv) %}
     {% set partitions_batches = get_partition_batches(tmp_relation) %}
     {% do log('BATCHES TO PROCESS: ' ~ partitions_batches | length) %}

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/helpers.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/helpers.sql
@@ -42,10 +42,12 @@
        (insert_overwrite, force_batch) require a physical table so every read
        sees identical data.
 
-       Like dbt-trino and dbt-snowflake, the merge strategy defaults to a
-       view. Set tmp_relation_type to 'table' to opt out, e.g. for models
-       projecting types that Athena views cannot hold, such as
-       'timestamp with time zone'.
+       The default is 'table' to preserve backward-compatible behavior; set
+       tmp_relation_type to 'view' to opt in for merge and append models.
+       The config name mirrors dbt-trino and dbt-snowflake. Note that Athena
+       views cannot hold some types, such as 'timestamp(6)' or
+       'timestamp with time zone' — cast those columns (e.g. to
+       'timestamp(3)') or keep 'table'.
   #} */
 
   {% if tmp_relation_type is not none and tmp_relation_type not in ['table', 'view'] %}
@@ -74,9 +76,7 @@
     {% endif %}
   {% endif %}
 
-  {% if tmp_relation_type in ['table', 'view'] %}
-    {% do return(tmp_relation_type) %}
-  {% elif language == 'sql' and strategy == 'merge' and not force_batch %}
+  {% if tmp_relation_type == 'view' %}
     {% do return('view') %}
   {% else %}
     {% do return('table') %}
@@ -87,26 +87,12 @@
 {% macro stage_incremental_tmp_relation(tmp_relation, tmp_relation_type, compiled_code, model_language, force_batch) %}
   /* {#
        Creates the staging relation for an incremental run and returns it.
-       When the resolved type is 'view' but the user did not request it
-       explicitly, an Athena rejection of the view's column types (e.g.
-       timestamp(6) or timestamp with time zone, which Glue views cannot
-       hold) falls back to staging a table. An explicitly configured view
-       fails loudly instead.
   #} */
   {% if tmp_relation_type == 'view' %}
-    {% if config.get('tmp_relation_type') is not none %}
-      {%- call statement('create_tmp_relation') -%}
-        {{ create_view_as(tmp_relation, compiled_code) }}
-      {%- endcall -%}
-      {% do return(tmp_relation) %}
-    {% else %}
-      {% set view_result = adapter.run_query_with_view_type_catching(create_view_as(tmp_relation, compiled_code)) %}
-      {% if view_result != 'UNSUPPORTED_VIEW_COLUMN_TYPE' %}
-        {% do return(tmp_relation) %}
-      {% endif %}
-      {% do log('Model columns are not supported in an Athena view, staging as a table instead') %}
-      {% set tmp_relation = tmp_relation.incorporate(type='table') %}
-    {% endif %}
+    {%- call statement('create_tmp_relation') -%}
+      {{ create_view_as(tmp_relation, compiled_code) }}
+    {%- endcall -%}
+    {% do return(tmp_relation) %}
   {% endif %}
 
   {% set query_result = safe_create_table_as(True, tmp_relation, compiled_code, model_language, force_batch) %}

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -46,6 +46,13 @@
     {% endif %}
   {% endif %}
 
+  -- Staging the model query as a view avoids writing the data twice, but is only
+  -- safe when a single statement reads it (merge or append insert)
+  {% set tmp_relation_type = validate_get_tmp_relation_type(strategy, table_type, force_batch, model_language) %}
+  {% if tmp_relation_type == 'view' %}
+    {% set tmp_relation = tmp_relation.incorporate(type='view') %}
+  {% endif %}
+
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- `BEGIN` happens here:
@@ -149,12 +156,10 @@
     {% if old_tmp_relation is not none %}
       {% do drop_relation(old_tmp_relation) %}
     {% endif %}
-    {% set query_result = safe_create_table_as(True, tmp_relation, compiled_code, model_language, force_batch) -%}
-    {%- if model_language == 'python' -%}
-      {% call statement('create_table', language=model_language) %}
-        {{ query_result }}
-      {% endcall %}
-    {%- endif -%}
+    {% set tmp_relation = stage_incremental_tmp_relation(
+        tmp_relation, tmp_relation_type, compiled_code, model_language, force_batch
+      )
+    %}
     {% set build_sql = incremental_insert(
         on_schema_change, tmp_relation, target_relation, existing_relation, force_batch
       )
@@ -189,12 +194,10 @@
     {% if old_tmp_relation is not none %}
       {% do drop_relation(old_tmp_relation) %}
     {% endif %}
-    {% set query_result = safe_create_table_as(True, tmp_relation, compiled_code, model_language, force_batch) -%}
-    {%- if model_language == 'python' -%}
-      {% call statement('create_table', language=model_language) %}
-        {{ query_result }}
-      {% endcall %}
-    {%- endif -%}
+    {% set tmp_relation = stage_incremental_tmp_relation(
+        tmp_relation, tmp_relation_type, compiled_code, model_language, force_batch
+      )
+    %}
     {% set build_sql = iceberg_merge(
         on_schema_change=on_schema_change,
         tmp_relation=tmp_relation,

--- a/dbt-athena/tests/functional/adapter/test_incremental_tmp_relation_type.py
+++ b/dbt-athena/tests/functional/adapter/test_incremental_tmp_relation_type.py
@@ -1,0 +1,353 @@
+"""
+Functional tests for the `tmp_relation_type` config on incremental models.
+
+`tmp_relation_type: view` stages the model query as a view instead of a
+temporary table, so the data is only written once (by the MERGE/INSERT into
+the target) instead of twice (CTAS into a tmp table, then again by the merge).
+"""
+
+import json
+
+import pytest
+
+from dbt.contracts.results import RunStatus
+from dbt.tests.util import check_relations_equal, run_dbt
+
+models__merge_default_tmp_sql = """
+{{ config(
+        table_type='iceberg',
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key=['id']
+    )
+}}
+
+{% if is_incremental() %}
+
+select * from (
+    values
+    (2, 'v2-updated')
+    , (3, 'v3')
+) as t (id, value)
+
+{% else %}
+
+select * from (
+    values
+    (1, 'v1')
+    , (2, 'v2')
+) as t (id, value)
+
+{% endif %}
+"""
+
+models__merge_view_tmp_sql = """
+{{ config(
+        table_type='iceberg',
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key=['id'],
+        tmp_relation_type='view'
+    )
+}}
+
+{% if is_incremental() %}
+
+select * from (
+    values
+    (2, 'v2-updated')
+    , (3, 'v3')
+) as t (id, value)
+
+{% else %}
+
+select * from (
+    values
+    (1, 'v1')
+    , (2, 'v2')
+) as t (id, value)
+
+{% endif %}
+"""
+
+models__merge_table_tmp_sql = """
+{{ config(
+        table_type='iceberg',
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key=['id'],
+        tmp_relation_type='table'
+    )
+}}
+
+{% if is_incremental() %}
+
+select * from (
+    values
+    (2, 'v2-updated')
+    , (3, 'v3')
+) as t (id, value)
+
+{% else %}
+
+select * from (
+    values
+    (1, 'v1')
+    , (2, 'v2')
+) as t (id, value)
+
+{% endif %}
+"""
+
+seeds__expected_merge_view_tmp_csv = """id,value
+1,v1
+2,v2-updated
+3,v3
+"""
+
+models__merge_view_unsupported_type_sql = """
+{{ config(
+        table_type='iceberg',
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key=['id']
+    )
+}}
+
+{% if is_incremental() %}
+
+select * from (
+    values
+    (2, 'v2-updated', cast('2024-01-02 00:00:00.123456' as timestamp(6)))
+    , (3, 'v3', cast('2024-01-03 00:00:00.123456' as timestamp(6)))
+) as t (id, value, ts)
+
+{% else %}
+
+select * from (
+    values
+    (1, 'v1', cast('2024-01-01 00:00:00.123456' as timestamp(6)))
+    , (2, 'v2', cast('2024-01-02 00:00:00.000000' as timestamp(6)))
+) as t (id, value, ts)
+
+{% endif %}
+"""
+
+models__view_tmp_insert_overwrite_sql = """
+{{ config(
+        materialized='incremental',
+        incremental_strategy='insert_overwrite',
+        partitioned_by=['id'],
+        tmp_relation_type='view'
+    )
+}}
+
+select * from (
+    values
+    (1, 'v1')
+) as t (id, value)
+"""
+
+models__view_tmp_force_batch_sql = """
+{{ config(
+        table_type='iceberg',
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key=['id'],
+        tmp_relation_type='view',
+        force_batch=true
+    )
+}}
+
+select * from (
+    values
+    (1, 'v1')
+) as t (id, value)
+"""
+
+
+def extract_athena_queries(dbt_run_capsys_output: str, relation_name: str) -> list:
+    """Collect every executed statement for the model from debug json logs.
+
+    Queries surface either as 'Running Athena query:' debug messages or as
+    SQLQuery events carrying the statement in data.sql.
+    """
+    queries = []
+    for events_msg in dbt_run_capsys_output.split("\n")[1:]:
+        try:
+            data = json.loads(events_msg).get("data", {})
+        except (json.JSONDecodeError, AttributeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        base_msg = data.get("base_msg")
+        if base_msg and "Running Athena query:" in str(base_msg):
+            queries.append(str(base_msg))
+        elif data.get("conn_name") == f"model.test.{relation_name}" and "sql" in data:
+            queries.append(str(data["sql"]))
+    return queries
+
+
+class BaseMergeTmpRelationType:
+    """Runs a merge model twice and returns the staging statements of the
+    incremental run so subclasses can assert on the tmp relation type."""
+
+    def run_and_get_tmp_queries(self, project, capsys, relation_name):
+        expected_seed_name = "expected_merge_view_tmp"
+        run_dbt(["seed", "--select", expected_seed_name, "--full-refresh"])
+
+        model_run = run_dbt(["run", "--select", relation_name])
+        assert model_run.results[0].status == RunStatus.Success
+        capsys.readouterr()  # discard first-run logs
+
+        incremental_run = run_dbt(
+            [
+                "run",
+                "--select",
+                relation_name,
+                "--log-level",
+                "debug",
+                "--log-format",
+                "json",
+            ]
+        )
+        assert incremental_run.results[0].status == RunStatus.Success
+
+        out, _ = capsys.readouterr()
+        queries = extract_athena_queries(out, relation_name)
+        tmp_queries = [q for q in queries if "__dbt_tmp" in q]
+
+        check_relations_equal(project.adapter, [relation_name, expected_seed_name])
+        return tmp_queries
+
+
+class TestIcebergMergeDefaultTmpRelationIsView(BaseMergeTmpRelationType):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"merge_default_tmp.sql": models__merge_default_tmp_sql}
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"expected_merge_view_tmp.csv": seeds__expected_merge_view_tmp_csv}
+
+    def test__merge_defaults_to_view_tmp_relation(self, project, capsys):
+        """With no tmp_relation_type set, merge stages the source as a view
+        (same default as dbt-trino and dbt-snowflake)."""
+
+        tmp_queries = self.run_and_get_tmp_queries(project, capsys, "merge_default_tmp")
+
+        view_creates = [q for q in tmp_queries if "create or replace view" in q.lower()]
+        table_creates = [q for q in tmp_queries if "create table" in q.lower()]
+
+        assert view_creates, "expected merge to stage the source as a view by default"
+        assert not table_creates, "expected no tmp table creation for the default merge path"
+
+
+class TestIcebergMergeViewTmpRelation(BaseMergeTmpRelationType):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"merge_view_tmp.sql": models__merge_view_tmp_sql}
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"expected_merge_view_tmp.csv": seeds__expected_merge_view_tmp_csv}
+
+    def test__merge_view_tmp_relation(self, project, capsys):
+        """tmp_relation_type=view stages the source as a view, not a tmp table."""
+
+        tmp_queries = self.run_and_get_tmp_queries(project, capsys, "merge_view_tmp")
+
+        view_creates = [q for q in tmp_queries if "create or replace view" in q.lower()]
+        table_creates = [q for q in tmp_queries if "create table" in q.lower()]
+
+        assert view_creates, "expected the tmp relation to be created as a view"
+        assert not table_creates, "expected no tmp table creation when tmp_relation_type=view"
+
+
+class TestIcebergMergeTableTmpRelationOptOut(BaseMergeTmpRelationType):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"merge_table_tmp.sql": models__merge_table_tmp_sql}
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"expected_merge_view_tmp.csv": seeds__expected_merge_view_tmp_csv}
+
+    def test__merge_table_tmp_relation(self, project, capsys):
+        """tmp_relation_type=table opts out of view staging, e.g. for models
+        projecting types views cannot hold (timestamp with time zone)."""
+
+        tmp_queries = self.run_and_get_tmp_queries(project, capsys, "merge_table_tmp")
+
+        view_creates = [q for q in tmp_queries if "create or replace view" in q.lower()]
+        table_creates = [q for q in tmp_queries if "create table" in q.lower()]
+
+        assert table_creates, "expected the tmp relation to be created as a table"
+        assert not view_creates, "expected no view creation when tmp_relation_type=table"
+
+
+class TestIcebergMergeViewFallbackOnUnsupportedType:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"merge_view_unsupported_type.sql": models__merge_view_unsupported_type_sql}
+
+    def test__falls_back_to_table_staging(self, project, capsys):
+        """timestamp(6) columns cannot live in an Athena view, so the default
+        view staging must fall back to a table and the run still succeed."""
+
+        relation_name = "merge_view_unsupported_type"
+        model_run = run_dbt(["run", "--select", relation_name])
+        assert model_run.results[0].status == RunStatus.Success
+        capsys.readouterr()  # discard first-run logs
+
+        incremental_run = run_dbt(
+            [
+                "run",
+                "--select",
+                relation_name,
+                "--log-level",
+                "debug",
+                "--log-format",
+                "json",
+            ]
+        )
+        assert incremental_run.results[0].status == RunStatus.Success
+
+        out, _ = capsys.readouterr()
+        queries = extract_athena_queries(out, relation_name)
+        tmp_queries = [q for q in queries if "__dbt_tmp" in q]
+        table_creates = [q for q in tmp_queries if "create table" in q.lower()]
+        assert table_creates, "expected fallback to table staging for unsupported view types"
+
+        rows = project.run_sql(
+            f"select count(*) from {project.test_schema}.{relation_name}", fetch="one"
+        )
+        assert rows[0] == 3
+
+
+class TestViewTmpRelationInvalidWithInsertOverwrite:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"view_tmp_insert_overwrite.sql": models__view_tmp_insert_overwrite_sql}
+
+    def test__view_tmp_relation_rejected(self, project):
+        """insert_overwrite runs multiple statements against the staged data,
+        so a view staging relation must be rejected on any run (fail fast)."""
+
+        result = run_dbt(["run", "--select", "view_tmp_insert_overwrite"], expect_pass=False)
+        assert result.results[0].status == RunStatus.Error
+        assert "tmp_relation_type" in result.results[0].message
+
+
+class TestViewTmpRelationInvalidWithForceBatch:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"view_tmp_force_batch.sql": models__view_tmp_force_batch_sql}
+
+    def test__view_tmp_relation_rejected(self, project):
+        """force_batch merges partition-by-partition (multiple reads of the
+        staged data), so a view staging relation must be rejected (fail fast)."""
+
+        result = run_dbt(["run", "--select", "view_tmp_force_batch"], expect_pass=False)
+        assert result.results[0].status == RunStatus.Error
+        assert "tmp_relation_type" in result.results[0].message

--- a/dbt-athena/tests/functional/adapter/test_incremental_tmp_relation_type.py
+++ b/dbt-athena/tests/functional/adapter/test_incremental_tmp_relation_type.py
@@ -110,7 +110,8 @@ models__merge_view_unsupported_type_sql = """
         table_type='iceberg',
         materialized='incremental',
         incremental_strategy='merge',
-        unique_key=['id']
+        unique_key=['id'],
+        tmp_relation_type='view'
     )
 }}
 
@@ -221,7 +222,7 @@ class BaseMergeTmpRelationType:
         return tmp_queries
 
 
-class TestIcebergMergeDefaultTmpRelationIsView(BaseMergeTmpRelationType):
+class TestIcebergMergeDefaultTmpRelationIsTable(BaseMergeTmpRelationType):
     @pytest.fixture(scope="class")
     def models(self):
         return {"merge_default_tmp.sql": models__merge_default_tmp_sql}
@@ -230,17 +231,17 @@ class TestIcebergMergeDefaultTmpRelationIsView(BaseMergeTmpRelationType):
     def seeds(self):
         return {"expected_merge_view_tmp.csv": seeds__expected_merge_view_tmp_csv}
 
-    def test__merge_defaults_to_view_tmp_relation(self, project, capsys):
-        """With no tmp_relation_type set, merge stages the source as a view
-        (same default as dbt-trino and dbt-snowflake)."""
+    def test__merge_defaults_to_table_tmp_relation(self, project, capsys):
+        """With no tmp_relation_type set, merge stages the source as a table,
+        preserving backward-compatible behavior."""
 
         tmp_queries = self.run_and_get_tmp_queries(project, capsys, "merge_default_tmp")
 
         view_creates = [q for q in tmp_queries if "create or replace view" in q.lower()]
         table_creates = [q for q in tmp_queries if "create table" in q.lower()]
 
-        assert view_creates, "expected merge to stage the source as a view by default"
-        assert not table_creates, "expected no tmp table creation for the default merge path"
+        assert table_creates, "expected merge to stage the source as a table by default"
+        assert not view_creates, "expected no view creation for the default merge path"
 
 
 class TestIcebergMergeViewTmpRelation(BaseMergeTmpRelationType):
@@ -286,43 +287,23 @@ class TestIcebergMergeTableTmpRelationOptOut(BaseMergeTmpRelationType):
         assert not view_creates, "expected no view creation when tmp_relation_type=table"
 
 
-class TestIcebergMergeViewFallbackOnUnsupportedType:
+class TestIcebergMergeViewUnsupportedTypeFailsLoudly:
     @pytest.fixture(scope="class")
     def models(self):
         return {"merge_view_unsupported_type.sql": models__merge_view_unsupported_type_sql}
 
-    def test__falls_back_to_table_staging(self, project, capsys):
-        """timestamp(6) columns cannot live in an Athena view, so the default
-        view staging must fall back to a table and the run still succeed."""
+    def test__view_with_unsupported_types_errors(self, project):
+        """timestamp(6) columns cannot live in an Athena view, so an explicitly
+        requested view staging must fail loudly on the incremental run instead
+        of silently changing behavior. Cast the columns or use 'table'."""
 
         relation_name = "merge_view_unsupported_type"
         model_run = run_dbt(["run", "--select", relation_name])
         assert model_run.results[0].status == RunStatus.Success
-        capsys.readouterr()  # discard first-run logs
 
-        incremental_run = run_dbt(
-            [
-                "run",
-                "--select",
-                relation_name,
-                "--log-level",
-                "debug",
-                "--log-format",
-                "json",
-            ]
-        )
-        assert incremental_run.results[0].status == RunStatus.Success
-
-        out, _ = capsys.readouterr()
-        queries = extract_athena_queries(out, relation_name)
-        tmp_queries = [q for q in queries if "__dbt_tmp" in q]
-        table_creates = [q for q in tmp_queries if "create table" in q.lower()]
-        assert table_creates, "expected fallback to table staging for unsupported view types"
-
-        rows = project.run_sql(
-            f"select count(*) from {project.test_schema}.{relation_name}", fetch="one"
-        )
-        assert rows[0] == 3
+        result = run_dbt(["run", "--select", relation_name], expect_pass=False)
+        assert result.results[0].status == RunStatus.Error
+        assert "type" in result.results[0].message.lower()
 
 
 class TestViewTmpRelationInvalidWithInsertOverwrite:


### PR DESCRIPTION
resolves #1962
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/# N/A (README updated in this PR; happy to open a docs issue if preferred)

### Problem

Incremental models on Iceberg using the `merge` strategy always stage the model
query as a physical temporary table (CTAS), then run `MERGE INTO target USING tmp_table`.
The staged data is written twice — once into the tmp table and again by the merge —
doubling S3 writes and adding a full read of the tmp table to every incremental run.

dbt-trino and dbt-snowflake avoid this by staging the model query as a **view** for
single-statement strategies, so the data is only materialized once, by the merge itself.

### Solution

Add a `tmp_relation_type` model config (`table` | `view`) for incremental models,
mirroring the dbt-snowflake config of the same name and dbt-trino's `views_enabled`:

- `view`: stages the compiled model SQL as a view for the `merge` and `append`
  strategies; the merge/insert reads it directly. Athena engine v3 supports
  `MERGE INTO ... USING <view>` natively.
- **Default is `table`** — existing behavior is unchanged; `view` is opt-in.
- `view` is rejected with a clear compile error for Python models, the
  `insert_overwrite` strategy, and `force_batch`, all of which read the staged
  data more than once and need a stable snapshot (same consistency rule
  dbt-trino/dbt-snowflake apply to multi-statement strategies).
- Athena views cannot hold some column types (`timestamp(6)`, `timestamp with
  time zone`); with `view` configured, such models fail loudly at staging —
  documented in the README with the cast workaround.

Benchmark on a production model (2.26M rows, 90-day incremental batch, Iceberg,
engine v3), comparing CTAS+MERGE vs VIEW+MERGE with identical output verified:

| Path | Data scanned | Engine time |
|---|---|---|
| CTAS tmp table + MERGE (current) | 533 MB | ~24.4s |
| CREATE VIEW + MERGE (`tmp_relation_type: view`) | 378 MB | ~14.0s |

~29% less data scanned and ~43% less engine time, plus the avoided S3
writes/storage for the tmp table (not visible in scan stats). A follow-up could
flip the default to `view` for merge (full trino/snowflake parity) after
real-world exposure.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
