### PR TITLE
fix(redshift): skip dist/sort on temporary tables

### DIFF
--- a/dbt-redshift/.changes/unreleased/Fixes-20260721-151504.yaml
+++ b/dbt-redshift/.changes/unreleased/Fixes-20260721-151504.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: Stop applying dist/sort configs to temporary tables created during incremental delete+insert and merge strategies, reducing unnecessary Redshift resource usage
+body: Stop applying dist/sort configs to temporary tables, reducing unnecessary Redshift resource usage
 time: 2026-07-21T15:15:04.774654-03:00
 custom:
     Author: alejandrofm

--- a/dbt-redshift/.changes/unreleased/Fixes-20260721-151504.yaml
+++ b/dbt-redshift/.changes/unreleased/Fixes-20260721-151504.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Stop applying dist/sort configs to temporary tables created during incremental delete+insert and merge strategies, reducing unnecessary Redshift resource usage
+time: 2026-07-21T15:15:04.774654-03:00
+custom:
+    Author: alejandrofm
+    Issue: "2085"

--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
@@ -54,8 +54,10 @@
     {{ get_assert_columns_equivalent(sql) }}
     {%- set sql = get_select_subquery(sql) %}
     {% if backup == false -%}backup no{%- endif %}
+    {%- if not temporary %}
     {{ dist(_dist) }}
     {{ sort(_sort_type, _sort) }}
+    {%- endif %}
   ;
 
   insert into {{ relation.include(database=(not temporary), schema=(not temporary)) }}
@@ -69,8 +71,10 @@
   create {% if temporary -%}temporary{%- endif %} table
     {{ relation.include(database=(not temporary), schema=(not temporary)) }}
     {% if backup == false -%}backup no{%- endif %}
+    {%- if not temporary %}
     {{ dist(_dist) }}
     {{ sort(_sort_type, _sort) }}
+    {%- endif %}
   as (
     {{ sql }}
   );

--- a/dbt-redshift/tests/unit/test_create_table_as_macro.py
+++ b/dbt-redshift/tests/unit/test_create_table_as_macro.py
@@ -10,7 +10,13 @@ def _render_create_table_as(temporary, dist="my_col", sort=["my_col"]):
     )
     template = env.get_template("adapters.sql")
 
-    config_values = {"dist": dist, "sort_type": None, "sort": sort, "sql_header": None, "backup": None}
+    config_values = {
+        "dist": dist,
+        "sort_type": None,
+        "sort": sort,
+        "sql_header": None,
+        "backup": None,
+    }
     contract_config = SimpleNamespace(enforced=False)
     config = SimpleNamespace(
         get=lambda key, default=None, validator=None: (

--- a/dbt-redshift/tests/unit/test_create_table_as_macro.py
+++ b/dbt-redshift/tests/unit/test_create_table_as_macro.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+import jinja2
+
+
+def _render_create_table_as(temporary, dist="my_col", sort=["my_col"]):
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader("src/dbt/include/redshift/macros"),
+        extensions=["jinja2.ext.do"],
+    )
+    template = env.get_template("adapters.sql")
+
+    config_values = {"dist": dist, "sort_type": None, "sort": sort, "sql_header": None, "backup": None}
+    contract_config = SimpleNamespace(enforced=False)
+    config = SimpleNamespace(
+        get=lambda key, default=None, validator=None: (
+            contract_config if key == "contract" else config_values.get(key, default)
+        )
+    )
+
+    relation = SimpleNamespace(include=lambda database=True, schema=True: "my_rel")
+
+    class _AnyValidator:
+        def __getitem__(self, item):
+            return None
+
+    validation = SimpleNamespace(any=_AnyValidator())
+
+    macros = template.make_module({"config": config, "validation": validation})
+    return macros.redshift__create_table_as(temporary, relation, "select 1")
+
+
+def test_dist_and_sort_omitted_for_temporary_tables():
+    rendered = _render_create_table_as(temporary=True).lower()
+    assert "distkey" not in rendered
+    assert "sortkey" not in rendered
+
+
+def test_dist_and_sort_applied_for_non_temporary_tables():
+    rendered = _render_create_table_as(temporary=False).lower()
+    assert "distkey" in rendered
+    assert "sortkey" in rendered


### PR DESCRIPTION
resolves #2085
N/A

### Problem

Redshift tables created with `dist`/`sort` configured had those settings applied even when the table was temporary — e.g. the intermediate `_tmp` table used by the incremental delete+insert and merge strategies. Temp tables are dropped shortly after creation, so the distkey/sortkey work was wasted and forced an unnecessary redistribution of data across nodes.

### Solution

`redshift__create_table_as` now only applies `dist()`/`sort()` when the table being created is not temporary. This covers any code path that creates a temporary table, not just incremental runs. The full-refresh path, which builds an intermediate relation that gets swapped in as the final table, is unaffected since it's not created with the temporary flag.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX