### PR TITLE
feat(bigquery): support Lakehouse Runtime Catalog PCNT relations

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Features-20260702-183000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Features-20260702-183000.yaml
@@ -1,0 +1,15 @@
+kind: Features
+body: Support BigQuery Lakehouse runtime catalog (Iceberg REST) tables addressed as
+    `project.catalog.namespace.table` by mapping `catalog.namespace` into the schema
+    slot. Models and sources use a literal dotted schema (`catalog.namespace`), with
+    model schemas passed through without the normal target-schema prefix. BigQuery
+    remains authoritative for unsupported materializations and table-option limitations,
+    while incompatible adapter transports such as rename, copy, and python model targets
+    are rejected at their operation boundaries.
+    Schema evolution routes through DDL; incremental strategies spill required temporary
+    relations to a configurable `temp_schema`; and lakehouse source freshness is computed
+    per source with error isolation
+time: 2026-07-02T18:30:00.000000+01:00
+custom:
+    Author: borjavb
+    Issue: "2066"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
@@ -90,7 +90,7 @@ from dbt.adapters.bigquery.record.record_types import (
     BigQueryAdapterAlterTableAddRemoveColumnsRecord,
     BigQueryAdapterSyncStructColumnsRecord,
 )
-from dbt.adapters.bigquery.relation import BigQueryRelation
+from dbt.adapters.bigquery.relation import BigQueryRelation, is_lakehouse_schema
 from dbt.adapters.bigquery.relation_configs import (
     BigQueryBaseRelationConfig,
     BigQueryMaterializedViewConfig,
@@ -192,6 +192,7 @@ class BigqueryConfig(AdapterConfig):
     enable_change_history: Optional[bool] = None
     job_execution_timeout_seconds: Optional[int] = None
     reservation: Optional[str] = None
+    temp_schema: Optional[str] = None
 
 
 class BigQueryAdapter(BaseAdapter):
@@ -276,6 +277,17 @@ class BigQueryAdapter(BaseAdapter):
         if is_cached:
             self.cache_dropped(relation)
 
+        if relation.is_lakehouse:
+            # the tables API cannot delete lakehouse catalog tables; DDL can.
+            # tolerate a missing namespace to match delete_table(not_found_ok=True)
+            try:
+                self.execute(f"drop table if exists {relation}")
+            except dbt_common.exceptions.DbtDatabaseError as e:
+                if "not found" not in str(e).lower():
+                    raise
+                logger.debug("Ignoring drop of {} in a missing namespace".format(relation))
+            return
+
         conn = self.connections.get_thread_connection()
 
         table_ref = self.get_table_ref_from_relation(relation)
@@ -291,6 +303,12 @@ class BigQueryAdapter(BaseAdapter):
     def rename_relation(
         self, from_relation: BigQueryRelation, to_relation: BigQueryRelation
     ) -> None:
+        if from_relation.is_lakehouse or to_relation.is_lakehouse:
+            raise dbt_common.exceptions.DbtRuntimeError(
+                f"Cannot rename {from_relation} to {to_relation}: rename requires a table "
+                "copy job, which is not supported for lakehouse catalog relations"
+            )
+
         conn = self.connections.get_thread_connection()
         client = conn.handle
 
@@ -337,6 +355,15 @@ class BigQueryAdapter(BaseAdapter):
     def check_schema_exists(self, database: str, schema: str) -> bool:
         conn = self.connections.get_thread_connection()
         client = conn.handle
+
+        if is_lakehouse_schema(schema):
+            # a tables.list probe is unreliable for EMPTY namespaces;
+            # datasets.get resolves dotted ids (verified live)
+            try:
+                client.get_dataset(self.connections.dataset_ref(database, schema))
+                return True
+            except google.api_core.exceptions.NotFound:
+                return False
 
         dataset_ref = self.connections.dataset_ref(database, schema)
         # try to do things with the dataset. If it doesn't exist it will 404.
@@ -418,7 +445,11 @@ class BigQueryAdapter(BaseAdapter):
             #       won't need to do this
             max_results=100000,
         )
-        all_routines = client.list_routines(dataset_ref)
+        all_routines: Iterable[Any] = []
+        if not schema_relation.is_lakehouse:
+            all_routines = client.list_routines(dataset_ref)
+        # else: lakehouse namespaces do not contain routines and the routines API
+        # cannot address them
 
         # This will 404 if the dataset does not exist. This behavior mirrors
         # the implementation of list_relations for other adapters
@@ -452,6 +483,11 @@ class BigQueryAdapter(BaseAdapter):
         if table is not None:
             return self._bq_table_to_relation(table)
 
+        if is_lakehouse_schema(schema):
+            # lakehouse namespaces do not contain routines, and
+            # RoutineReference.from_string cannot parse a four-part id
+            return None
+
         # Fall back to checking if it's a routine (function/procedure)
         connection = self.connections.get_thread_connection()
         client = connection.handle
@@ -473,6 +509,16 @@ class BigQueryAdapter(BaseAdapter):
         # use SQL 'create schema'
         relation = relation.without_identifier()
 
+        if relation.is_lakehouse:
+            # lakehouse namespaces cannot be created from BigQuery in the current
+            # preview; accept ones that already exist and fail clearly otherwise
+            if self.check_schema_exists(relation.database, relation.schema):
+                return
+            raise dbt_common.exceptions.DbtRuntimeError(
+                f"Lakehouse namespace {relation} does not exist. Create it with an engine "
+                "that manages the catalog (e.g. Spark or Trino) before running dbt."
+            )
+
         fire_event(SchemaCreation(relation=_make_ref_key_dict(relation)))
         kwargs = {
             "relation": relation,
@@ -483,6 +529,12 @@ class BigQueryAdapter(BaseAdapter):
         # don't want to (incorrectly) say that it's empty
 
     def drop_schema(self, relation: BigQueryRelation) -> None:
+        if relation.is_lakehouse:
+            raise dbt_common.exceptions.DbtRuntimeError(
+                f"Cannot drop namespace {relation.schema}: dropping namespaces is not "
+                "supported for lakehouse catalog relations"
+            )
+
         # still use a client method, rather than SQL 'drop schema ... cascade'
         database = relation.database
         schema = relation.schema
@@ -569,6 +621,15 @@ class BigQueryAdapter(BaseAdapter):
         id_field_name="thread_id",
     )
     def copy_table(self, source, destination, materialization):
+        # the copy materialization passes `source` as a list of relations
+        sources = source if isinstance(source, list) else [source]
+        for relation in [*sources, destination]:
+            if getattr(relation, "is_lakehouse", False):
+                raise dbt_common.exceptions.DbtRuntimeError(
+                    f"Cannot copy {source} to {destination}: table copy jobs are not "
+                    "supported for lakehouse catalog relations"
+                )
+
         if materialization == "incremental":
             write_disposition = WRITE_APPEND
         elif materialization == "table":
@@ -734,6 +795,16 @@ class BigQueryAdapter(BaseAdapter):
         if not relation:
             return True
 
+        if relation.is_lakehouse:
+            # lakehouse partition metadata is unreliable both ways: engine-created
+            # tables report timePartitioning=null even when partitioned, and
+            # BQ-created ones report synthetic fields (e.g. __PARTITIONTIME), so a
+            # config comparison would force a destructive drop+create on every run.
+            # `create or replace` with an unchanged partition spec is the documented
+            # path; a changed spec fails server-side with the table intact, and the
+            # materializations pre-drop on an explicit --full-refresh as recovery.
+            return True
+
         try:
             table = self.connections.get_bq_table(
                 database=relation.database, schema=relation.schema, identifier=relation.identifier
@@ -801,6 +872,13 @@ class BigQueryAdapter(BaseAdapter):
         if len(columns) == 0:
             return
 
+        if relation.is_lakehouse:
+            logger.warning(
+                "persist_docs column descriptions are not supported for lakehouse "
+                "catalog relations yet; skipping {}".format(relation)
+            )
+            return
+
         conn = self.connections.get_thread_connection()
         table_ref = self.get_table_ref_from_relation(relation)
         table = conn.handle.get_table(table_ref)
@@ -819,6 +897,13 @@ class BigQueryAdapter(BaseAdapter):
     def update_table_description(
         self, database: str, schema: str, identifier: str, description: str
     ):
+        if is_lakehouse_schema(schema):
+            logger.warning(
+                "persist_docs relation descriptions are not supported for lakehouse "
+                "catalog relations yet; skipping {}.{}.{}".format(database, schema, identifier)
+            )
+            return
+
         conn = self.connections.get_thread_connection()
         client = conn.handle
 
@@ -846,6 +931,29 @@ class BigQueryAdapter(BaseAdapter):
         id_field_name="thread_id",
     )
     def alter_table_add_remove_columns(self, relation, add_columns, remove_columns):
+        if relation.is_lakehouse and add_columns:
+            # Validate every unsupported addition before issuing any DROP. A
+            # sync_all_columns run can contain removals and additions together,
+            # so checking this later could leave the target partially mutated.
+            nested_adds = [column.name for column in add_columns if "." in column.name]
+            if nested_adds:
+                raise dbt_common.exceptions.DbtRuntimeError(
+                    f"Cannot add nested STRUCT fields to lakehouse catalog table "
+                    f"{relation}: {nested_adds}. Recreate the table with full_refresh "
+                    "or evolve the schema with an engine that manages the catalog."
+                )
+
+        if relation.is_lakehouse and add_columns and remove_columns:
+            # documented Lakehouse limitation: DROP COLUMN followed by re-adding
+            # the same column name is not supported; catch it before the drop runs
+            readded = {c.name for c in remove_columns} & {c.name for c in add_columns}
+            if readded:
+                raise dbt_common.exceptions.DbtRuntimeError(
+                    f"Cannot drop and re-add columns {sorted(readded)} on lakehouse "
+                    f"catalog table {relation}: BigQuery does not support re-adding a "
+                    "dropped column name on Lakehouse Iceberg tables. Recreate the "
+                    "table with full_refresh instead."
+                )
         conn = self.connections.get_thread_connection()
         client = conn.handle
 
@@ -889,6 +997,16 @@ class BigQueryAdapter(BaseAdapter):
             schema_as_dicts = [field.to_api_repr() for field in table.schema]
 
         if add_columns:
+            if relation.is_lakehouse:
+                # the tables API cannot mutate lakehouse catalog tables; use DDL.
+                # ALTER TABLE can only add top-level columns.
+                add_clauses = [
+                    f"add column {self.quote(column.name)} {column.data_type}"
+                    for column in add_columns
+                ]
+                self.execute(f"alter table {relation.render()} {', '.join(add_clauses)}")
+                return
+
             additions = build_nested_additions(add_columns)
             schema_as_dicts = merge_nested_fields(schema_as_dicts, additions)
             new_schema = [SchemaField.from_api_repr(field) for field in schema_as_dicts]
@@ -1096,6 +1214,15 @@ class BigQueryAdapter(BaseAdapter):
         )
         return super()._catalog_filter_table(table, used_schemas)
 
+    @staticmethod
+    def _skip_lakehouse_catalog(database: Optional[str], schema: Optional[str]) -> bool:
+        if is_lakehouse_schema(schema):
+            # INFORMATION_SCHEMA cannot address lakehouse namespaces. Skip
+            # database-derived catalog enrichment for these relations.
+            logger.debug("Skipping catalog enrichment for {}.{}".format(database, schema))
+            return True
+        return False
+
     def _get_catalog_schemas(self, relation_config: Iterable[RelationConfig]) -> SchemaSearchMap:
         candidates = super()._get_catalog_schemas(relation_config)
         db_schemas: Dict[str, Set[str]] = {}
@@ -1103,6 +1230,8 @@ class BigQueryAdapter(BaseAdapter):
 
         for candidate, schemas in candidates.items():
             database = candidate.database
+            if self._skip_lakehouse_catalog(database, candidate.schema):
+                continue
             if database not in db_schemas:
                 db_schemas[database] = set(self.list_schemas(database))  # type:ignore
             if candidate.schema in db_schemas[database]:  # type:ignore
@@ -1123,6 +1252,8 @@ class BigQueryAdapter(BaseAdapter):
         for info_schema, rels in candidates.items():
             database = info_schema.database
             schema = info_schema.schema
+            if self._skip_lakehouse_catalog(database, schema):
+                continue
             if database not in schema_exists:
                 schema_exists[database] = {}
             if schema not in schema_exists[database]:
@@ -1172,6 +1303,12 @@ class BigQueryAdapter(BaseAdapter):
         table = client.get_table(table_ref)
         snapshot = datetime.now(tz=pytz.UTC)
 
+        if table.modified is None:
+            raise dbt_common.exceptions.DbtRuntimeError(
+                f"BigQuery did not return a last-modified time for {source}. "
+                "Set `loaded_at_field` on this source to use a query-based freshness check."
+            )
+
         freshness = FreshnessResponse(
             max_loaded_at=table.modified,
             snapshotted_at=snapshot,
@@ -1204,12 +1341,41 @@ class BigQueryAdapter(BaseAdapter):
         for source in sources:
             self._check_for_wildcard_identifier(source)
 
-        # Legacy behavior: use metadata-based freshness for each source
-        if not self.behavior.bigquery_use_batch_source_freshness:
-            for source in sources:
+        # INFORMATION_SCHEMA.TABLE_STORAGE does not include lakehouse catalog
+        # tables; compute their freshness individually from the tables API.
+        # Errors stay isolated per source so one bad lakehouse source cannot
+        # invalidate the project-wide freshness cache dbt-core builds from this.
+        batch_sources: List[BaseRelation] = []
+        for source in sources:
+            if not getattr(source, "is_lakehouse", False):
+                batch_sources.append(source)
+                continue
+            try:
                 adapter_response, freshness_response = self.calculate_freshness_from_metadata(
                     source, macro_resolver
                 )
+            except (
+                google.api_core.exceptions.NotFound,
+                google.api_core.exceptions.Forbidden,
+                dbt_common.exceptions.DbtRuntimeError,
+            ) as e:
+                logger.warning("Could not compute metadata freshness for {}: {}".format(source, e))
+                continue
+            adapter_responses.append(adapter_response)
+            freshness_responses[source] = freshness_response
+
+        sources = batch_sources
+        if not sources:
+            # the batch macro below indexes relations[0]; nothing left to batch
+            return adapter_responses, freshness_responses
+
+        # Legacy behavior: use metadata-based freshness for each source
+        if not self.behavior.bigquery_use_batch_source_freshness:
+            for source in sources:
+                (
+                    adapter_response,
+                    freshness_response,
+                ) = self.calculate_freshness_from_metadata(source, macro_resolver)
                 adapter_responses.append(adapter_response)
                 freshness_responses[source] = freshness_response
             return adapter_responses, freshness_responses
@@ -1270,10 +1436,63 @@ class BigQueryAdapter(BaseAdapter):
 
         return opts
 
+    def _validate_lakehouse_options(self, config: Dict[str, Any], node: Dict[str, Any]) -> None:
+        schema = node.get("schema")
+        if not is_lakehouse_schema(schema):
+            return
+
+        relation_config = getattr(config, "model", None)
+        if relation_config and (catalog := parse_model.catalog_name(relation_config)):
+            if catalog != constants.DEFAULT_INFO_SCHEMA_CATALOG.name:
+                # a BigLake write integration would emit storage_uri and
+                # WITH CONNECTION into DDL the lakehouse catalog cannot accept
+                raise dbt_common.exceptions.DbtRuntimeError(
+                    f"`catalog_name: {catalog}` cannot be combined with lakehouse schema "
+                    f"`{schema}`; remove the catalog config — Lakehouse "
+                    "Runtime Catalog tables are addressed directly as "
+                    "`project.catalog.namespace.table`"
+                )
+
+        if partition_config := self.parse_partition_by(config.get("partition_by")):
+            if partition_config.data_type.lower() not in (
+                "date",
+                "timestamp",
+                "datetime",
+                "int64",
+            ):
+                # the partition_by macro silently renders NO partition clause for
+                # unknown data types; on lakehouse that traps the user behind the
+                # same-spec CREATE OR REPLACE rule, so fail loudly instead
+                raise dbt_common.exceptions.DbtRuntimeError(
+                    f"dbt-bigquery cannot render a partition clause for "
+                    f"`{partition_config.data_type}`; use date, timestamp, datetime, or int64"
+                )
+            if partition_config.copy_partitions:
+                raise dbt_common.exceptions.DbtRuntimeError(
+                    "`copy_partitions` uses BigQuery copy jobs, which are not supported "
+                    "for lakehouse catalog tables"
+                )
+
+    @available.parse_none
+    def validate_lakehouse_target(
+        self, config: Dict[str, Any], node: Dict[str, Any], language: Optional[str] = None
+    ) -> None:
+        """Reject semantic conflicts and incompatible PCNT writer transports."""
+        self._validate_lakehouse_options(config, node)
+        if (
+            is_lakehouse_schema(node.get("schema"))
+            and (language or node.get("language")) == "python"
+        ):
+            raise dbt_common.exceptions.DbtRuntimeError(
+                "Python models cannot target lakehouse catalog relations: the BigQuery "
+                "Python connectors do not support four-part PCNT destinations"
+            )
+
     @available.parse(lambda *a, **k: {})
     def get_table_options(
         self, config: Dict[str, Any], node: Dict[str, Any], temporary: bool
     ) -> Dict[str, Any]:
+        self._validate_lakehouse_options(config, node)
         opts = self.get_common_options(config, node, temporary)
 
         if config.get("kms_key_name") is not None:

--- a/dbt-bigquery/src/dbt/adapters/bigquery/relation.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/relation.py
@@ -26,6 +26,17 @@ from dbt.adapters.bigquery.relation_configs._cluster import BigQueryClusterConfi
 Self = TypeVar("Self", bound="BigQueryRelation")
 
 
+def is_lakehouse_schema(schema: Optional[str]) -> bool:
+    """True when a schema/dataset id addresses a Lakehouse runtime catalog namespace.
+
+    BigQuery models `catalog.namespace` as a dataset whose id contains a dot;
+    regular dataset ids cannot contain dots, so a dotted schema is unambiguous.
+    This is the single definition of the discriminator — every lakehouse check
+    in the adapter must go through it (or the `is_lakehouse` relation property).
+    """
+    return schema is not None and "." in schema
+
+
 @dataclass(frozen=True, eq=False, repr=False)
 class BigQueryRelation(BaseRelation):
     quote_character: str = "`"
@@ -48,6 +59,21 @@ class BigQueryRelation(BaseRelation):
             }
         )
     )
+
+    def __post_init__(self) -> None:
+        if not self.is_lakehouse:
+            return
+
+        schema_parts = (self.schema or "").split(".")
+        if (
+            len(schema_parts) != 2
+            or not all(schema_parts)
+            or any(part != part.strip() for part in schema_parts)
+        ):
+            raise CompilationError(
+                f"Invalid BigQuery Lakehouse schema `{self.schema}`: expected exactly "
+                "`catalog.namespace` with both parts non-empty"
+            )
 
     def matches(
         self,
@@ -80,6 +106,18 @@ class BigQueryRelation(BaseRelation):
     @property
     def dataset(self):
         return self.schema
+
+    @property
+    def is_lakehouse(self) -> bool:
+        """True when this relation lives in a Lakehouse runtime catalog,
+        addressed as `project.catalog.namespace.table`."""
+        return is_lakehouse_schema(self.schema)
+
+    @property
+    def can_be_renamed(self) -> bool:
+        # BigQuery renames tables with a copy job + delete; copy jobs are not
+        # available for lakehouse catalog tables
+        return super().can_be_renamed and not self.is_lakehouse
 
     @classmethod
     def materialized_view_from_relation_config(

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/adapters.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/adapters.sql
@@ -254,7 +254,43 @@ having count(*) > 1
 
 {% endmacro %}
 
+{% macro bigquery__validate_lakehouse_temp_schema(base_relation) %}
+    {% if base_relation.is_lakehouse %}
+        {#-- lakehouse namespaces don't support expiring helper tables, and temp churn
+             would trigger Iceberg snapshot/management jobs; spill to a regular dataset.
+             `temp_schema` must be a plain dataset colocated with the catalog data. --#}
+        {% set configured_temp_schema = config.get('temp_schema') %}
+        {% set spill_schema = target.schema if configured_temp_schema is none else configured_temp_schema %}
+        {% if spill_schema is not string
+              or not spill_schema | trim
+              or spill_schema != spill_schema | trim
+              or '.' in spill_schema %}
+            {% do exceptions.raise_compiler_error(
+                "Temp relations for lakehouse models must spill to a regular dataset, but `"
+                ~ spill_schema ~ "` is a lakehouse namespace. Set `temp_schema` to a plain "
+                ~ "BigQuery dataset in the same location as the catalog."
+            ) %}
+        {% endif %}
+    {% endif %}
+{% endmacro %}
+
 {% macro bigquery__make_temp_relation(base_relation, suffix) %}
+    {% if base_relation.is_lakehouse %}
+        {% do bigquery__validate_lakehouse_temp_schema(base_relation) %}
+        {% set configured_temp_schema = config.get('temp_schema') %}
+        {% set spill_schema = target.schema if configured_temp_schema is none else configured_temp_schema %}
+        {% set spill_identifier = base_relation.schema | replace('.', '__') ~ '__' ~ base_relation.identifier %}
+        {#-- keep the model's own project: a cross-project lakehouse model must not
+             spill temps into the profile's project --#}
+        {% set base_relation = base_relation.incorporate(path={
+            "database": base_relation.database,
+            "schema": spill_schema,
+            "identifier": spill_identifier
+        }) %}
+        {#-- the spill dataset is not a model schema, so dbt's start-of-run schema
+             creation never covers it; ensure it exists (idempotent) --#}
+        {% do adapter.create_schema(base_relation) %}
+    {% endif %}
     {% set temp_relation = bigquery__make_relation_with_suffix(base_relation, suffix, dstring=True) %}
     {{ return(temp_relation) }}
 {% endmacro %}

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/get_custom_name/get_custom_schema.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/get_custom_name/get_custom_schema.sql
@@ -1,0 +1,21 @@
+{% macro bigquery__generate_schema_name(custom_schema_name, node) -%}
+    {%- set schema_name = custom_schema_name | trim if custom_schema_name is not none else none -%}
+    {%- if schema_name is not none and '.' in schema_name -%}
+        {#-- A dotted BigQuery schema is the literal `catalog.namespace` part of
+             a Lakehouse PCNT name. It must not receive the usual target prefix. --#}
+        {%- set parts = schema_name.split('.') -%}
+        {%- if parts | length != 2
+            or not parts[0]
+            or not parts[1]
+            or parts[0] != parts[0] | trim
+            or parts[1] != parts[1] | trim -%}
+            {%- do exceptions.raise_compiler_error(
+                "Invalid BigQuery Lakehouse schema `" ~ schema_name ~ "`: expected "
+                ~ "exactly `catalog.namespace` with both parts non-empty"
+            ) -%}
+        {%- endif -%}
+        {{ schema_name }}
+    {%- else -%}
+        {{ default__generate_schema_name(custom_schema_name, node) }}
+    {%- endif -%}
+{%- endmacro %}

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/incremental.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/incremental.sql
@@ -75,9 +75,10 @@
   {%- set full_refresh_mode = (should_full_refresh()) -%}
   {%- set language = model['language'] %}
 
+  {#-- Validate before pre-hooks, scratch creation, or any type/full-refresh drop. --#}
+  {% do adapter.validate_lakehouse_target(config, model, language) %}
   {%- set target_relation = this %}
   {%- set existing_relation = load_relation(this) %}
-  {%- set tmp_relation = make_temp_relation(this) %}
 
   {#-- Validate early so we don't run SQL if the strategy is invalid --#}
   {% set strategy = dbt_bigquery_validate_get_incremental_strategy(config) -%}
@@ -114,8 +115,10 @@
       {%- endcall -%}
 
   {% elif full_refresh_mode %}
-      {#-- If the partition/cluster config has changed, then we must drop and recreate --#}
-      {% if not adapter.is_replaceable(existing_relation, partition_by, cluster_by) %}
+      {#-- If the partition/cluster config has changed, then we must drop and recreate.
+           Lakehouse tables always report replaceable but reject a changed partition
+           spec server-side, so full refresh must pre-drop to be a real recovery path --#}
+      {% if not adapter.is_replaceable(existing_relation, partition_by, cluster_by) or existing_relation.is_lakehouse %}
           {% do log("Hard refreshing " ~ existing_relation ~ " because it is not replaceable") %}
           {{ adapter.drop_relation(existing_relation) }}
       {% endif %}
@@ -131,6 +134,14 @@
       {%- endset %}
       {% do exceptions.raise_compiler_error(python_unsupported_msg) %}
     {%- endif -%}
+
+    {#-- Construct a scratch relation only for paths that materialize one. --#}
+    {% set needs_tmp_relation = on_schema_change != 'ignore' or language == 'python' %}
+    {% if strategy in ['insert_overwrite', 'microbatch'] and
+          (partition_by.copy_partitions or partitions is none or partitions == []) %}
+      {% set needs_tmp_relation = true %}
+    {% endif %}
+    {% set tmp_relation = make_temp_relation(this) if needs_tmp_relation else none %}
 
     {% set tmp_relation_exists = false %}
     {% if on_schema_change != 'ignore' or language == 'python' %}

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/table.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/table.sql
@@ -2,6 +2,8 @@
 
   {%- set language = model['language'] -%}
   {%- set identifier = model['alias'] -%}
+  {#-- Validate before pre-hooks or any type/full-refresh drop. --#}
+  {% do adapter.validate_lakehouse_target(config, model, language) %}
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
   {%- set exists_not_as_table = (old_relation is not none and not old_relation.is_table) -%}
   {%- set target_relation = api.Relation.create(database=database, schema=schema, identifier=identifier, type='table') -%}
@@ -24,7 +26,11 @@
   {%- set raw_partition_by = config.get('partition_by', none) -%}
   {%- set partition_by = adapter.parse_partition_by(raw_partition_by) -%}
   {%- set cluster_by = config.get('cluster_by', none) -%}
-  {% if not adapter.is_replaceable(old_relation, partition_by, cluster_by) %}
+  {#-- lakehouse tables always report replaceable (their partition metadata is
+       unreliable), but CREATE OR REPLACE fails server-side on a changed partition
+       spec; an explicit --full-refresh is the recovery path, so it must pre-drop --#}
+  {% set lakehouse_full_refresh = old_relation is not none and old_relation.is_lakehouse and should_full_refresh() %}
+  {% if not adapter.is_replaceable(old_relation, partition_by, cluster_by) or lakehouse_full_refresh %}
     {% do log("Hard refreshing " ~ old_relation ~ " because it is not replaceable") %}
     {% do adapter.drop_relation(old_relation) %}
   {% endif %}

--- a/dbt-bigquery/test.env.example
+++ b/dbt-bigquery/test.env.example
@@ -17,3 +17,9 @@ DBT_TEST_USER_3="serviceAccount:dbt-integration-test-user@dbt-test-env.iam.gserv
 COMPUTE_REGION=us-
 DATAPROC_CLUSTER_NAME=
 GCS_BUCKET=
+
+# only needed for lakehouse runtime catalog tests (tests/functional/adapter/lakehouse)
+# the schema must be an existing catalog.namespace the caller can create tables in
+BIGQUERY_TEST_LAKEHOUSE_DATABASE=
+BIGQUERY_TEST_LAKEHOUSE_SCHEMA=
+BIGQUERY_TEST_LAKEHOUSE_LOCATION=

--- a/dbt-bigquery/tests/functional/adapter/lakehouse/test_lakehouse.py
+++ b/dbt-bigquery/tests/functional/adapter/lakehouse/test_lakehouse.py
@@ -1,0 +1,352 @@
+"""Functional tests for BigQuery Lakehouse runtime catalog support.
+
+These run against a real, pre-provisioned lakehouse catalog and are gated on:
+
+- BIGQUERY_TEST_LAKEHOUSE_DATABASE: the GCP project hosting the catalog
+- BIGQUERY_TEST_LAKEHOUSE_SCHEMA: an existing `catalog.namespace` the caller may
+  create and drop tables in
+- BIGQUERY_TEST_LAKEHOUSE_LOCATION (optional): the catalog's location, so the
+  framework's scratch dataset (also used for temp-relation spill) is colocated
+
+Namespaces cannot be created from BigQuery, so unlike standard functional tests
+these reuse one namespace and keep table names unique per run instead.
+"""
+
+import os
+import time
+
+import pytest
+
+from dbt.tests.util import run_dbt
+
+_DATABASE = os.getenv("BIGQUERY_TEST_LAKEHOUSE_DATABASE")
+_SCHEMA = os.getenv("BIGQUERY_TEST_LAKEHOUSE_SCHEMA")
+_LOCATION = os.getenv("BIGQUERY_TEST_LAKEHOUSE_LOCATION")
+_SUFFIX = f"{os.getpid()}_{int(time.time())}"
+
+pytestmark = pytest.mark.skipif(
+    not (_DATABASE and _SCHEMA),
+    reason="BIGQUERY_TEST_LAKEHOUSE_DATABASE and BIGQUERY_TEST_LAKEHOUSE_SCHEMA "
+    "must point at a provisioned lakehouse catalog namespace",
+)
+
+
+class _LakehouseBase:
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self):
+        target = {
+            "type": "bigquery",
+            "method": "oauth",
+            "threads": 2,
+            "job_retries": 2,
+            "project": _DATABASE,
+        }
+        if _LOCATION:
+            target["location"] = _LOCATION
+        return target
+
+    CLEANUP_ALIASES: tuple = ()
+
+    @pytest.fixture(scope="class", autouse=True)
+    def cleanup_lakehouse_tables(self, project):
+        yield
+        for alias in self.CLEANUP_ALIASES:
+            project.run_sql(f"drop table if exists `{_DATABASE}.{_SCHEMA}.{alias}`")
+
+
+_TABLE_ALIAS = f"zz_dbt_lk_tbl_{_SUFFIX}"
+
+MODEL__TABLE = f"""
+{{{{ config(
+    materialized='table',
+    schema='{_SCHEMA}',
+    alias='{_TABLE_ALIAS}',
+    partition_by={{'field': 'ds', 'data_type': 'date'}},
+) }}}}
+select 1 as id, date '2026-07-01' as ds
+union all
+select 2 as id, date '2026-07-02' as ds
+"""
+
+SOURCES__YML = f"""
+version: 2
+sources:
+  - name: lakehouse
+    database: {_DATABASE}
+    schema: {_SCHEMA}
+    freshness:
+      warn_after: {{count: 480, period: hour}}
+    tables:
+      - name: {_TABLE_ALIAS}
+"""
+
+
+class TestLakehouseTable(_LakehouseBase):
+    CLEANUP_ALIASES = (_TABLE_ALIAS,)
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"lake_table.sql": MODEL__TABLE, "sources.yml": SOURCES__YML}
+
+    def test_table_lifecycle(self, project):
+        # first build
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].node.database == _DATABASE
+        assert results[0].node.schema == _SCHEMA
+
+        rows = project.run_sql(
+            f"select count(*) as n from `{_DATABASE}.{_SCHEMA}.{_TABLE_ALIAS}`",
+            fetch="one",
+        )
+        assert rows[0] == 2
+
+        # steady-state rebuild: must be a same-spec `create or replace`,
+        # never a drop (is_replaceable returns True for lakehouse)
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        # metadata source freshness (tables.get lastModifiedTime path)
+        freshness = run_dbt(["source", "freshness"])
+        assert freshness[0].status in ("pass", "warn")
+
+        # docs generation skips database-derived enrichment for lakehouse relations
+        run_dbt(["docs", "generate"])
+
+
+_INC_ALIAS = f"zz_dbt_lk_inc_{_SUFFIX}"
+
+MODEL__INCREMENTAL = f"""
+{{{{ config(
+    materialized='incremental',
+    incremental_strategy='merge',
+    unique_key='id',
+    schema='{_SCHEMA}',
+    alias='{_INC_ALIAS}',
+    on_schema_change='append_new_columns',
+) }}}}
+select 1 as id, 'a' as val
+{{% if var('extra_col', false) %}}, 'x' as extra{{% endif %}}
+{{% if is_incremental() %}}
+union all
+select 2 as id, 'b' as val
+{{% if var('extra_col', false) %}}, 'y' as extra{{% endif %}}
+{{% endif %}}
+"""
+
+
+class TestLakehouseIncrementalMerge(_LakehouseBase):
+    CLEANUP_ALIASES = (_INC_ALIAS,)
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"lake_incremental.sql": MODEL__INCREMENTAL}
+
+    def test_merge_and_schema_evolution(self, project):
+        # initial build
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        rows = project.run_sql(
+            f"select count(*) as n from `{_DATABASE}.{_SCHEMA}.{_INC_ALIAS}`",
+            fetch="one",
+        )
+        assert rows[0] == 1
+
+        # incremental run adding a row AND a column: exercises the MERGE DML,
+        # the temp-relation spill into the scratch dataset, and the
+        # on_schema_change ALTER TABLE ADD COLUMN DDL branch
+        results = run_dbt(["run", "--vars", "{extra_col: true}"])
+        assert len(results) == 1
+
+        rows = project.run_sql(
+            f"select count(*) as n, count(extra) as extras "
+            f"from `{_DATABASE}.{_SCHEMA}.{_INC_ALIAS}`",
+            fetch="one",
+        )
+        assert rows[0] == 2
+        assert rows[1] >= 1
+
+
+_IO_ALIAS = f"zz_dbt_lk_io_{_SUFFIX}"
+
+MODEL__INSERT_OVERWRITE = f"""
+{{{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partition_by={{'field': 'ds', 'data_type': 'date'}},
+    partitions=["date('2026-07-01')", "date('2026-07-02')"],
+    schema='{_SCHEMA}',
+    alias='{_IO_ALIAS}',
+) }}}}
+select 1 as id, date '2026-07-01' as ds
+union all
+select 2 as id, date '2026-07-02' as ds
+{{% if is_incremental() %}}
+union all
+select 3 as id, date '2026-07-02' as ds
+{{% endif %}}
+"""
+
+
+_IOD_ALIAS = f"zz_dbt_lk_iod_{_SUFFIX}"
+
+MODEL__INSERT_OVERWRITE_DYNAMIC = f"""
+{{{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partition_by={{'field': 'ds', 'data_type': 'date'}},
+    schema='{_SCHEMA}',
+    alias='{_IOD_ALIAS}',
+) }}}}
+select 1 as id, date '2026-07-01' as ds
+union all
+select 2 as id, date '2026-07-02' as ds
+{{% if is_incremental() %}}
+union all
+select 3 as id, date '2026-07-02' as ds
+{{% endif %}}
+"""
+
+
+class TestLakehouseInsertOverwrite(_LakehouseBase):
+    """insert_overwrite rides MERGE DML (dynamic partitions additionally ride a
+    multi-statement script) — verify both live rather than leaving them in the
+    gap between guarded and verified."""
+
+    CLEANUP_ALIASES = (_IO_ALIAS, _IOD_ALIAS)
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "lake_insert_overwrite.sql": MODEL__INSERT_OVERWRITE,
+            "lake_insert_overwrite_dynamic.sql": MODEL__INSERT_OVERWRITE_DYNAMIC,
+        }
+
+    def test_static_insert_overwrite(self, project):
+        results = run_dbt(["run", "--select", "lake_insert_overwrite"])
+        assert len(results) == 1
+        rows = project.run_sql(
+            f"select count(*) as n from `{_DATABASE}.{_SCHEMA}.{_IO_ALIAS}`",
+            fetch="one",
+        )
+        assert rows[0] == 2
+
+        # incremental run replaces the listed partitions with the new output
+        results = run_dbt(["run", "--select", "lake_insert_overwrite"])
+        assert len(results) == 1
+        rows = project.run_sql(
+            f"select count(*) as n from `{_DATABASE}.{_SCHEMA}.{_IO_ALIAS}`",
+            fetch="one",
+        )
+        assert rows[0] == 3
+
+    def test_dynamic_insert_overwrite(self, project):
+        # Build this model independently; test order is not guaranteed.
+        results = run_dbt(["run", "--select", "lake_insert_overwrite_dynamic"])
+        assert len(results) == 1
+        rows = project.run_sql(
+            f"select count(*) as n from `{_DATABASE}.{_SCHEMA}.{_IOD_ALIAS}`",
+            fetch="one",
+        )
+        assert rows[0] == 2
+
+        # The incremental run executes the declare + temp table + merge script.
+        results = run_dbt(["run", "--select", "lake_insert_overwrite_dynamic"])
+        assert len(results) == 1
+        rows = project.run_sql(
+            f"select count(*) as n from `{_DATABASE}.{_SCHEMA}.{_IOD_ALIAS}`",
+            fetch="one",
+        )
+        assert rows[0] == 3
+
+
+_SYNC_ALIAS = f"zz_dbt_lk_sync_{_SUFFIX}"
+
+MODEL__SYNC_ALL_COLUMNS = f"""
+{{{{ config(
+    materialized='incremental',
+    incremental_strategy='merge',
+    unique_key='id',
+    schema='{_SCHEMA}',
+    alias='{_SYNC_ALIAS}',
+    on_schema_change='sync_all_columns',
+) }}}}
+select 1 as id, 'a' as val {{% if not var('drop_col', false) %}}, 'x' as extra{{% endif %}}
+{{% if is_incremental() %}}
+union all
+select 2 as id, 'b' as val {{% if not var('drop_col', false) %}}, 'y' as extra{{% endif %}}
+{{% endif %}}
+"""
+
+
+class TestLakehouseSyncAllColumns(_LakehouseBase):
+    """sync_all_columns column REMOVAL rides the DDL DROP COLUMN path — the one
+    schema-evolution branch the merge test does not reach."""
+
+    CLEANUP_ALIASES = (_SYNC_ALIAS,)
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"lake_sync.sql": MODEL__SYNC_ALL_COLUMNS}
+
+    def test_sync_drops_removed_column(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        # source no longer emits `extra` -> ALTER TABLE ... DROP COLUMN via DDL
+        results = run_dbt(["run", "--vars", "{drop_col: true}"])
+        assert len(results) == 1
+
+        rows = project.run_sql(
+            f"select count(*) as n, count(val) as vals "
+            f"from `{_DATABASE}.{_SCHEMA}.{_SYNC_ALIAS}`",
+            fetch="one",
+        )
+        assert rows[0] == 2
+        assert rows[1] == 2
+        with pytest.raises(Exception):
+            project.run_sql(
+                f"select extra from `{_DATABASE}.{_SCHEMA}.{_SYNC_ALIAS}` limit 1",
+                fetch="one",
+            )
+
+
+_RESPEC_ALIAS = f"zz_dbt_lk_respec_{_SUFFIX}"
+
+MODEL__RESPEC = f"""
+{{{{ config(
+    materialized='table',
+    schema='{_SCHEMA}',
+    alias='{_RESPEC_ALIAS}',
+    partition_by={{'field': 'ts', 'data_type': 'timestamp', 'granularity': var('grain', 'day')}},
+) }}}}
+select timestamp '2026-07-01 00:00:00' as ts, 1 as id
+"""
+
+
+class TestLakehouseFullRefreshRecovery(_LakehouseBase):
+    """A changed partition spec fails CREATE OR REPLACE server-side, and
+    --full-refresh must recover by pre-dropping the Lakehouse table."""
+
+    CLEANUP_ALIASES = (_RESPEC_ALIAS,)
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"lake_respec.sql": MODEL__RESPEC}
+
+    def test_full_refresh_recovers_partition_spec_change(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        # spec change: day -> month; plain CREATE OR REPLACE must fail
+        results = run_dbt(["run", "--vars", "{grain: month}"], expect_pass=False)
+        assert "different partitioning spec" in results[0].message.lower()
+
+        # --full-refresh pre-drops and recreates with the new spec
+        results = run_dbt(["run", "--full-refresh", "--vars", "{grain: month}"])
+        assert len(results) == 1
+        rows = project.run_sql(
+            f"select count(*) as n from `{_DATABASE}.{_SCHEMA}.{_RESPEC_ALIAS}`",
+            fetch="one",
+        )
+        assert rows[0] == 1

--- a/dbt-bigquery/tests/unit/test_lakehouse.py
+++ b/dbt-bigquery/tests/unit/test_lakehouse.py
@@ -1,0 +1,541 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import google.api_core.exceptions
+import jinja2
+import pytest
+
+from dbt.adapters.bigquery import BigQueryAdapter
+from dbt.adapters.bigquery.relation import BigQueryRelation, is_lakehouse_schema
+from dbt.adapters.contracts.relation import RelationType
+from dbt_common.exceptions import CompilationError, DbtDatabaseError, DbtRuntimeError
+
+
+def lakehouse_relation(identifier="my_table", type=RelationType.Table):
+    return BigQueryRelation.create(
+        database="my-project",
+        schema="my_catalog.my_namespace",
+        identifier=identifier,
+        type=type,
+    )
+
+
+def standard_relation(identifier="my_table", type=RelationType.Table):
+    return BigQueryRelation.create(
+        database="my-project",
+        schema="my_dataset",
+        identifier=identifier,
+        type=type,
+    )
+
+
+class TestLakehouseRelation:
+    def test_is_lakehouse_for_dotted_schema(self):
+        assert lakehouse_relation().is_lakehouse is True
+
+    def test_is_not_lakehouse_for_regular_schema(self):
+        assert standard_relation().is_lakehouse is False
+
+    def test_is_not_lakehouse_without_schema(self):
+        relation = BigQueryRelation.create(database="my-project", identifier="my_table")
+        assert relation.is_lakehouse is False
+
+    def test_is_lakehouse_schema_predicate(self):
+        assert is_lakehouse_schema("my_catalog.my_namespace") is True
+        assert is_lakehouse_schema("my_dataset") is False
+        assert is_lakehouse_schema(None) is False
+
+    def test_render_matches_stock_form(self):
+        # BigQuery normalizes backticked paths, so the stock per-component
+        # rendering is a valid four-part reference
+        assert lakehouse_relation().render() == "`my-project`.`my_catalog.my_namespace`.`my_table`"
+
+    def test_lakehouse_table_cannot_be_renamed(self):
+        assert standard_relation().can_be_renamed is True
+        assert lakehouse_relation().can_be_renamed is False
+
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            ".test_namespace",
+            "test_catalog.",
+            ".",
+            "a..b",
+            "a.b.c",
+            "test_catalog. test_namespace",
+        ],
+    )
+    def test_invalid_dotted_schema_fails_when_relation_is_created(self, schema):
+        with pytest.raises(CompilationError, match="catalog.namespace"):
+            BigQueryRelation.create(
+                database="my-project",
+                schema=schema,
+                identifier="my_table",
+            )
+
+
+class TestLakehouseSchemaNaming:
+    @staticmethod
+    def _generate_schema_name():
+        macro_root = Path(__file__).parents[2] / "src/dbt/include/bigquery/macros"
+        environment = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(macro_root),
+            extensions=["jinja2.ext.do"],
+        )
+        template = environment.get_template("get_custom_name/get_custom_schema.sql")
+
+        def default_generate_schema_name(custom_schema_name, _node):
+            if custom_schema_name is None:
+                return "target_schema"
+            return f"target_schema_{custom_schema_name.strip()}"
+
+        def raise_compiler_error(message):
+            raise DbtRuntimeError(message)
+
+        module = template.make_module(
+            {
+                "default__generate_schema_name": default_generate_schema_name,
+                "exceptions": SimpleNamespace(raise_compiler_error=raise_compiler_error),
+            }
+        )
+        return module.bigquery__generate_schema_name
+
+    @pytest.mark.parametrize(
+        ("custom_schema_name", "expected"),
+        [
+            (None, "target_schema"),
+            ("analytics", "target_schema_analytics"),
+            (" test_catalog.test_namespace ", "test_catalog.test_namespace"),
+        ],
+    )
+    def test_schema_name_generation(self, custom_schema_name, expected):
+        result = self._generate_schema_name()(custom_schema_name, None)
+        assert result.strip() == expected
+
+    @pytest.mark.parametrize(
+        "schema_name",
+        [
+            ".test_namespace",
+            "test_catalog.",
+            ".",
+            "a..b",
+            "a.b.c",
+            "test_catalog. test_namespace",
+            "test_catalog .test_namespace",
+        ],
+    )
+    def test_invalid_lakehouse_schema_raises(self, schema_name):
+        with pytest.raises(DbtRuntimeError, match="catalog.namespace"):
+            self._generate_schema_name()(schema_name, None)
+
+
+class TestLakehouseTempSchemaValidation:
+    @staticmethod
+    def _validate(configured_temp_schema, target_schema="scratch_dataset"):
+        macro_root = Path(__file__).parents[2] / "src/dbt/include/bigquery/macros"
+        environment = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(macro_root),
+            extensions=["jinja2.ext.do"],
+        )
+        template = environment.get_template("adapters.sql")
+
+        def raise_compiler_error(message):
+            raise DbtRuntimeError(message)
+
+        config = {}
+        if configured_temp_schema is not None:
+            config["temp_schema"] = configured_temp_schema
+        module = template.make_module(
+            {
+                "config": config,
+                "target": SimpleNamespace(schema=target_schema),
+                "exceptions": SimpleNamespace(raise_compiler_error=raise_compiler_error),
+            }
+        )
+        module.bigquery__validate_lakehouse_temp_schema(SimpleNamespace(is_lakehouse=True))
+
+    @pytest.mark.parametrize("temp_schema", ["scratch_dataset", "scratch_123"])
+    def test_plain_temp_schema_is_accepted(self, temp_schema):
+        self._validate(temp_schema)
+
+    @pytest.mark.parametrize(
+        "temp_schema",
+        ["catalog.namespace", "", " scratch", "scratch ", 123],
+    )
+    def test_invalid_explicit_temp_schema_is_rejected(self, temp_schema):
+        with pytest.raises(DbtRuntimeError, match="regular dataset"):
+            self._validate(temp_schema)
+
+    def test_dotted_default_target_schema_is_rejected(self):
+        with pytest.raises(DbtRuntimeError, match="regular dataset"):
+            self._validate(None, target_schema="catalog.namespace")
+
+
+class TestLakehouseGuards:
+    """The guards are the first statements of their methods, so they can be
+    exercised as unbound calls with a mocked adapter instance."""
+
+    def test_rename_relation_raises(self):
+        with pytest.raises(DbtRuntimeError, match="rename"):
+            BigQueryAdapter.rename_relation(
+                MagicMock(), lakehouse_relation(), standard_relation("other")
+            )
+
+    def test_copy_table_raises_for_scalar_source(self):
+        with pytest.raises(DbtRuntimeError, match="copy"):
+            BigQueryAdapter.copy_table(
+                MagicMock(), standard_relation(), lakehouse_relation(), "table"
+            )
+
+    def test_copy_table_raises_for_list_source(self):
+        # the copy materialization passes `source` as a list of relations;
+        # the guard must inspect the elements, not the list object
+        with pytest.raises(DbtRuntimeError, match="copy"):
+            BigQueryAdapter.copy_table(
+                MagicMock(), [lakehouse_relation()], standard_relation("dest"), "table"
+            )
+
+    def test_drop_schema_raises(self):
+        with pytest.raises(DbtRuntimeError, match="not supported"):
+            BigQueryAdapter.drop_schema(MagicMock(), lakehouse_relation())
+
+
+class TestLakehouseSchemaLifecycle:
+    def test_create_schema_noops_when_namespace_exists(self):
+        mock_self = MagicMock()
+        mock_self.check_schema_exists.return_value = True
+
+        BigQueryAdapter.create_schema(mock_self, lakehouse_relation())
+
+        mock_self.check_schema_exists.assert_called_once_with(
+            "my-project", "my_catalog.my_namespace"
+        )
+        mock_self.execute_macro.assert_not_called()
+
+    def test_create_schema_raises_when_namespace_missing(self):
+        mock_self = MagicMock()
+        mock_self.check_schema_exists.return_value = False
+
+        with pytest.raises(DbtRuntimeError, match="does not exist"):
+            BigQueryAdapter.create_schema(mock_self, lakehouse_relation())
+
+    def test_check_schema_exists_uses_datasets_get_for_lakehouse(self):
+        # a tables.list probe is unreliable for EMPTY namespaces
+        mock_self = MagicMock()
+        client = mock_self.connections.get_thread_connection.return_value.handle
+
+        assert (
+            BigQueryAdapter.check_schema_exists(mock_self, "my-project", "my_catalog.my_ns")
+            is True
+        )
+        client.get_dataset.assert_called_once()
+        client.list_tables.assert_not_called()
+
+        client.get_dataset.side_effect = google.api_core.exceptions.NotFound("missing")
+        assert (
+            BigQueryAdapter.check_schema_exists(mock_self, "my-project", "my_catalog.my_ns")
+            is False
+        )
+
+    def test_get_relation_skips_routine_fallback(self):
+        mock_self = MagicMock()
+        mock_self._schema_is_cached.return_value = False
+        mock_self.connections.get_bq_table.side_effect = google.api_core.exceptions.NotFound(
+            "missing"
+        )
+
+        # RoutineReference.from_string would raise ValueError on a four-part id;
+        # reaching `None` proves the fallback was skipped
+        result = BigQueryAdapter.get_relation(
+            mock_self, "my-project", "my_catalog.my_namespace", "my_table"
+        )
+
+        assert result is None
+
+
+class TestLakehouseReplaceability:
+    def test_is_replaceable_true_without_metadata_probe(self):
+        # Iceberg tables report no partition metadata via the tables API, so a
+        # config comparison would force a destructive drop+create on every run
+        mock_self = MagicMock()
+
+        result = BigQueryAdapter.is_replaceable(
+            mock_self, lakehouse_relation(), MagicMock(), ["col"]
+        )
+
+        assert result is True
+        mock_self.connections.get_bq_table.assert_not_called()
+
+
+class TestLakehouseFreshnessRouting:
+    def test_batch_freshness_routes_lakehouse_sources_individually(self):
+        mock_self = MagicMock()
+        freshness = object()
+        mock_self.calculate_freshness_from_metadata.return_value = (None, freshness)
+        source = lakehouse_relation()
+
+        (
+            responses,
+            freshness_responses,
+        ) = BigQueryAdapter.calculate_freshness_from_metadata_batch(mock_self, [source])
+
+        mock_self.calculate_freshness_from_metadata.assert_called_once_with(source, None)
+        assert freshness_responses == {source: freshness}
+        # the batch macro path must not run when only lakehouse sources exist
+        mock_self.execute_macro.assert_not_called()
+
+    def test_batch_freshness_isolates_failing_lakehouse_source(self):
+        # one bad lakehouse source must not raise out of the batch method:
+        # dbt-core would discard the whole project's metadata freshness cache
+        mock_self = MagicMock()
+        mock_self.calculate_freshness_from_metadata.side_effect = (
+            google.api_core.exceptions.NotFound("gone")
+        )
+        source = lakehouse_relation()
+
+        (
+            responses,
+            freshness_responses,
+        ) = BigQueryAdapter.calculate_freshness_from_metadata_batch(mock_self, [source])
+
+        assert freshness_responses == {}
+        mock_self.execute_macro.assert_not_called()
+
+
+class TestLakehouseDropRelation:
+    def test_drop_relation_uses_sql_ddl(self):
+        mock_self = MagicMock()
+        mock_self._schema_is_cached.return_value = False
+        relation = lakehouse_relation()
+
+        BigQueryAdapter.drop_relation(mock_self, relation)
+
+        mock_self.execute.assert_called_once_with(f"drop table if exists {relation}")
+        mock_self.connections.get_thread_connection.assert_not_called()
+
+    def test_drop_relation_tolerates_missing_namespace(self):
+        # parity with delete_table(not_found_ok=True), which swallowed a 404
+        # for a namespace dropped by the catalog-managing engine
+        mock_self = MagicMock()
+        mock_self._schema_is_cached.return_value = False
+        mock_self.execute.side_effect = DbtDatabaseError("Not found: Dataset my-project:x")
+
+        BigQueryAdapter.drop_relation(mock_self, lakehouse_relation())
+
+    def test_drop_relation_reraises_other_errors(self):
+        mock_self = MagicMock()
+        mock_self._schema_is_cached.return_value = False
+        mock_self.execute.side_effect = DbtDatabaseError("Access Denied")
+
+        with pytest.raises(DbtDatabaseError, match="Access Denied"):
+            BigQueryAdapter.drop_relation(mock_self, lakehouse_relation())
+
+
+class TestLakehouseSchemaEvolution:
+    def _mock_self_with_empty_table(self):
+        mock_self = MagicMock()
+        client = mock_self.connections.get_thread_connection.return_value.handle
+        client.get_table.return_value.schema = []
+        mock_self.quote.side_effect = lambda name: f"`{name}`"
+        return mock_self, client
+
+    def test_alter_table_add_columns_uses_ddl(self):
+        mock_self, client = self._mock_self_with_empty_table()
+        relation = lakehouse_relation()
+        add_columns = [SimpleNamespace(name="new_col", data_type="STRING")]
+
+        BigQueryAdapter.alter_table_add_remove_columns(mock_self, relation, add_columns, None)
+
+        executed_sql = mock_self.execute.call_args[0][0]
+        assert executed_sql == f"alter table {relation.render()} add column `new_col` STRING"
+        client.update_table.assert_not_called()
+
+    def test_alter_table_add_nested_column_raises(self):
+        mock_self, client = self._mock_self_with_empty_table()
+        add_columns = [SimpleNamespace(name="parent.child", data_type="STRING")]
+
+        with pytest.raises(DbtRuntimeError, match="nested STRUCT"):
+            BigQueryAdapter.alter_table_add_remove_columns(
+                mock_self, lakehouse_relation(), add_columns, None
+            )
+        client.update_table.assert_not_called()
+
+    def test_nested_addition_is_rejected_before_any_drop(self):
+        mock_self, client = self._mock_self_with_empty_table()
+        add_columns = [SimpleNamespace(name="parent.child", data_type="STRING")]
+        remove_columns = [SimpleNamespace(name="old_col", data_type="STRING")]
+
+        with pytest.raises(DbtRuntimeError, match="nested STRUCT"):
+            BigQueryAdapter.alter_table_add_remove_columns(
+                mock_self, lakehouse_relation(), add_columns, remove_columns
+            )
+
+        mock_self.execute.assert_not_called()
+        client.get_table.assert_not_called()
+
+    def test_drop_and_readd_same_column_raises(self):
+        # documented Lakehouse limitation: DROP COLUMN then re-adding the same
+        # name fails server-side; the guard must fire before the drop executes
+        mock_self, client = self._mock_self_with_empty_table()
+        add_columns = [SimpleNamespace(name="x", data_type="STRING")]
+        remove_columns = [SimpleNamespace(name="x", data_type="INT64")]
+
+        with pytest.raises(DbtRuntimeError, match="re-add"):
+            BigQueryAdapter.alter_table_add_remove_columns(
+                mock_self, lakehouse_relation(), add_columns, remove_columns
+            )
+        mock_self.execute.assert_not_called()
+        client.update_table.assert_not_called()
+
+    def test_update_columns_skips_lakehouse(self):
+        mock_self = MagicMock()
+
+        BigQueryAdapter.update_columns(mock_self, lakehouse_relation(), {"col": {}})
+
+        mock_self.connections.get_thread_connection.assert_not_called()
+
+    def test_update_table_description_skips_lakehouse(self):
+        mock_self = MagicMock()
+
+        BigQueryAdapter.update_table_description(
+            mock_self, "my-project", "my_catalog.my_namespace", "my_table", "desc"
+        )
+
+        mock_self.connections.get_thread_connection.assert_not_called()
+
+
+class TestLakehouseOptionValidation:
+    def _validate(self, config, node=None, model=None):
+        adapter = BigQueryAdapter.__new__(BigQueryAdapter)
+        node = node or {
+            "schema": "my_catalog.my_namespace",
+            "database": "my-project",
+            "alias": "t",
+        }
+        config_mock = MagicMock()
+        config_mock.get.side_effect = lambda key, default=None: config.get(key, default)
+        config_mock.model = model
+        return adapter._validate_lakehouse_options(config_mock, node)
+
+    def test_table_options_are_left_to_bigquery(self):
+        self._validate(
+            {
+                "cluster_by": ["col"],
+                "hours_to_expiration": 24,
+                "kms_key_name": "key",
+                "require_partition_filter": True,
+                "partition_expiration_days": 7,
+                "enable_change_history": True,
+                "grants": {"select": ["user:reader@example.com"]},
+                "partition_by": {"field": "day", "data_type": "date"},
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "partition_by",
+        [
+            {
+                "field": "id",
+                "data_type": "int64",
+                "range": {"start": 0, "end": 100, "interval": 10},
+            },
+            {"field": "day", "data_type": "date", "granularity": "hour"},
+            {"field": "ts", "data_type": "timestamp", "granularity": "week"},
+        ],
+    )
+    def test_rendered_partition_variants_are_left_to_bigquery(self, partition_by):
+        self._validate({"partition_by": partition_by})
+
+    def test_copy_partitions_inside_partition_by_raises(self):
+        # the canonical spelling lives inside partition_by, not at the top level
+        partition_by = {"field": "day", "data_type": "date", "copy_partitions": True}
+        with pytest.raises(DbtRuntimeError, match="`copy_partitions` uses BigQuery copy jobs"):
+            self._validate({"partition_by": partition_by})
+
+    def test_string_partitioning_raises(self):
+        # the partition_by macro renders NO clause for unknown data types; on
+        # lakehouse that silently creates an unpartitioned table the user can
+        # never re-spec through CREATE OR REPLACE
+        partition_by = {"field": "country", "data_type": "string"}
+        with pytest.raises(DbtRuntimeError, match="cannot render a partition clause"):
+            self._validate({"partition_by": partition_by})
+
+    def test_non_lakehouse_node_skips_validation(self):
+        node = {"schema": "my_dataset", "database": "my-project", "alias": "t"}
+        self._validate({"cluster_by": ["col"]}, node=node)
+
+    @pytest.mark.parametrize("config_key", ["catalog_name", "catalog"])
+    def test_biglake_catalog_config_conflict_raises(self, config_key):
+        # a biglake write integration would emit storage_uri/WITH CONNECTION
+        # into lakehouse DDL
+        model = SimpleNamespace(config={config_key: "managed_iceberg"})
+        with pytest.raises(DbtRuntimeError, match="cannot be combined"):
+            self._validate({}, model=model)
+
+    def test_no_catalog_config_passes(self):
+        model = SimpleNamespace(config={})
+        self._validate({}, model=model)
+
+    def test_python_target_is_rejected_by_early_validator(self):
+        adapter = BigQueryAdapter.__new__(BigQueryAdapter)
+        config_mock = MagicMock()
+        config_mock.get.side_effect = lambda key, default=None: default
+        config_mock.model = None
+        node = {
+            "schema": "my_catalog.my_namespace",
+            "database": "my-project",
+            "alias": "t",
+            "language": "python",
+        }
+
+        with pytest.raises(DbtRuntimeError, match="Python models cannot target"):
+            adapter.validate_lakehouse_target(config_mock, node, "python")
+
+
+class TestLakehouseOptionEmission:
+    def _table_options(self, config, node):
+        mock_self = MagicMock()
+        mock_self.get_common_options.return_value = {}
+        mock_self.build_catalog_relation.return_value = None
+        config_mock = MagicMock()
+        config_mock.get.side_effect = lambda key, default=None: config.get(key, default)
+        config_mock.model = None
+        return BigQueryAdapter.get_table_options(mock_self, config_mock, node, temporary=False)
+
+    def test_table_options_are_not_silently_suppressed_for_lakehouse(self):
+        node = {
+            "schema": "my_catalog.my_namespace",
+            "database": "my-project",
+            "alias": "t",
+        }
+        config = {
+            "partition_by": {"field": "day", "data_type": "date"},
+            "require_partition_filter": False,
+            "partition_expiration_days": 0,
+            "enable_change_history": False,
+        }
+
+        opts = self._table_options(config, node)
+
+        assert opts["require_partition_filter"] is False
+        assert opts["partition_expiration_days"] == 0
+        assert opts["enable_change_history"] is False
+
+
+class TestLakehouseCommonOptions:
+    def _common_options(self, config, node):
+        mock_self = MagicMock()
+        config_mock = MagicMock()
+        config_mock.get.side_effect = lambda key, default=None: config.get(key, default)
+        config_mock.persist_relation_docs.return_value = False
+        return BigQueryAdapter.get_common_options(mock_self, config_mock, node)
+
+    def test_hours_to_expiration_is_not_silently_suppressed_for_lakehouse(self):
+        node = {
+            "schema": "my_catalog.my_namespace",
+            "database": "my-project",
+            "alias": "t",
+        }
+        opts = self._common_options({"hours_to_expiration": 0}, node)
+        assert "expiration_timestamp" in opts


### PR DESCRIPTION
resolves #2066

  [docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) TBD

  ### Problem

  BigQuery Lakehouse Runtime Catalog addresses Iceberg tables using four-part PCNT: `project.catalog.namespace.table` names, while dbt relations expose three fields: database, schema, and identifier.

  BigQuery’s APIs already provide a lossless three-field representation:

  ```text
  projectId = project
  datasetId = catalog.namespace
  tableId   = table
```
  ### Solution

  Represent Lakehouse tables through dbt’s existing relation contract as:
```
  database   = project
  schema     = catalog.namespace
  identifier = table
```

  The implementation deliberately does not introduce a Lakehouse-specific CatalogIntegration or require catalogs.yml. The catalog is part of the relation address and does not independently define storage options, connections, or alternative table-creation behavioor.

  A shared fourth relation component was also considered, but BigQuery already exposes the required mapping through datasetId = catalog.namespace. Extending dbt’s common relation model would require broad changes across adapters, manifests, cache keys, quoting, and metadata APIs without adding information for BigQuery.


The commits with the main logic
  - 8a6ebbe27 — feat(bigquery): support Lakehouse PCNT relation naming
  - 68715024e — feat(bigquery): support Lakehouse PCNT table workflows
  - 5ba49abf1 — test(bigquery): add Lakehouse PCNT coverage



Things that I left behind because I felt that this PR could blow up on feature implementation and also because they are missing from lakehouse support:
  - dbt snapshot support and lifecycle validation.
  - Proper dbt docs generate column/statistics enrichment without duplicating SQL metadata definitions. (information schema doesn't work but it can be retrieved by the bq api)
  - Dedicated support for views, materialized views, and seeds.
  - Lakehouse-aware grants or documented catalog-level IAM integration.
  - persist_docs support for table and column descriptions.
  - Python model support.
  - Alternatives for rename, copy, clone, and copy_partitions.
  



  ### Checklist

  - [x] I have read the contributing guide (https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
  - [x] I have run this code in development and it appears to resolve the stated issue
  - [x] This PR includes tests, or tests are not required/relevant for this PR
  - [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX