### PR TITLE
Revert "fix(dbt-athena): use pyathena ExecuteOptions, bump pyathena floor to 3.35"

### DIFF
--- a/dbt-athena/.changes/unreleased/Fixes-20260710-120000.yaml
+++ b/dbt-athena/.changes/unreleased/Fixes-20260710-120000.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Fix AthenaCursor.execute() to use pyathena's ExecuteOptions instead of removed flat keyword arguments, and raise the pyathena floor to 3.35 to match
-time: 2026-07-10T12:00:00.000000+00:00
-custom:
-    Author: itsnamangoyal
-    Issue: "2061"

--- a/dbt-athena/pyproject.toml
+++ b/dbt-athena/pyproject.toml
@@ -34,7 +34,7 @@ dependencies=[
     "boto3>=1.28",
     "boto3-stubs[athena,glue,lakeformation,sts]>=1.28",
     "mmh3>=4.0.1,<4.2.0",
-    "pyathena>=3.35,<4.0",
+    "pyathena>=2.25,<4.0",
     "pydantic>=1.10,<3.0",
     "tenacity>=8.2,<10.0",
 ]

--- a/dbt-athena/src/dbt/adapters/athena/connections.py
+++ b/dbt-athena/src/dbt/adapters/athena/connections.py
@@ -22,7 +22,6 @@ from pyathena.formatter import (
     _escape_presto,
 )
 from pyathena.model import AthenaQueryExecution
-from pyathena.options import ExecuteOptions
 from pyathena.result_set import AthenaResultSet
 from pyathena.util import RetryConfig
 from tenacity import (
@@ -203,12 +202,10 @@ class AthenaCursor(Cursor):
                 query_id = self._execute(
                     operation,
                     parameters=parameters,
-                    options=ExecuteOptions(
-                        work_group=work_group,
-                        s3_staging_dir=s3_staging_dir,
-                        cache_size=cache_size,
-                        cache_expiration_time=cache_expiration_time,
-                    ),
+                    work_group=work_group,
+                    s3_staging_dir=s3_staging_dir,
+                    cache_size=cache_size,
+                    cache_expiration_time=cache_expiration_time,
                 )
 
                 LOGGER.debug(f"Athena query ID {query_id}")


### PR DESCRIPTION
Reverts dbt-labs/dbt-adapters#2062