### PR TITLE
fix(dbt-athena): use pyathena ExecuteOptions, bump pyathena floor to 3.35

### DIFF
--- a/dbt-athena/.changes/unreleased/Fixes-20260710-120000.yaml
+++ b/dbt-athena/.changes/unreleased/Fixes-20260710-120000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix AthenaCursor.execute() to use pyathena's ExecuteOptions instead of removed flat keyword arguments, and raise the pyathena floor to 3.35 to match
+time: 2026-07-10T12:00:00.000000+00:00
+custom:
+    Author: itsnamangoyal
+    Issue: "2061"

--- a/dbt-athena/pyproject.toml
+++ b/dbt-athena/pyproject.toml
@@ -34,7 +34,7 @@ dependencies=[
     "boto3>=1.28",
     "boto3-stubs[athena,glue,lakeformation,sts]>=1.28",
     "mmh3>=4.0.1,<4.2.0",
-    "pyathena>=2.25,<4.0",
+    "pyathena>=3.35,<4.0",
     "pydantic>=1.10,<3.0",
     "tenacity>=8.2,<10.0",
 ]

--- a/dbt-athena/src/dbt/adapters/athena/connections.py
+++ b/dbt-athena/src/dbt/adapters/athena/connections.py
@@ -22,6 +22,7 @@ from pyathena.formatter import (
     _escape_presto,
 )
 from pyathena.model import AthenaQueryExecution
+from pyathena.options import ExecuteOptions
 from pyathena.result_set import AthenaResultSet
 from pyathena.util import RetryConfig
 from tenacity import (
@@ -202,10 +203,12 @@ class AthenaCursor(Cursor):
                 query_id = self._execute(
                     operation,
                     parameters=parameters,
-                    work_group=work_group,
-                    s3_staging_dir=s3_staging_dir,
-                    cache_size=cache_size,
-                    cache_expiration_time=cache_expiration_time,
+                    options=ExecuteOptions(
+                        work_group=work_group,
+                        s3_staging_dir=s3_staging_dir,
+                        cache_size=cache_size,
+                        cache_expiration_time=cache_expiration_time,
+                    ),
                 )
 
                 LOGGER.debug(f"Athena query ID {query_id}")


### PR DESCRIPTION
## Summary
- `pyathena` 3.35.0 collapsed `BaseCursor._execute()`'s flat keyword arguments (`work_group`, `s3_staging_dir`, `cache_size`, `cache_expiration_time`, etc.) into a single `options: ExecuteOptions` parameter, breaking `AthenaCursor.execute()`'s call site with `TypeError: BaseCursor._execute() got an unexpected keyword argument 'work_group'`. This broke every Athena integration test on `stable` (see CI run https://github.com/dbt-labs/dbt-adapters/actions/runs/28993727547).
- Updates `connections.py` to build a `pyathena.options.ExecuteOptions` and pass it via `options=`, matching the new `BaseCursor._execute()` signature.
- Raises the `pyathena` floor from `>=2.25` to `>=3.35`, since `ExecuteOptions` doesn't exist before that release — the wider pin was silently resolving to an incompatible version.
- `AthenaCursor.execute()`'s own public signature is unchanged; this is an internal call-site fix only.

Fixes #2061

## Test plan
- [x] Verified `dbt.adapters.athena.connections` imports cleanly against real `pyathena==3.35.0` in a clean venv
- [x] Verified `pyathena.common.BaseCursor._execute()`'s live signature in 3.35.0 exactly matches the patched call (`operation`, `parameters`, `options: ExecuteOptions | None`)
- [x] Confirmed no other call site in `dbt-athena` passes `work_group`/`s3_staging_dir`/`cache_size`/`cache_expiration_time` directly to `_execute`
- [ ] CI integration tests against real Athena (requires AWS creds in CI)