### PR TITLE
refactor(redshift): read grants behavior flag directly

### DIFF
--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -209,11 +209,6 @@ class RedshiftAdapter(SQLAdapter):
         return bool(self.config.credentials.drop_without_cascade)
 
     @available
-    def use_grants_extended(self) -> bool:
-        """Whether to use extended grants support for groups and roles."""
-        return self.behavior.redshift_grants_extended.no_warn
-
-    @available
     def verify_database(self, database):
         if database.startswith('"'):
             database = database.strip('"')
@@ -362,7 +357,7 @@ class RedshiftAdapter(SQLAdapter):
         grants_dict: Dict[str, List[str]] = {}
         current_user = self.config.credentials.user.lower()
 
-        if not self.use_grants_extended():
+        if not self.behavior.redshift_grants_extended.no_warn:
             if not self.use_show_apis():
                 # pg_user query returns a 'grantee' column — delegate to base.
                 return super().standardize_grants_dict(grants_table)

--- a/dbt-redshift/src/dbt/include/redshift/macros/metadata/helpers.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/metadata/helpers.sql
@@ -3,7 +3,7 @@
 {% endmacro %}
 
 {% macro redshift__use_grants_extended() %}
-    {{ return(adapter.use_grants_extended()) }}
+    {{ return(adapter.behavior.redshift_grants_extended.no_warn) }}
 {% endmacro %}
 
 {% macro redshift__drop_without_cascade() %}


### PR DESCRIPTION
### Problem

`redshift_grants_extended` is a behavior flag, but the Redshift grants macro reads it through a Redshift-specific adapter method. That method only wraps `adapter.behavior.redshift_grants_extended.no_warn`, adding an unnecessary public adapter surface.

### Solution

Update `redshift__use_grants_extended()` to read the behavior flag directly from Jinja, matching the existing behavior flag pattern used by other adapter macros.

Also remove the redundant `RedshiftAdapter.use_grants_extended()` wrapper and read the behavior flag directly inside `standardize_grants_dict()`.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX