### PR TITLE
fix(snowflake): cast FIXED dtype to NUMBER in snapshot deletion_records

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20260710-120000.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260710-120000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix invalid 'FIXED' dtype in snapshot deletion_records cast to NUMBER
+time: 2026-07-10T12:00:00.000000-04:00
+custom:
+    Author: itsnamangoyal
+    Issue: "1986"

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/utils/safe_cast.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/utils/safe_cast.sql
@@ -3,6 +3,11 @@
         try_to_geometry({{field}})
     {% elif type|upper == "GEOGRAPHY" -%}
         try_to_geography({{field}})
+    {% elif type|upper == "FIXED" -%}
+        {#-- 'FIXED' is snowflake-connector-python's internal name for fixed-point
+        numeric types (surfaced by get_column_schema_from_query's cursor
+        introspection) -- it is not valid Snowflake DDL, so cast to NUMBER instead --#}
+        try_cast({{field}} as NUMBER)
     {% elif type|upper != "VARIANT" -%}
         {#-- Snowflake try_cast does not support casting to variant, and expects the field as a string --#}
         {% set field_as_string =  dbt.string_literal(field) if field is number else field %}


### PR DESCRIPTION
## Summary

Snowflake's `DESCRIBE`-based cursor introspection reports fixed-point numeric columns as `"FIXED"`, which is not valid Snowflake DDL. This breaks snapshots using `hard_deletes: new_record` when a new numeric column is added to the source relation, since the `deletion_records` CTE emits `try_cast(NULL as FIXED)`.

Fixes this at the `snowflake__safe_cast` macro — the exact call site that emits invalid DDL — rather than in `get_column_schema_from_query()`, which is shared by three other call sites (contract equivalence checks, Iceberg/Glue CLD table creation, snapshot timestamp lookup) that already have their own handling of the `FIXED` string and would regress if that method's return contract changed.

Closes #1986. Supersedes #1988, which fixed `get_column_schema_from_query()` directly — I verified that approach breaks 15 constraint-equivalence functional tests (`test_constraints.py`), since `assert_columns_equivalent` compares two independent calls to that method and previously relied on both sides coincidentally returning the same `"FIXED"` string. Changing that method's output broke the coincidence without fixing the underlying comparison logic.

Thanks to @rio-not-real for reporting #1986, root-causing it down to `snowflake-connector-python`'s `FIELD_ID_TO_NAME` mapping, and opening #1988 with the first fix attempt — this PR builds directly on that investigation, just relocates the fix to avoid the regression above.

## Test plan
- [x] Full `dbt-snowflake` unit test suite (265 tests) — passing
- [x] Full `dbt-snowflake` functional test suite against live Snowflake (469 tests) — no failures attributable to this change; remaining failures are pre-existing environment/credential gaps (missing Iceberg external volume, missing role grants) present on `main` too
- [x] `test_constraints.py` (15 tests that failed under #1988's approach) — all passing with this fix
- [x] `test_ephemeral_snapshot_hard_deletes.py` and `test_simple_snapshot.py` — passing
- [x] Live end-to-end repro in a real dbt project: reproduced #1986 exactly on unpatched `main`, confirmed fixed with this patch, confirmed contract enforcement on a numeric column still passes
- [x] `black`/`mypy` clean against CI's exact pinned versions