### PR TITLE
fix: guard build_catalog_relation against non-mapping node config (ExportConfig)

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20260708-000000.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20260708-000000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: 'build_catalog_relation no longer raises AttributeError for nodes whose config is not mapping-like (e.g. a saved-query export''s ExportConfig); it returns None so generate_database_name resolves normally.'
+time: 2026-07-08T00:00:00.000000+00:00
+custom:
+    Author: aahel
+    Issue: "2004"

--- a/dbt-adapters/src/dbt/adapters/base/impl.py
+++ b/dbt-adapters/src/dbt/adapters/base/impl.py
@@ -209,6 +209,17 @@ def _relation_name(rel: Optional[BaseRelation]) -> str:
         return str(rel)
 
 
+def _config_get(config: Any, key: str) -> Any:
+    """Read ``key`` from a node config that may not be dict-like.
+
+    Some node configs are typed, non-mapping objects (e.g. a saved-query export's
+    ``ExportConfig``, which has no ``.get``). Return None for those rather than
+    raising AttributeError.
+    """
+    get = getattr(config, "get", None)
+    return get(key) if callable(get) else None
+
+
 def log_code_execution(code_execution_function):
     # decorator to log code and execution time
     if code_execution_function.__name__ != "submit_python_job":
@@ -392,16 +403,10 @@ class BaseAdapter(metaclass=AdapterMeta):
         if not config.config:
             return None
 
-        # Catalogs are referenced via a mapping-style `catalog_name`/`catalog` key.
-        # Some node types expose a typed, non-mapping config object (e.g. a saved-query
-        # export's `ExportConfig`, which has no `.get`). Those can't reference a catalog,
-        # so bail out instead of raising AttributeError on `.get`.
-        get = getattr(config.config, "get", None)
-        if not callable(get):
-            return None
-
         # "catalog" is legacy, but we support it for backward compatibility
-        if catalog_name := get(CATALOG_INTEGRATION_MODEL_CONFIG_NAME) or get("catalog"):
+        if catalog_name := _config_get(
+            config.config, CATALOG_INTEGRATION_MODEL_CONFIG_NAME
+        ) or _config_get(config.config, "catalog"):
             catalog = self.get_catalog_integration(catalog_name)
             return catalog.build_relation(config)
 

--- a/dbt-adapters/src/dbt/adapters/base/impl.py
+++ b/dbt-adapters/src/dbt/adapters/base/impl.py
@@ -392,10 +392,16 @@ class BaseAdapter(metaclass=AdapterMeta):
         if not config.config:
             return None
 
+        # Catalogs are referenced via a mapping-style `catalog_name`/`catalog` key.
+        # Some node types expose a typed, non-mapping config object (e.g. a saved-query
+        # export's `ExportConfig`, which has no `.get`). Those can't reference a catalog,
+        # so bail out instead of raising AttributeError on `.get`.
+        get = getattr(config.config, "get", None)
+        if not callable(get):
+            return None
+
         # "catalog" is legacy, but we support it for backward compatibility
-        if catalog_name := config.config.get(
-            CATALOG_INTEGRATION_MODEL_CONFIG_NAME
-        ) or config.config.get("catalog"):
+        if catalog_name := get(CATALOG_INTEGRATION_MODEL_CONFIG_NAME) or get("catalog"):
             catalog = self.get_catalog_integration(catalog_name)
             return catalog.build_relation(config)
 

--- a/dbt-adapters/tests/unit/test_catalogs_v2.py
+++ b/dbt-adapters/tests/unit/test_catalogs_v2.py
@@ -24,6 +24,7 @@ class _StubAdapter:
     _v2_table_format = BaseAdapter._v2_table_format
     _translate_v2_properties = BaseAdapter._translate_v2_properties
     bridge_v2_catalog = BaseAdapter.bridge_v2_catalog
+    build_catalog_relation = BaseAdapter.build_catalog_relation
 
 
 class TestBaseAdapterV2Hooks:
@@ -98,3 +99,22 @@ class TestBaseAdapterBridgeV2Catalog:
         )
         result = self.adapter.bridge_v2_catalog(catalog)
         assert result.external_volume == "correct"
+
+
+class TestBuildCatalogRelation:
+    def setup_method(self):
+        self.adapter = _StubAdapter()
+
+    def test_non_mapping_config_returns_none(self):
+        # Saved-query export nodes carry a typed ExportConfig (no `.get`); build_catalog_relation
+        # must not raise AttributeError on it — it just can't reference a catalog.
+        export_config = SimpleNamespace(export_as="table", schema_name="s", alias="a")
+        node = SimpleNamespace(config=export_config)
+        assert self.adapter.build_catalog_relation(node) is None
+
+    def test_empty_config_returns_none(self):
+        assert self.adapter.build_catalog_relation(SimpleNamespace(config={})) is None
+
+    def test_mapping_config_without_catalog_name_returns_none(self):
+        node = SimpleNamespace(config={"materialized": "table"})
+        assert self.adapter.build_catalog_relation(node) is None


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

### Problem

After #2004 ("support catalog_database on all catalog types") landed, downstream CI (dbt-core, dbt-common) started failing with:

```
AttributeError: 'ExportConfig' object has no attribute 'get'
```

on any `dbt` run touching a **saved query with exports** (e.g. `tests/functional/saved_queries/*`, `tests/functional/list/*`).

**Root cause:** #2004 rewrote `default__generate_database_name` to call `adapter.build_catalog_relation(node)` for *every* node with a config:

```jinja
{%- if node is not none -%}
    {%- set catalog_relation = adapter.build_catalog_relation(node) -%}
```

`build_catalog_relation` (unchanged by #2004, but now reached for far more node types) does `config.config.get(...)`, assuming a mapping. A saved-query export node's `config` is a typed `ExportConfig` (`dbt_semantic_interfaces.protocols.export.ExportConfig`) — properties only, **no `.get`** — and it's truthy, so it passes the `if not config.config` check and then raises on `.get`.

The macro can't guard this itself: a check like `node.config.get('catalog_name')` would hit the *same* AttributeError. The only safe place to detect "config isn't mapping-like" is inside `build_catalog_relation`.

### Solution

Return `None` from `build_catalog_relation` when `config.config` has no callable `.get` — such nodes can't reference a catalog anyway, so `generate_database_name` falls through to its normal precedence (`custom_database_name` > `target.database`). No macro change needed; fixes all current and future callers.

```python
get = getattr(config.config, "get", None)
if not callable(get):
    return None
```

### Tests

Adds `TestBuildCatalogRelation`: non-mapping config (ExportConfig-like) → `None` (no raise); empty config → `None`; mapping config without `catalog_name` → `None`.

### Note

There is a separate, related version-skew issue from #2004: dbt-core's `core/dbt/config/catalogs.py` needs a matching `catalog_database` field on its `CatalogWriteIntegrationConfig` (mypy: "Cannot instantiate abstract class ... with abstract attribute catalog_database"). That's a dbt-core-side fix, tracked/handled separately.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX