### PR TITLE
Fix trailing backtick in numeric precision warning and add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,63 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in this project, we encourage you to report it responsibly. **Please do not open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+Use GitHub's built-in private vulnerability reporting to submit your report:
+
+1. Navigate to the **Security** tab of this repository.
+2. Click **"Report a vulnerability"** under **Private vulnerability reporting**.
+3. Fill out the advisory form with as much detail as possible.
+
+Alternatively, you can go directly to:
+
+```
+https://github.com/dbt-labs/dbt-adapters/security/advisories/new
+```
+
+### What to Include
+
+To help us understand and resolve the issue quickly, please include:
+
+- A description of the vulnerability and its potential impact.
+- Step-by-step instructions to reproduce the issue.
+- The affected version(s) of the project.
+- Any relevant logs, screenshots, or proof-of-concept code.
+- Your suggested severity (Critical, High, Medium, Low) if you have one.
+
+### What to Expect
+
+- **Acknowledgment:** We will acknowledge receipt of your report within **3 business days**.
+- **Updates:** We will provide status updates as we investigate, typically within **10 business days**.
+- **Resolution:** Once a fix is ready, we will coordinate disclosure with you before making any public announcement.
+
+### Scope
+
+This policy applies to the latest supported release of this project. If you are unsure whether a version is still supported, please include the version details in your report and we will let you know.
+
+dbt-adapters handles database connections and credentials as part of its adapter interface. Security issues related to credential handling, connection string exposure, or SQL injection in adapter macros are particularly relevant.
+
+### Guidelines
+
+We ask that you:
+
+- Give us a reasonable amount of time to address the issue before making any public disclosure.
+- Make a good-faith effort to avoid disrupting the project, its infrastructure, or its users during your research.
+- Do not access, modify, or delete data that does not belong to you.
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| Latest  | Yes       |
+
+For questions about which versions are actively maintained, please refer to the project's release documentation.
+
+## Thank You
+
+We appreciate the security research community's efforts in helping keep dbt Labs and our users safe. Responsible disclosure makes the open-source ecosystem stronger for everyone.
+
+For urgent or critical issues, please reach out to the [dbt Labs Security Team](mailto:security+ghreport@dbtlabs.com).

--- a/dbt-adapters/src/dbt/include/global_project/macros/adapters/columns.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/adapters/columns.sql
@@ -65,7 +65,7 @@
     {%- if (col_err | length) > 0 -%}
       {{ exceptions.column_type_missing(column_names=col_err) }}
     {%- elif (col_naked_numeric | length) > 0 -%}
-      {{ exceptions.warn("Detected columns with numeric type and unspecified precision/scale, this can lead to unintended rounding: " ~ col_naked_numeric ~ "`") }}
+      {{ exceptions.warn("Detected columns with numeric type and unspecified precision/scale, this can lead to unintended rounding: " ~ col_naked_numeric ~ "") }}
     {%- endif -%}
 {% endmacro %}
 


### PR DESCRIPTION
## Summary

- **Fix trailing backtick in warning message** (`columns.sql` line 68): The `get_empty_subquery_sql` macro emits a warning when columns with unspecified numeric precision/scale are detected. The warning string contained a stray backtick character (`` ` ``) that appeared in user-facing logs. This removes it.
- **Add SECURITY.md**: Adds a security policy based on the dbt-labs org template, with dbt-adapters-specific scope noting relevance of credential handling, connection strings, and adapter macros.

## Details

The backtick was at the end of the warning string concatenation:
```
~ col_naked_numeric ~ "`"
```
Changed to:
```
~ col_naked_numeric ~ ""
```

Fixes #196

## Testing

- Verified the warning string no longer contains a trailing backtick
- SECURITY.md follows the standard dbt-labs org security policy format