### PR TITLE
pin pyathena to less than 3.35

### DIFF
--- a/dbt-athena/.changes/unreleased/Dependencies-20260714-164035.yaml
+++ b/dbt-athena/.changes/unreleased/Dependencies-20260714-164035.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Pin pyathena to <3.34
+time: 2026-07-14T16:40:35.144165+05:30
+custom:
+    Author: ash2shukla
+    PR: ' '

--- a/dbt-athena/.changes/unreleased/Dependencies-20260714-164035.yaml
+++ b/dbt-athena/.changes/unreleased/Dependencies-20260714-164035.yaml
@@ -3,4 +3,4 @@ body: Pin pyathena to <3.34
 time: 2026-07-14T16:40:35.144165+05:30
 custom:
     Author: ash2shukla
-    PR: ' '
+    PR: '2071'

--- a/dbt-athena/pyproject.toml
+++ b/dbt-athena/pyproject.toml
@@ -34,7 +34,7 @@ dependencies=[
     "boto3>=1.28",
     "boto3-stubs[athena,glue,lakeformation,sts]>=1.28",
     "mmh3>=4.0.1,<4.2.0",
-    "pyathena>=2.25,<4.0",
+    "pyathena>=2.25,<3.35",
     "pydantic>=1.10,<3.0",
     "tenacity>=8.2,<10.0",
 ]


### PR DESCRIPTION
resolves #2061 

### Problem
Pyathena 3.35 breaks execute options interface

### Solution
Pin to < 3.35, once we increase floor to  > 3.35 we will make ExecuteOptions changes in the execute call.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
