### PR TITLE
Remove lockfile PR step from scheduled publishing

### DIFF
--- a/.github/workflows/scheduled-publishing.yml
+++ b/.github/workflows/scheduled-publishing.yml
@@ -35,43 +35,9 @@ jobs:
             package: ${{ matrix.package }}
         secrets: inherit
 
-    open-lockfile-pr:
-        needs: publish
-        runs-on: ${{ vars.DEFAULT_RUNNER }}
-        steps:
-            - name: "Trigger lockfile PR and get PR number"
-              id: pr
-              shell: bash
-              run: |
-                  RUN_ID=$(gh workflow run $WORKFLOW --repo $REPO)
-                  echo $RUN_ID
-                  gh run watch $RUN_ID
-
-                  PR=$(gh pr list --repo $REPO --search "$PR_TITLE in:title" --json number | jq 'max .number')
-                  echo $PR
-                  echo "number=$PR" >> $GITHUB_OUTPUT
-              env:
-                  GH_TOKEN: ${{ secrets.FISHTOWN_BOT_PAT }}
-                  REPO: "dbt-labs/dbt-mantle"
-                  WORKFLOW: "open-lockfile-pr.yml"
-                  PR_TITLE: "Generate new lockfile for dbt-mantle"
-
-            - name: "Notify Slack"
-              uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # ravsamhq/notify-slack-action@v2
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-                  status: ${{ job.status }}
-                  notification_title: "dbt-mantle lockfile is ready for review"
-                  message_format: "View PR: https://github.com/dbt-labs/dbt-mantle/pull/${{ steps.pr.outputs.number }}"
-                  mention_groups: ${{ vars.SLACK_ON_CALL }}
-                  mention_groups_when: "success"
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_ADAPTER_PULL_REQUESTS }}
-
     notify-failure:
         needs:
             - publish
-            - open-lockfile-pr
         if: ${{ failure() }}
         runs-on: ${{ vars.DEFAULT_RUNNER }}
         steps:


### PR DESCRIPTION
## What

Removes the `open-lockfile-pr` job from the scheduled publishing workflow, along with its reference in the `notify-failure` job's `needs`.

## Why

This step never worked and always failed, so it's being removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)