### PR TITLE
Fix batch source freshness crash when no sources are metadata-based

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fixes-20260722-121500.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20260722-121500.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix "list object has no element 0" in batch source freshness when no selected
+    source is metadata-based (all declare a loaded_at_field)
+time: 2026-07-22T12:15:00.000000+09:00
+custom:
+    Author: ota2000
+    Issue: "1789"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
@@ -1218,6 +1218,10 @@ class BigQueryAdapter(BaseAdapter):
         adapter_responses: List[Optional[AdapterResponse]] = []
         freshness_responses: Dict[BaseRelation, FreshnessResponse] = {}
 
+        # get_relation_last_modified cannot render with an empty relation list
+        if not sources:
+            return adapter_responses, freshness_responses
+
         for source in sources:
             self._check_for_wildcard_identifier(source)
 

--- a/dbt-bigquery/tests/unit/test_calculate_freshness_from_metadata_batch.py
+++ b/dbt-bigquery/tests/unit/test_calculate_freshness_from_metadata_batch.py
@@ -1,0 +1,23 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from dbt.adapters.bigquery.impl import BigQueryAdapter
+
+
+@pytest.fixture
+def adapter():
+    return BigQueryAdapter(MagicMock(), MagicMock())
+
+
+class TestCalculateFreshnessFromMetadataBatch:
+    def test_empty_sources_returns_early_without_querying(self, adapter, mocker):
+        execute_macro = mocker.patch.object(adapter, "execute_macro")
+
+        adapter_responses, freshness_responses = adapter.calculate_freshness_from_metadata_batch(
+            sources=[]
+        )
+
+        assert adapter_responses == []
+        assert freshness_responses == {}
+        execute_macro.assert_not_called()


### PR DESCRIPTION
resolves #1789
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

### Problem

`BigQueryAdapter.calculate_freshness_from_metadata_batch` is called by the task layer even when the batch is empty — which happens whenever every selected freshness source declares a `loaded_at_field` (only sources without one are batched). With `bigquery_use_batch_source_freshness: True`, the `get_relation_last_modified` macro then fails on `relations[0]`:

```
Compilation Error
  list object has no element 0
```

This is the root cause of #1789: both sources in that repro declare `loaded_at_field: updated_at`, so the batch list is empty (`Pulling freshness from warehouse metadata tables for 0 sources`). On dbt-core 1.12 the impact is worse: the batch failure now causes every source to be SKIPped instead of falling back to per-source checks (dbt-labs/dbt-core#15634).

### Solution

Return early from `calculate_freshness_from_metadata_batch` when `sources` is empty, before any behavior-flag access or macro rendering. As a side benefit, an empty batch no longer fires the `bigquery_use_batch_source_freshness` `BehaviorChangeEvent`, which projects promoting deprecations via `warn_error_options` currently receive as a hard `CompilationError`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
