### PR TITLE
feat(athena): support unpartitioned Hive insert_overwrite

### DIFF
--- a/dbt-athena/.changes/unreleased/Features-20260719-144916.yaml
+++ b/dbt-athena/.changes/unreleased/Features-20260719-144916.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support explicit insert_overwrite for unpartitioned Hive incremental models using a staged table and Glue catalog swap.
+time: 2026-07-19T14:49:16.104549-03:00
+custom:
+    Author: AlejandroMorgante
+    Issue: "2081"

--- a/dbt-athena/README.md
+++ b/dbt-athena/README.md
@@ -360,9 +360,12 @@ Support for [incremental models](https://docs.getdbt.com/docs/build/incremental-
 
 These strategies are supported:
 
-- `insert_overwrite` (default): The insert overwrite strategy deletes the overlapping partitions from the destination
-  table, and then inserts the new records from the source. This strategy depends on the `partitioned_by` keyword! If no
-  partitions are defined, dbt will fall back to the `append` strategy.
+- `insert_overwrite` (default): For partitioned tables, the insert overwrite strategy deletes the overlapping
+  partitions from the destination table and then inserts the new records from the source. When explicitly configured
+  on an unpartitioned Hive table, it replaces the full table using a staged table and a Glue catalog swap. This requires
+  an `s3_data_naming` value containing `unique` and does not support `external_location`. For backward compatibility,
+  an unpartitioned incremental model without an explicitly configured strategy continues to use `append`. As with HA
+  Hive tables, the four most recent Glue table versions and their S3 data are retained by default.
 - `append`: Insert new records without updating, deleting or overwriting any existing data. There might be duplicate
   data (e.g. great for log or historical data).
 - `merge`: Conditionally updates, deletes, or inserts rows into an Iceberg table. Used in combination with `unique_key`.

--- a/dbt-athena/README.md
+++ b/dbt-athena/README.md
@@ -362,10 +362,11 @@ These strategies are supported:
 
 - `insert_overwrite` (default): For partitioned tables, the insert overwrite strategy deletes the overlapping
   partitions from the destination table and then inserts the new records from the source. When explicitly configured
-  on an unpartitioned Hive table, it replaces the full table using a staged table and a Glue catalog swap. This requires
-  an `s3_data_naming` value containing `unique` and does not support `external_location`. For backward compatibility,
-  an unpartitioned incremental model without an explicitly configured strategy continues to use `append`. As with HA
-  Hive tables, the four most recent Glue table versions and their S3 data are retained by default.
+  on an unpartitioned Hive table with an isolated S3 location, it replaces the full table using a staged table and a
+  Glue catalog swap. This requires an `s3_data_naming` value containing `unique` without `external_location`.
+  Otherwise, dbt logs a message and preserves the existing `append` fallback. An unpartitioned incremental model
+  without an explicitly configured strategy also continues to use `append`. When full-table replacement is enabled,
+  the four most recent Glue table versions and their S3 data are retained by default, as with HA Hive tables.
 - `append`: Insert new records without updating, deleting or overwriting any existing data. There might be duplicate
   data (e.g. great for log or historical data).
 - `merge`: Conditionally updates, deletes, or inserts rows into an Iceberg table. Used in combination with `unique_key`.

--- a/dbt-athena/README.md
+++ b/dbt-athena/README.md
@@ -362,11 +362,12 @@ These strategies are supported:
 
 - `insert_overwrite` (default): For partitioned tables, the insert overwrite strategy deletes the overlapping
   partitions from the destination table and then inserts the new records from the source. When explicitly configured
-  on an unpartitioned Hive table with an isolated S3 location, it replaces the full table using a staged table and a
-  Glue catalog swap. This requires an `s3_data_naming` value containing `unique` without `external_location`.
-  Otherwise, dbt logs a message and preserves the existing `append` fallback. An unpartitioned incremental model
-  without an explicitly configured strategy also continues to use `append`. When full-table replacement is enabled,
-  the four most recent Glue table versions and their S3 data are retained by default, as with HA Hive tables.
+  on an unpartitioned Hive table, it replaces the full table using a staged table and a Glue catalog swap when
+  `external_location` is not configured and `s3_data_naming` contains `unique`; the default settings satisfy both
+  conditions. Otherwise, dbt logs a message and preserves the existing `append` fallback. An unpartitioned
+  incremental model without an explicitly configured strategy also continues to use `append`. When full-table
+  replacement is enabled, the four most recent Glue table versions and their S3 data are retained by default, as with
+  HA Hive tables.
 - `append`: Insert new records without updating, deleting or overwriting any existing data. There might be duplicate
   data (e.g. great for log or historical data).
 - `merge`: Conditionally updates, deletes, or inserts rows into an Iceberg table. Used in combination with `unique_key`.

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -16,10 +16,16 @@
   {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}
   {% set s3_data_naming = config.get('s3_data_naming', default=target.s3_data_naming) %}
-  {% set is_unpartitioned_hive_overwrite = (
+  {% set is_unpartitioned_hive_overwrite_requested = (
     table_type == 'hive'
     and partitioned_by is none
     and configured_strategy == 'insert_overwrite'
+  ) %}
+  {% set has_isolated_s3_location = (
+    external_location is none and 'unique' in s3_data_naming
+  ) %}
+  {% set is_unpartitioned_hive_overwrite = (
+    is_unpartitioned_hive_overwrite_requested and has_isolated_s3_location
   ) %}
   {% set default_versions_to_keep = 4 if is_unpartitioned_hive_overwrite else 1 %}
   {% set versions_to_keep = config.get('versions_to_keep', default_versions_to_keep) | as_number %}
@@ -57,13 +63,14 @@
     ) %}
   {% endif %}
 
-  {% if is_unpartitioned_hive_overwrite and ('unique' not in s3_data_naming or external_location is not none) %}
-    {% set unsafe_location_msg -%}
-      dbt-athena requires a unique S3 location for unpartitioned Hive models using the
-      'insert_overwrite' incremental strategy. Configure an s3_data_naming value containing
-      'unique' and do not set external_location.
+  {% if is_unpartitioned_hive_overwrite_requested and not has_isolated_s3_location %}
+    {% set nonisolated_location_msg -%}
+      dbt-athena cannot replace an unpartitioned Hive table using the 'insert_overwrite'
+      incremental strategy without an isolated S3 location. Falling back to 'append', as in
+      previous releases. To enable full-table replacement, configure an s3_data_naming value
+      containing 'unique' and do not set external_location.
     {%- endset %}
-    {% do exceptions.raise_compiler_error(unsafe_location_msg) %}
+    {% do log(nonisolated_location_msg, info=True) %}
   {% endif %}
 
   {% if partitioned_by is none and strategy == 'insert_overwrite' %}
@@ -75,7 +82,7 @@
       {%- endset %}
       {% do exceptions.raise_compiler_error(missing_partition_key_microbatch_msg) %}
     {% elif not is_unpartitioned_hive_overwrite %}
-      -- Preserve the historical append default when no incremental strategy is configured.
+      -- Preserve the historical append behavior when full-table replacement is not enabled.
       {% set strategy = 'append' %}
     {% endif %}
   {% endif %}

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -1,20 +1,28 @@
 {% materialization incremental, adapter='athena', supported_languages=['sql', 'python'] -%}
-  {% set raw_strategy = config.get('incremental_strategy') or 'insert_overwrite' %}
+  {% set configured_strategy = config.get('incremental_strategy') %}
+  {% set raw_strategy = configured_strategy or 'insert_overwrite' %}
   {% set is_microbatch = raw_strategy == 'microbatch' %}
   {% set table_type = resolve_table_type() %}
   {% set model_language = model['language'] %}
   {% set strategy = validate_get_incremental_strategy(raw_strategy, table_type) %}
   {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
-  {% set versions_to_keep = config.get('versions_to_keep', 1) | as_number %}
   {% set lf_tags_config = config.get('lf_tags_config') %}
   {% set lf_grants = config.get('lf_grants') %}
   {% set partitioned_by = config.get('partitioned_by') %}
+  {% set external_location = config.get('external_location') %}
   {% set force_batch = config.get('force_batch', False) | as_bool -%}
   {% set unique_tmp_table_suffix = config.get('unique_tmp_table_suffix', False) | as_bool -%}
   {% set temp_schema = config.get('temp_schema') %}
   {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}
   {% set s3_data_naming = config.get('s3_data_naming', default=target.s3_data_naming) %}
+  {% set is_unpartitioned_hive_overwrite = (
+    table_type == 'hive'
+    and partitioned_by is none
+    and configured_strategy == 'insert_overwrite'
+  ) %}
+  {% set default_versions_to_keep = 4 if is_unpartitioned_hive_overwrite else 1 %}
+  {% set versions_to_keep = config.get('versions_to_keep', default_versions_to_keep) | as_number %}
   -- If using insert_overwrite on Hive table, allow to set a unique tmp table suffix
   {% if unique_tmp_table_suffix == True and strategy == 'insert_overwrite' and table_type == 'hive' %}
     {% set tmp_table_suffix = adapter.generate_unique_temporary_table_suffix() %}
@@ -31,6 +39,32 @@
                                              database=database) %}
   {% set tmp_relation = make_temp_relation(target_relation, suffix=tmp_table_suffix, temp_schema=temp_schema) %}
 
+  {% if is_unpartitioned_hive_overwrite %}
+    {% set tmp_relation = api.Relation.create(
+      identifier=target_relation.identifier ~ tmp_table_suffix,
+      schema=temp_schema or target_relation.schema,
+      database=target_relation.database,
+      s3_path_table_part=target_relation.identifier,
+      type='table'
+    ) %}
+    {% if temp_schema is not none %}
+      {% do create_schema(tmp_relation) %}
+    {% endif %}
+    {% set old_tmp_relation = adapter.get_relation(
+      identifier=tmp_relation.identifier,
+      schema=tmp_relation.schema,
+      database=tmp_relation.database
+    ) %}
+  {% endif %}
+
+  {% if is_unpartitioned_hive_overwrite and ('unique' not in s3_data_naming or external_location is not none) %}
+    {% set unsafe_location_msg -%}
+      dbt-athena requires a unique S3 location for unpartitioned Hive models using the
+      'insert_overwrite' incremental strategy. Configure an s3_data_naming value containing
+      'unique' and do not set external_location.
+    {%- endset %}
+    {% do exceptions.raise_compiler_error(unsafe_location_msg) %}
+  {% endif %}
 
   {% if partitioned_by is none and strategy == 'insert_overwrite' %}
     {% if is_microbatch %}
@@ -40,8 +74,8 @@
         Ensure you are using a `partitioned_by` column that is of grain {{ config.get('batch_size') }}.
       {%- endset %}
       {% do exceptions.raise_compiler_error(missing_partition_key_microbatch_msg) %}
-    {% else %}
-      -- If no partitions are used with insert_overwrite, we fall back to append mode.
+    {% elif not is_unpartitioned_hive_overwrite %}
+      -- Preserve the historical append default when no incremental strategy is configured.
       {% set strategy = 'append' %}
     {% endif %}
   {% endif %}
@@ -126,7 +160,24 @@
     {%- endif -%}
     {% set build_sql = "select '" ~ query_result ~ "'" -%}
 
-  -- Insert Overwrite Strategy --
+  -- Unpartitioned Hive Insert Overwrite Strategy --
+  {% elif is_unpartitioned_hive_overwrite %}
+    {% if old_tmp_relation is not none %}
+      {# The target may already point to this relation's S3 location after an interrupted run. #}
+      {% do adapter.delete_from_glue_catalog(old_tmp_relation) %}
+    {% endif %}
+    {% set query_result = safe_create_table_as(False, tmp_relation, compiled_code, model_language, force_batch) -%}
+    {%- if model_language == 'python' -%}
+      {% call statement('create_table', language=model_language) %}
+        {{ query_result }}
+      {% endcall %}
+    {%- endif -%}
+    {% do adapter.swap_table(tmp_relation, target_relation) %}
+    {# Keep the staged data now referenced by the target and remove only its temporary catalog entry. #}
+    {% do adapter.delete_from_glue_catalog(tmp_relation) %}
+    {% set build_sql = "select '" ~ query_result ~ "'" -%}
+
+  -- Partitioned Hive Insert Overwrite Strategy --
   {% elif strategy in ("insert_overwrite") %}
     {% if old_tmp_relation is not none %}
       {% do drop_relation(old_tmp_relation) %}
@@ -249,7 +300,9 @@
   {# S3 Tables manages its own Iceberg versioning; the Glue GetTableVersions API is not
      available for the federated catalog (raises EntityNotFoundException), so skip it. #}
   {% if not adapter.is_s3_tables_database(target_relation.database) %}
-    {% do adapter.expire_glue_table_versions(target_relation, versions_to_keep, False) %}
+    {% do adapter.expire_glue_table_versions(
+      target_relation, versions_to_keep, is_unpartitioned_hive_overwrite
+    ) %}
   {% endif %}
 
   {{ return({'relations': [target_relation]}) }}

--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -65,10 +65,9 @@
 
   {% if is_unpartitioned_hive_overwrite_requested and not has_isolated_s3_location %}
     {% set nonisolated_location_msg -%}
-      dbt-athena cannot replace an unpartitioned Hive table using the 'insert_overwrite'
-      incremental strategy without an isolated S3 location. Falling back to 'append', as in
-      previous releases. To enable full-table replacement, configure an s3_data_naming value
-      containing 'unique' and do not set external_location.
+      Full-table replacement for an unpartitioned Hive table requires external_location to be
+      unset and s3_data_naming to contain 'unique'. Falling back to 'append', as in previous
+      releases.
     {%- endset %}
     {% do log(nonisolated_location_msg, info=True) %}
   {% endif %}

--- a/dbt-athena/tests/functional/adapter/test_incremental_hive_unpartitioned.py
+++ b/dbt-athena/tests/functional/adapter/test_incremental_hive_unpartitioned.py
@@ -1,0 +1,89 @@
+import pytest
+
+from dbt.contracts.results import RunStatus
+from dbt.tests.util import run_dbt, run_dbt_and_capture
+
+
+models__explicit_insert_overwrite_sql = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    table_type='hive',
+    s3_data_naming='schema_table_unique'
+) }}
+
+select 1 as id
+"""
+
+models__default_strategy_sql = """
+{{ config(
+    materialized='incremental',
+    table_type='hive'
+) }}
+
+select 1 as id
+"""
+
+models__unsafe_location_sql = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    table_type='hive',
+    s3_data_naming='schema_table'
+) }}
+
+select 1 as id
+"""
+
+
+class TestIncrementalHiveUnpartitioned:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "explicit_insert_overwrite.sql": models__explicit_insert_overwrite_sql,
+            "default_strategy.sql": models__default_strategy_sql,
+            "unsafe_location.sql": models__unsafe_location_sql,
+        }
+
+    def test_explicit_insert_overwrite_replaces_all_rows(self, project):
+        relation_name = "explicit_insert_overwrite"
+        args = ["run", "--select", relation_name]
+
+        first_run = run_dbt(args)
+        assert first_run.results[0].status == RunStatus.Success
+        assert (
+            project.run_sql(
+                f"select count(*) from {project.test_schema}.{relation_name}", fetch="one"
+            )[0]
+            == 1
+        )
+
+        second_run = run_dbt(args)
+        assert second_run.results[0].status == RunStatus.Success
+        assert (
+            project.run_sql(
+                f"select count(*) from {project.test_schema}.{relation_name}", fetch="one"
+            )[0]
+            == 1
+        )
+
+    def test_omitted_strategy_preserves_append_behavior(self, project):
+        relation_name = "default_strategy"
+        args = ["run", "--select", relation_name]
+
+        first_run = run_dbt(args)
+        assert first_run.results[0].status == RunStatus.Success
+
+        second_run = run_dbt(args)
+        assert second_run.results[0].status == RunStatus.Success
+        assert (
+            project.run_sql(
+                f"select count(*) from {project.test_schema}.{relation_name}", fetch="one"
+            )[0]
+            == 2
+        )
+
+    def test_explicit_insert_overwrite_requires_unique_location(self, project):
+        _, stdout = run_dbt_and_capture(["run", "--select", "unsafe_location"], expect_pass=False)
+
+        assert "dbt-athena requires a unique S3 location for unpartitioned Hive models" in stdout

--- a/dbt-athena/tests/functional/adapter/test_incremental_hive_unpartitioned.py
+++ b/dbt-athena/tests/functional/adapter/test_incremental_hive_unpartitioned.py
@@ -15,8 +15,7 @@ models__explicit_insert_overwrite_sql = """
 {{ config(
     materialized='incremental',
     incremental_strategy='insert_overwrite',
-    table_type='hive',
-    s3_data_naming='schema_table_unique'
+    table_type='hive'
 ) }}
 
 select 1 as id

--- a/dbt-athena/tests/functional/adapter/test_incremental_hive_unpartitioned.py
+++ b/dbt-athena/tests/functional/adapter/test_incremental_hive_unpartitioned.py
@@ -83,7 +83,21 @@ class TestIncrementalHiveUnpartitioned:
             == 2
         )
 
-    def test_explicit_insert_overwrite_requires_unique_location(self, project):
-        _, stdout = run_dbt_and_capture(["run", "--select", "unsafe_location"], expect_pass=False)
+    def test_nonisolated_location_preserves_append_behavior(self, project):
+        relation_name = "unsafe_location"
+        args = ["run", "--select", relation_name]
 
-        assert "dbt-athena requires a unique S3 location for unpartitioned Hive models" in stdout
+        first_run = run_dbt(args)
+        assert first_run.results[0].status == RunStatus.Success
+
+        second_run, stdout = run_dbt_and_capture(args)
+        assert second_run.results[0].status == RunStatus.Success
+        assert (
+            project.run_sql(
+                f"select count(*) from {project.test_schema}.{relation_name}", fetch="one"
+            )[0]
+            == 2
+        )
+
+        assert "dbt-athena cannot replace an unpartitioned Hive table" in stdout
+        assert "previous releases." in stdout

--- a/dbt-athena/tests/functional/adapter/test_incremental_hive_unpartitioned.py
+++ b/dbt-athena/tests/functional/adapter/test_incremental_hive_unpartitioned.py
@@ -4,6 +4,13 @@ from dbt.contracts.results import RunStatus
 from dbt.tests.util import run_dbt, run_dbt_and_capture
 
 
+EXPECTED_FALLBACK_MESSAGE = (
+    "Full-table replacement for an unpartitioned Hive table requires external_location to be "
+    "unset and s3_data_naming to contain 'unique'. Falling back to 'append', as in previous "
+    "releases."
+)
+
+
 models__explicit_insert_overwrite_sql = """
 {{ config(
     materialized='incremental',
@@ -24,12 +31,28 @@ models__default_strategy_sql = """
 select 1 as id
 """
 
-models__unsafe_location_sql = """
+models__nonunique_s3_naming_sql = """
 {{ config(
     materialized='incremental',
     incremental_strategy='insert_overwrite',
     table_type='hive',
     s3_data_naming='schema_table'
+) }}
+
+select 1 as id
+"""
+
+models__external_location_sql = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    table_type='hive',
+    external_location=(
+        (target.s3_staging_dir | trim('/'))
+        ~ '/tables/'
+        ~ target.schema
+        ~ '/external_location'
+    )
 ) }}
 
 select 1 as id
@@ -42,7 +65,8 @@ class TestIncrementalHiveUnpartitioned:
         return {
             "explicit_insert_overwrite.sql": models__explicit_insert_overwrite_sql,
             "default_strategy.sql": models__default_strategy_sql,
-            "unsafe_location.sql": models__unsafe_location_sql,
+            "nonunique_s3_naming.sql": models__nonunique_s3_naming_sql,
+            "external_location.sql": models__external_location_sql,
         }
 
     def test_explicit_insert_overwrite_replaces_all_rows(self, project):
@@ -83,8 +107,8 @@ class TestIncrementalHiveUnpartitioned:
             == 2
         )
 
-    def test_nonisolated_location_preserves_append_behavior(self, project):
-        relation_name = "unsafe_location"
+    def test_nonunique_s3_naming_preserves_append_behavior(self, project):
+        relation_name = "nonunique_s3_naming"
         args = ["run", "--select", relation_name]
 
         first_run = run_dbt(args)
@@ -99,5 +123,22 @@ class TestIncrementalHiveUnpartitioned:
             == 2
         )
 
-        assert "dbt-athena cannot replace an unpartitioned Hive table" in stdout
-        assert "previous releases." in stdout
+        assert EXPECTED_FALLBACK_MESSAGE in " ".join(stdout.split())
+
+    def test_external_location_preserves_append_behavior(self, project):
+        relation_name = "external_location"
+        args = ["run", "--select", relation_name]
+
+        first_run = run_dbt(args)
+        assert first_run.results[0].status == RunStatus.Success
+
+        second_run, stdout = run_dbt_and_capture(args)
+        assert second_run.results[0].status == RunStatus.Success
+        assert (
+            project.run_sql(
+                f"select count(*) from {project.test_schema}.{relation_name}", fetch="one"
+            )[0]
+            == 2
+        )
+
+        assert EXPECTED_FALLBACK_MESSAGE in " ".join(stdout.split())


### PR DESCRIPTION
Resolves #2081.

Documentation is tracked in [dbt-labs/docs.getdbt.com#9643](https://github.com/dbt-labs/docs.getdbt.com/issues/9643). The dbt-athena README is also updated in this PR.

### Summary

For unpartitioned Hive models, an explicit `insert_overwrite` performs a full-table replacement when `external_location` is unset (the default) and `s3_data_naming` contains `unique` (the default is `schema_table_unique`). Otherwise, dbt preserves the existing `append` behavior and logs an informational message.

### Problem

dbt-athena currently defaults Hive incremental models to `insert_overwrite`, but falls back to `append` whenever `partitioned_by` is not configured.

Because the materialization does not distinguish between an omitted strategy and an explicitly configured strategy, this model silently appends:

```sql
{{
    config(
        materialized='incremental',
        incremental_strategy='insert_overwrite',
        table_type='hive',
        format='parquet'
    )
}}

select 1 as id
```

**Instead of replacing the target table, every incremental run appends the complete model result. For this one-row example, running the model N times produces N identical rows, even though `insert_overwrite` is explicitly configured.**

This is counterintuitive from a user's perspective: an explicitly requested overwrite is expected to replace existing data, not accumulate another copy on every run.

A standalone reproduction is available here:

https://github.com/AlejandroMorgante/dbt-athena-hive-insert-overwrite-repro

### Solution

This PR distinguishes an explicitly configured strategy from the historical default.

For an unpartitioned Hive model, full-table replacement is enabled only when:

- `incremental_strategy='insert_overwrite'` is explicitly configured.
- `s3_data_naming` contains `unique`.
- `external_location` is not configured.

This is the default storage behavior because the default `s3_data_naming` value is `schema_table_unique`.

The implementation:

1. Builds the complete result in a staged Hive table with a new S3 location.
2. Uses the existing `adapter.swap_table` operation to update the target Glue table.
3. Deletes only the temporary Glue catalog entry, preserving the staged data now referenced by the target.
4. Retains and expires Glue table versions and their S3 locations using the existing Hive HA mechanism.

All other behavior remains compatible:

| Configuration | Previous behavior | New behavior |
| --- | --- | --- |
| Unpartitioned Hive, strategy omitted | `append` | `append` |
| Unpartitioned Hive, explicit `insert_overwrite`, `external_location` unset (default) and `s3_data_naming` contains `unique` (default: `schema_table_unique`) | `append` | Full-table replacement |
| Unpartitioned Hive, explicit `insert_overwrite`, `external_location` set or `s3_data_naming` does not contain `unique` | `append` | `append` with an informational message |
| Partitioned Hive and other strategies | Existing behavior | Unchanged |

No configuration that currently completes successfully becomes a hard failure.

### Precedent

dbt-spark already treats an explicitly configured unpartitioned `insert_overwrite` as a full-table replacement.

It emits `INSERT OVERWRITE TABLE` without a partition clause and has a functional test that compares its unpartitioned model with `expected_overwrite`:

- Implementation:
  https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-spark/src/dbt/include/spark/macros/materializations/incremental/strategies.sql#L1-L15
- Unpartitioned fixture:
  https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-spark/tests/functional/adapter/incremental_strategies/fixtures.py#L216-L235
- Functional assertion:
  https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-spark/tests/functional/adapter/incremental_strategies/test_incremental_strategies.py#L64-L83

Athena Hive does not provide the same native SQL operation, so this PR reproduces the same user-facing semantics using a staged table and Glue catalog swap.

### Validation

- `hatch run code-quality`
  - YAML, end-of-file, whitespace, dbt-core usage, Black, Flake8, and MyPy all passed.
- `hatch run unit-tests tests/unit/test_adapter.py -k swap_table -v`
  - 4 passed.
- `hatch run integration-tests tests/functional/adapter/test_incremental_hive_unpartitioned.py -v`
  - 4 passed against Athena engine v3.
  - Explicit `insert_overwrite` with the default storage settings: one row after repeated runs.
  - Omitted strategy: two rows, preserving the existing `append` behavior.
  - `external_location` configured: two rows with the informational fallback message.
  - `s3_data_naming` without `unique`: two rows with the informational fallback message.
- Standalone POC pinned to the proposed commit:
  https://github.com/AlejandroMorgante/dbt-athena-hive-insert-overwrite-repro

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX

Product/DX feedback is requested through #2081.


