### PR TITLE
test: skip flaky BigQuery query-cancellation test

### DIFF
--- a/dbt-bigquery/tests/functional/test_cancel.py
+++ b/dbt-bigquery/tests/functional/test_cancel.py
@@ -104,6 +104,7 @@ def _get_job_id(project, table_name):
     return job_id
 
 
+@pytest.mark.skip(reason="flaky in CI: subprocess signal timing is unreliable")
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="running signt is unsupported on Windows."
 )


### PR DESCRIPTION
## What

Skips `TestBigqueryCancelsQueriesOnKeyboardInterrupt` in `dbt-bigquery/tests/functional/test_cancel.py`.

## Why

This test drives dbt in a subprocess and sends `SIGINT` after seeing `1 of 1 START` in stdout, then asserts the BigQuery query was cancelled. The signal timing is inherently racy and fails intermittently in CI.

Using `@pytest.mark.skip` (rather than `@pytest.mark.flaky`) removes it from both the main and dedicated flaky BigQuery integration-test jobs until the cancellation flow can be exercised deterministically.

## Trade-off

BigQuery query cancellation on `SIGINT` is now untested. If preserving coverage is preferred, `@pytest.mark.flaky` would keep it running in the isolated `integration-tests-bigquery-flaky` job instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)