### PR TITLE
fix(snowflake): detect query body changes in dynamic table config changeset

### DIFF
--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
@@ -28,6 +28,7 @@ from dbt.adapters.snowflake.relation_configs import (
     SnowflakeDynamicTableImmutableWhereConfigChange,
     SnowflakeDynamicTableClusterByConfigChange,
     SnowflakeDynamicTableTransientConfigChange,
+    SnowflakeDynamicTableQueryConfigChange,
     SnowflakeQuotePolicy,
     SnowflakeRelationType,
 )
@@ -105,6 +106,12 @@ class SnowflakeRelation(BaseRelation):
         new_dynamic_table = SnowflakeDynamicTableConfig.from_relation_config(relation_config)
 
         config_change_collection = SnowflakeDynamicTableConfigChangeset()
+
+        if new_dynamic_table.query != existing_dynamic_table.query:
+            config_change_collection.query = SnowflakeDynamicTableQueryConfigChange(
+                action=RelationConfigChangeAction.create,  # type:ignore
+                context=new_dynamic_table.query,
+            )
 
         if (
             new_dynamic_table.target_lag != existing_dynamic_table.target_lag

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/__init__.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/__init__.py
@@ -11,6 +11,7 @@ from dbt.adapters.snowflake.relation_configs.dynamic_table import (
     SnowflakeDynamicTableImmutableWhereConfigChange,
     SnowflakeDynamicTableClusterByConfigChange,
     SnowflakeDynamicTableTransientConfigChange,
+    SnowflakeDynamicTableQueryConfigChange,
 )
 from dbt.adapters.snowflake.relation_configs.policies import (
     SnowflakeIncludePolicy,

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation_configs/dynamic_table.py
@@ -318,8 +318,18 @@ class SnowflakeDynamicTableTransientConfigChange(RelationConfigChange):
         return True
 
 
+@dataclass(frozen=True, eq=True, unsafe_hash=True)
+class SnowflakeDynamicTableQueryConfigChange(RelationConfigChange):
+    context: Optional[str] = None
+
+    @property
+    def requires_full_refresh(self) -> bool:
+        return True
+
+
 @dataclass
 class SnowflakeDynamicTableConfigChangeset:
+    query: Optional[SnowflakeDynamicTableQueryConfigChange] = None
     target_lag: Optional[SnowflakeDynamicTableTargetLagConfigChange] = None
     snowflake_warehouse: Optional[SnowflakeDynamicTableWarehouseConfigChange] = None
     snowflake_initialization_warehouse: Optional[
@@ -335,6 +345,7 @@ class SnowflakeDynamicTableConfigChangeset:
     def requires_full_refresh(self) -> bool:
         return any(
             [
+                self.query.requires_full_refresh if self.query else False,
                 self.target_lag.requires_full_refresh if self.target_lag else False,
                 (
                     self.snowflake_warehouse.requires_full_refresh
@@ -358,6 +369,7 @@ class SnowflakeDynamicTableConfigChangeset:
     def has_changes(self) -> bool:
         return any(
             [
+                self.query,
                 self.target_lag,
                 self.snowflake_warehouse,
                 self.snowflake_initialization_warehouse,


### PR DESCRIPTION
## Summary

`SnowflakeDynamicTableConfigChangeset.has_changes` checks `target_lag`, `snowflake_warehouse`, `refresh_mode`, etc. but **not the query body**. When only the SQL of a dynamic table model changes (no config param diff), dbt logs `No configuration changes were identified` and skips the DDL — the Snowflake dynamic table silently keeps its old query.

- Adds `SnowflakeDynamicTableQueryConfigChange` with `requires_full_refresh = True` (query changes require `CREATE OR REPLACE`, not `ALTER`)
- Adds `query` field to `SnowflakeDynamicTableConfigChangeset`
- Wires up the comparison in `dynamic_table_config_changeset` in `relation.py`
- Exports the new class from `relation_configs/__init__.py`

## Reproduction

1. Create a dbt dynamic table model and run it
2. Change only the SQL body (e.g. add a row to an allowlist)
3. Run `dbt run --select <model>` — observe `skip` with "No configuration changes were identified"
4. The Snowflake dynamic table still has the old query

## Test plan

- [ ] Unit test: changeset detects a query diff and sets `query` change with `requires_full_refresh=True`
- [ ] Unit test: changeset returns `None` when query is unchanged
- [ ] Integration: `dbt run` on a model with a SQL-only change triggers `CREATE OR REPLACE DYNAMIC TABLE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)