### PR TITLE
add fix for node.config.get to avoid AttributeError

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20260715-031943.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20260715-031943.yaml
@@ -3,4 +3,4 @@ body: Make sure that for calling build_catalog_relation node has a mapping type 
 time: 2026-07-15T03:19:43.785555+05:30
 custom:
     Author: ash2shukla
-    Issue: "12345"
+    Issue: "2073"

--- a/dbt-adapters/.changes/unreleased/Fixes-20260715-031943.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20260715-031943.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Make sure that for calling build_catalog_relation node has a mapping type config
+time: 2026-07-15T03:19:43.785555+05:30
+custom:
+    Author: ash2shukla
+    Issue: "12345"

--- a/dbt-adapters/src/dbt/include/global_project/macros/get_custom_name/get_custom_database.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/get_custom_name/get_custom_database.sql
@@ -19,7 +19,7 @@
 
 {% macro default__generate_database_name(custom_database_name=none, node=none) -%}
     {%- set default_database = target.database -%}
-    {%- if node is not none -%}
+    {%- if node is not none and node|attr('database') -%}
         {%- set catalog_relation = adapter.build_catalog_relation(node) -%}
         {%- if catalog_relation and catalog_relation|attr('catalog_database') -%}
             {{ return(catalog_relation.catalog_database) }}


### PR DESCRIPTION
resolves #2073

### Problem
default__generate_database_name calls build_catalog_relation for all node types

### Solution
Gate the call for node types that have database attribute and have mappable config attribute ( ie. seeds, snapshots, models and sources )

### Test
Always sunny passes for one of the downstream failing adapters ( trino ) - https://github.com/dbt-labs/always-sunny/actions/runs/29372893686/job/87220024772


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
