### PR TITLE
fix(snowflake): ignore change_tracking=false for Iceberg tables

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20260721-144323.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260721-144323.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Ignore `change_tracking=false` for Iceberg tables instead of emitting invalid
+  DDL, since Snowflake does not allow change tracking to be turned off for Iceberg
+  tables
+time: 2026-07-21T14:43:23.000000-05:00
+custom:
+  Author: tauhid621
+  Issue: "0"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
@@ -125,7 +125,7 @@ class BuiltInCatalogIntegration(CatalogIntegration):
             automatic_clustering=parse_model.automatic_clustering(model),
             storage_serialization_policy=storage_serialization_policy,
             max_data_extension_time_in_days=max_data_extension_time_in_days,
-            change_tracking=resolve_change_tracking(model, self.change_tracking),
+            change_tracking=resolve_change_tracking(model, self.change_tracking, is_iceberg=True),
             data_retention_time_in_days=data_retention_time_in_days,
             iceberg_version=iceberg_version,
             catalog_database=self.catalog_database,

--- a/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_common.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_common.py
@@ -1,8 +1,11 @@
 from typing import Optional
 
 from dbt.adapters.contracts.relation import RelationConfig
+from dbt.adapters.events.logging import AdapterLogger
 
 from dbt.adapters.snowflake.constants import SnowflakeIcebergTableRelationParameters
+
+logger = AdapterLogger("Snowflake")
 
 _BOOL_TO_STR_MAP = {
     True: "TRUE",
@@ -13,12 +16,17 @@ _BOOL_TO_STR_MAP = {
 
 
 def resolve_change_tracking(
-    model: RelationConfig, integration_default: Optional[bool | str]
+    model: RelationConfig,
+    integration_default: Optional[bool | str],
+    is_iceberg: bool = False,
 ) -> Optional[str]:
     """
-    Resolves change tracking for a catalog integration.
-    If `change_tracking` is set in the model config, it will override the integration default.
-    If not set on either the model or integration, it will return None.
+    Resolves change tracking for a catalog integration. The model config overrides the
+    integration default; if neither is set, returns None.
+
+    Snowflake does not allow change tracking to be turned off for Iceberg tables, so when
+    `is_iceberg` and the resolved value is "FALSE", we warn and omit the property (return None)
+    rather than emitting DDL that Snowflake would reject.
     """
     if (
         model.config
@@ -32,8 +40,17 @@ def resolve_change_tracking(
         if isinstance(change_tracking, str):
             change_tracking = change_tracking.lower()
         try:
-            return _BOOL_TO_STR_MAP[change_tracking]
+            resolved = _BOOL_TO_STR_MAP[change_tracking]
         except KeyError:
             raise ValueError("Invalid value for change_tracking. Expected 'true' or 'false'.")
+
+        if is_iceberg and resolved == "FALSE":
+            logger.warning(
+                "Change tracking cannot be turned off for Iceberg tables in Snowflake. "
+                "Ignoring change_tracking=false; the property will be omitted and Snowflake "
+                "will keep change tracking enabled."
+            )
+            return None
+        return resolved
     else:
         return None

--- a/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
@@ -74,5 +74,6 @@ class TestSnowflakeBuiltInCatalogIntegration(BaseCatalogIntegrationValidation):
         )
         assert "storage_serialization_policy = 'COMPATIBLE'" in iceberg_table_with_configs_sql
         assert "max_data_extension_time_in_days = 30" in iceberg_table_with_configs_sql
-        assert "change_tracking = FALSE" in iceberg_table_with_configs_sql
+        # change_tracking=false is ignored for Iceberg (Snowflake forbids turning it off)
+        assert "change_tracking" not in iceberg_table_with_configs_sql
         assert "data_retention_time_in_days = 1" in iceberg_table_with_configs_sql

--- a/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalogs_v2.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalogs_v2.py
@@ -90,6 +90,7 @@ class TestSnowflakeV2HorizonCatalog:
 
         configs_sql = get_cleaned_model_ddl_from_file("horizon_with_configs.sql")
         assert "storage_serialization_policy = 'COMPATIBLE'" in configs_sql
-        assert "change_tracking = FALSE" in configs_sql
+        # change_tracking=false is ignored for Iceberg (Snowflake forbids turning it off)
+        assert "change_tracking" not in configs_sql
         assert "max_data_extension_time_in_days = 30" in configs_sql
         assert "data_retention_time_in_days = 1" in configs_sql

--- a/dbt-snowflake/tests/functional/adapter/change_tracking/test_change_tracking_show_tables.py
+++ b/dbt-snowflake/tests/functional/adapter/change_tracking/test_change_tracking_show_tables.py
@@ -99,7 +99,8 @@ class TestIcebergTableChangeTrackingShowTables(BaseCatalogIntegrationValidation)
     def test_change_tracking_on_iceberg_from_catalog_default(self, project):
         assert query_change_tracking_from_show_tables(project, "basic_iceberg_table") == "ON"
 
-    def test_change_tracking_off_iceberg_from_model_config(self, project):
+    def test_change_tracking_false_ignored_for_iceberg(self, project):
+        # change_tracking=false is ignored for Iceberg; Snowflake keeps it ON
         assert (
-            query_change_tracking_from_show_tables(project, "iceberg_table_with_configs") == "OFF"
+            query_change_tracking_from_show_tables(project, "iceberg_table_with_configs") == "ON"
         )

--- a/dbt-snowflake/tests/unit/test_catalog_relation_built_in.py
+++ b/dbt-snowflake/tests/unit/test_catalog_relation_built_in.py
@@ -60,9 +60,9 @@ def test_iceberg_base_location_built_in(fake_integration, config, expected):
     "config,expected",
     [
         (None, None),
-        (False, "FALSE"),
+        (False, None),  # false ignored for Iceberg
         (True, "TRUE"),
-        ("False", "FALSE"),
+        ("False", None),  # false ignored for Iceberg
         ("True", "TRUE"),
     ],
 )
@@ -121,7 +121,8 @@ def test_model_config_overrides_adapter_properties():
     model = deepcopy(model_base)
     model.config.update({"change_tracking": False})
     relation = integration.build_relation(model)
-    assert relation.change_tracking == "FALSE"
+    # model false overrides adapter true, then is omitted (None) since Iceberg can't disable it
+    assert relation.change_tracking is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What / why

CI started failing on several Snowflake catalog/Iceberg tests with:

```
001435 (22023): SQL compilation error:
invalid value 'false' for property 'CHANGE_TRACKING',
Reason: Change Tracking cannot be turned off for Iceberg tables
```

This is a **Snowflake platform behavior change**, not a code regression. dbt has generated `CHANGE_TRACKING = FALSE` for Iceberg tables since the change-tracking feature landed (#1732, March), and none of the DDL-generation code has changed since. Snowflake now rejects that DDL at compile time — Iceberg tables require change tracking to stay on.

## Change

`resolve_change_tracking` now takes an `is_iceberg` flag. When it's an Iceberg table and the resolved value is `FALSE`, it logs a warning and omits the property (returns `None`) instead of emitting DDL Snowflake rejects. The `BUILT_IN` (Iceberg) catalog passes `is_iceberg=True`; native `INFO_SCHEMA` tables are unaffected and can still disable change tracking.

Only the `BUILT_IN` create path emits `change_tracking` for Iceberg; Iceberg REST macros never did, so no other path needed changing.

## Tests

- Unit + functional tests updated to expect the property to be omitted for Iceberg and the table to stay `ON`.
- `hatch run unit-tests` (catalog suites) and `hatch run code-quality` pass locally. Functional tests require live Snowflake and were verified by tracing.

## Note

The unrelated flaky failure in `TestSnowflakeIcebergRestCatalogIntegration` (`The external catalog request rate has been exceeded`) is REST-catalog throttling, not related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)