### PR TITLE
add defensive get for catalog_name

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fixes-20260714-210000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20260714-210000.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Check for model catalog_name defensively
+time: 2026-07-14T21:00:00.837615+05:30
+custom:
+    Author: ash2shukla
+    Issue: "2004"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/parse_model.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/parse_model.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 from dbt.adapters.contracts.relation import RelationConfig
 
@@ -6,16 +6,27 @@ from dbt.adapters.catalogs import CATALOG_INTEGRATION_MODEL_CONFIG_NAME
 from dbt.adapters.bigquery import constants
 
 
+def _config_get(config: Any, key: str) -> Any:
+    """Read ``key`` from a node config that may not be dict-like.
+
+    Some node configs are typed, non-mapping objects (e.g. a saved-query export's
+    ``ExportConfig``, which has no ``.get``). Return None for those rather than
+    raising AttributeError.
+    """
+    get = getattr(config, "get", None)
+    return get(key) if callable(get) else None
+
+
 def catalog_name(model: RelationConfig) -> Optional[str]:
     # while this looks equivalent to `if not getattr(model, "config", None):`, `mypy` disagrees
     if not hasattr(model, "config") or not model.config:
         return None
 
-    if _catalog := model.config.get(CATALOG_INTEGRATION_MODEL_CONFIG_NAME):
+    if _catalog := _config_get(model.config, CATALOG_INTEGRATION_MODEL_CONFIG_NAME):
         return _catalog
 
     # TODO: deprecate this as it's been replaced with catalog_name
-    if _catalog := model.config.get("catalog"):
+    if _catalog := _config_get(model.config, "catalog"):
         return _catalog
 
     return constants.DEFAULT_INFO_SCHEMA_CATALOG.name

--- a/dbt-bigquery/tests/functional/adapter/catalog_integrations/test_saved_query_export.py
+++ b/dbt-bigquery/tests/functional/adapter/catalog_integrations/test_saved_query_export.py
@@ -10,6 +10,22 @@ MODEL__ORDERS = """
 select 1 as id, 10 as amount, cast('2020-01-01' as datetime) as ordered_at
 """
 
+# The semantic layer requires a time spine model with DAY (or finer) granularity.
+MODEL__TIME_SPINE = """
+{{ config(materialized='table') }}
+select cast('2020-01-01' as date) as date_day
+"""
+
+TIME_SPINE__YML = """
+models:
+  - name: metricflow_time_spine
+    time_spine:
+      standard_granularity_column: date_day
+    columns:
+      - name: date_day
+        granularity: day
+"""
+
 SEMANTIC_MODELS__YML = """
 semantic_models:
   - name: orders
@@ -59,6 +75,8 @@ class TestSavedQueryExportParse:
     def models(self):
         return {
             "orders.sql": MODEL__ORDERS,
+            "metricflow_time_spine.sql": MODEL__TIME_SPINE,
+            "time_spine.yml": TIME_SPINE__YML,
             "semantic_models.yml": SEMANTIC_MODELS__YML,
             "metrics.yml": METRICS__YML,
             "saved_queries.yml": SAVED_QUERIES__YML,

--- a/dbt-bigquery/tests/functional/adapter/catalog_integrations/test_saved_query_export.py
+++ b/dbt-bigquery/tests/functional/adapter/catalog_integrations/test_saved_query_export.py
@@ -1,0 +1,69 @@
+from dbt.tests.util import run_dbt
+import pytest
+
+
+# A saved query with an export carries a typed ``ExportConfig`` on the export node
+# (not a dict). Parsing it runs the adapter's ``generate_database_name`` ->
+# ``build_catalog_relation`` -> ``parse_model.catalog_name`` path, which must not
+# raise ``AttributeError: 'ExportConfig' object has no attribute 'get'``.
+MODEL__ORDERS = """
+select 1 as id, 10 as amount, cast('2020-01-01' as datetime) as ordered_at
+"""
+
+SEMANTIC_MODELS__YML = """
+semantic_models:
+  - name: orders
+    model: ref('orders')
+    defaults:
+      agg_time_dimension: ordered_at
+    entities:
+      - name: id
+        type: primary
+    dimensions:
+      - name: ordered_at
+        type: time
+        type_params:
+          time_granularity: day
+    measures:
+      - name: total_amount
+        agg: sum
+        expr: amount
+"""
+
+METRICS__YML = """
+metrics:
+  - name: total_amount
+    label: Total Amount
+    type: simple
+    type_params:
+      measure: total_amount
+"""
+
+SAVED_QUERIES__YML = """
+saved_queries:
+  - name: my_saved_query
+    query_params:
+      metrics:
+        - total_amount
+      group_by:
+        - "Dimension('orders__ordered_at')"
+    exports:
+      - name: my_export
+        config:
+          export_as: table
+"""
+
+
+class TestSavedQueryExportParse:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "orders.sql": MODEL__ORDERS,
+            "semantic_models.yml": SEMANTIC_MODELS__YML,
+            "metrics.yml": METRICS__YML,
+            "saved_queries.yml": SAVED_QUERIES__YML,
+        }
+
+    def test_parse_saved_query_export(self, project):
+        # Regression: this used to raise AttributeError on the export's ExportConfig.
+        run_dbt(["parse"])


### PR DESCRIPTION
resolves #2004 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

### Problem
bigquery export config on model node fails due to non existent catalog_name

### Solution
Add a defensive get and if attribute doesn't exist just consider model node has no catalog associated with it

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
