### PR TITLE
fix(snowflake): raise early dbt error for bare NUMBER in Iceberg contracts (099200)

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20260709-123000.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260709-123000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Raise a clear dbt error, before the CREATE reaches Snowflake, when a model contract
+  declares a bare NUMBER/NUMERIC/DECIMAL (no precision/scale) on an Iceberg table, instead of
+  the opaque 099200 Snowflake returns at runtime. The user's declared type is not rewritten
+time: 2026-07-09T12:30:00.000000-07:00
+custom:
+  Author: sfc-gh-nijain
+  Issue: "2091"

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/column/columns_spec_ddl.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/column/columns_spec_ddl.sql
@@ -1,0 +1,38 @@
+{% macro snowflake__get_table_columns_and_constraints() -%}
+  {#-
+    Snowflake + Iceberg: a model contract that declares a numeric column without precision
+    and scale (a bare NUMBER / NUMERIC / DECIMAL) renders DDL that Snowflake rejects on Iceberg
+    tables with error 099200. Regular Snowflake tables silently coerce bare NUMBER to
+    NUMBER(38,0), but Iceberg requires the precision and scale to be explicit.
+
+    Fail fast with a clear dbt error before the CREATE is sent to Snowflake, instead of the
+    opaque runtime 099200 Snowflake returns after the statement executes. This runs at the
+    start of `dbt run` (where dbt enforces contracts), not during `dbt compile`. We do not
+    rewrite the user's declared type; we ask them to make it explicit.
+
+    Scope: only when the target is an Iceberg relation (BUILT_IN managed or ICEBERG_REST CLD).
+    Non-Iceberg contracts are unaffected and fall through to the standard rendering.
+  -#}
+  {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
+  {%- if catalog_relation is not none
+        and catalog_relation.catalog_type in ['BUILT_IN', 'ICEBERG_REST']
+        and model.get('columns') -%}
+    {%- set bare_numeric_columns = [] -%}
+    {%- for column in model['columns'].values() -%}
+      {%- set data_type = (column.get('data_type') or '') | trim | lower -%}
+      {%- if '(' not in data_type and data_type in ['number', 'numeric', 'decimal'] -%}
+        {%- do bare_numeric_columns.append(column['name']) -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- if bare_numeric_columns | length > 0 -%}
+      {%- do exceptions.raise_compiler_error(
+        "Iceberg tables require explicit precision and scale for numeric types. In model '"
+        ~ model['name'] ~ "', the contract declares column(s) "
+        ~ (bare_numeric_columns | join(', '))
+        ~ " as a bare NUMBER/NUMERIC/DECIMAL. Set an explicit precision and scale (for example "
+        ~ "number(38, 0)) in the contract. Left unspecified, Snowflake rejects the Iceberg "
+        ~ "table creation with error 099200.") -%}
+    {%- endif -%}
+  {%- endif -%}
+  {{ return(table_columns_and_constraints()) }}
+{%- endmacro %}

--- a/dbt-snowflake/tests/functional/iceberg/test_contract_numeric_precision.py
+++ b/dbt-snowflake/tests/functional/iceberg/test_contract_numeric_precision.py
@@ -1,0 +1,77 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+
+# A contract that declares a bare NUMBER (no precision/scale) on an Iceberg table.
+# The guard should fail this at compile time, before any DDL reaches Snowflake.
+_MODEL_BARE_NUMBER = """
+{{
+  config(
+    materialized="table",
+    table_format="iceberg",
+    contract={"enforced": true},
+  )
+}}
+select 1::number as id
+"""
+
+_SCHEMA_BARE_NUMBER = """
+version: 2
+models:
+  - name: iceberg_bare_number
+    columns:
+      - name: id
+        data_type: number
+"""
+
+# The same shape with an explicit precision/scale must NOT trip the guard.
+_MODEL_EXPLICIT_NUMBER = """
+{{
+  config(
+    materialized="table",
+    table_format="iceberg",
+    contract={"enforced": true},
+  )
+}}
+select 1::number(38, 0) as id
+"""
+
+_SCHEMA_EXPLICIT_NUMBER = """
+version: 2
+models:
+  - name: iceberg_explicit_number
+    columns:
+      - name: id
+        data_type: number(38, 0)
+"""
+
+
+class TestIcebergContractBareNumericRaises:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "iceberg_bare_number.sql": _MODEL_BARE_NUMBER,
+            "schema.yml": _SCHEMA_BARE_NUMBER,
+        }
+
+    def test_bare_number_contract_raises_actionable_error(self, project):
+        result = run_dbt(["run"], expect_pass=False)
+        assert len(result) == 1
+        message = result[0].message
+        assert "099200" in message
+        assert "number(38, 0)" in message
+        assert "id" in message
+
+
+class TestIcebergContractExplicitNumericPasses:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "iceberg_explicit_number.sql": _MODEL_EXPLICIT_NUMBER,
+            "schema.yml": _SCHEMA_EXPLICIT_NUMBER,
+        }
+
+    def test_explicit_precision_does_not_trip_the_guard(self, project):
+        # With explicit precision the guard must not fire; the model builds normally.
+        run_dbt(["run"])

--- a/dbt-snowflake/tests/unit/test_iceberg_contract_numeric_precision.py
+++ b/dbt-snowflake/tests/unit/test_iceberg_contract_numeric_precision.py
@@ -1,0 +1,79 @@
+import os
+import unittest
+from unittest import mock
+
+from jinja2 import Environment, FileSystemLoader
+
+MACROS_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "../../src/dbt/include/snowflake/macros")
+)
+
+
+class _CompilerError(Exception):
+    """Stand-in for dbt's compiler error so the test can assert on the raised message."""
+
+
+class TestIcebergContractNumericPrecisionMacro(unittest.TestCase):
+    """Unit tests for snowflake__get_table_columns_and_constraints (Iceberg bare-numeric guard)."""
+
+    def setUp(self):
+        self.jinja_env = Environment(
+            loader=FileSystemLoader(MACROS_DIR),
+            extensions=["jinja2.ext.do"],
+        )
+        self.exceptions = mock.Mock()
+
+        def _raise(message):
+            raise _CompilerError(message)
+
+        self.exceptions.raise_compiler_error.side_effect = _raise
+
+        self.context = {
+            "exceptions": self.exceptions,
+            "config": mock.Mock(),
+            "adapter": mock.Mock(),
+            # base macro the override delegates to when the guard does not fire
+            "table_columns_and_constraints": lambda: "COLUMNS_AND_CONSTRAINTS_DDL",
+            "return": lambda value: value,
+        }
+
+    def _run(self, catalog_type, columns):
+        context = dict(self.context)
+        context["model"] = {"name": "m", "columns": columns}
+        context["adapter"].build_catalog_relation = mock.Mock(
+            return_value=mock.Mock(catalog_type=catalog_type)
+        )
+        template = self.jinja_env.get_template(
+            "relations/column/columns_spec_ddl.sql", globals=context
+        )
+        return template.module.snowflake__get_table_columns_and_constraints()
+
+    def test_iceberg_bare_number_raises_with_column_and_error_code(self):
+        with self.assertRaises(_CompilerError) as ctx:
+            self._run("BUILT_IN", {"id": {"name": "id", "data_type": "number"}})
+        message = str(ctx.exception)
+        self.assertIn("id", message)
+        self.assertIn("099200", message)
+        self.assertIn("number(38, 0)", message)
+
+    def test_iceberg_rest_bare_decimal_raises(self):
+        with self.assertRaises(_CompilerError):
+            self._run("ICEBERG_REST", {"amt": {"name": "amt", "data_type": "DECIMAL"}})
+
+    def test_iceberg_explicit_precision_does_not_raise(self):
+        result = self._run("BUILT_IN", {"id": {"name": "id", "data_type": "number(38,0)"}})
+        self.assertIn("COLUMNS_AND_CONSTRAINTS_DDL", result)
+
+    def test_non_iceberg_bare_number_does_not_raise(self):
+        result = self._run("INFO_SCHEMA", {"id": {"name": "id", "data_type": "number"}})
+        self.assertIn("COLUMNS_AND_CONSTRAINTS_DDL", result)
+
+    def test_iceberg_non_numeric_columns_do_not_raise(self):
+        result = self._run(
+            "BUILT_IN",
+            {
+                "id": {"name": "id", "data_type": "number(38,0)"},
+                "name": {"name": "name", "data_type": "varchar"},
+            },
+        )
+        self.assertIn("COLUMNS_AND_CONSTRAINTS_DDL", result)


### PR DESCRIPTION
resolves #2091
docs: N/A

### Problem

When a dbt model targets an Iceberg table with a contract that declares a numeric column as bare `NUMBER`, `NUMERIC`, or `DECIMAL` (no precision or scale), Snowflake rejects the generated DDL at runtime with opaque error 099200 that does not name the offending column or explain the fix. Regular Snowflake tables silently coerce bare `NUMBER` to `NUMBER(38,0)`, so users migrating from non-Iceberg to Iceberg tables encounter this unexpectedly.

### Solution

Override `snowflake__get_table_columns_and_constraints` to inspect the model contract before the `CREATE` reaches Snowflake. If the target is an Iceberg relation (BUILT_IN or ICEBERG_REST) and any contract column declares a bare numeric type, raise a clear dbt compiler error that names the column(s) and directs the user to set explicit precision and scale (e.g. `number(38, 0)`).

The user's declared type is not rewritten — we ask them to be explicit. Non-Iceberg contracts are unaffected.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX