### PR TITLE
fix: raise instead of dropping all columns when temp relation introspection returns empty

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20260728-114754.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20260728-114754.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Raise a clear error instead of dropping all target columns when column introspection
+    of an incremental model's temporary relation returns no columns
+time: 2026-07-28T11:47:54.242865-07:00
+custom:
+    Author: will-sargent-dbtlabs
+    Issue: "1947 1991"

--- a/dbt-adapters/.changes/unreleased/Fixes-20260728-114754.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20260728-114754.yaml
@@ -1,6 +1,7 @@
 kind: Fixes
 body: Raise a clear error instead of dropping all target columns when column introspection
-    of an incremental model's temporary relation returns no columns
+    of an incremental model's temporary relation returns no columns. on_schema_change='append_new_columns'
+    warns and continues instead, since it cannot drop columns
 time: 2026-07-28T11:47:54.242865-07:00
 custom:
     Author: will-sargent-dbtlabs

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/on_schema_change.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/on_schema_change.sql
@@ -27,6 +27,36 @@
 
   {%- set source_columns = adapter.get_columns_in_relation(source_relation) -%}
   {%- set target_columns = adapter.get_columns_in_relation(target_relation) -%}
+
+  {#-
+    An empty source column list is a metadata failure, not a real schema. This materialization
+    just built and populated `source_relation`, so it necessarily has columns. If column
+    introspection comes back empty it means the adapter could not see the relation -- and
+    continuing would compute "every target column is missing from the source", which under
+    on_schema_change='sync_all_columns' drops every column in the target table.
+    Fail loudly instead of silently destroying the target schema.
+  -#}
+  {%- if source_columns | length == 0 -%}
+    {%- set empty_source_columns_msg -%}
+      Could not read any columns for {{ source_relation }} while checking for schema changes on
+      incremental model {{ target_relation }}.
+
+      This is a metadata failure rather than an empty schema: {{ source_relation }} was just built
+      by this run, so it does have columns. Continuing would treat every column in
+      {{ target_relation }} as removed and, with on_schema_change='sync_all_columns', drop them.
+
+      Common causes:
+        - the warehouse does not expose this intermediate/temporary relation to the catalog views
+          the adapter reads column metadata from
+        - the connection's database differs from the one the temporary relation was created in
+
+      Workarounds:
+        - set on_schema_change='ignore' to skip this check
+        - run the model with --full-refresh to rebuild it
+    {%- endset -%}
+    {%- do exceptions.raise_compiler_error(empty_source_columns_msg) -%}
+  {%- endif -%}
+
   {%- set source_not_in_target = diff_columns(source_columns, target_columns) -%}
   {%- set target_not_in_source = diff_columns(target_columns, source_columns) -%}
 

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/on_schema_change.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/on_schema_change.sql
@@ -27,36 +27,6 @@
 
   {%- set source_columns = adapter.get_columns_in_relation(source_relation) -%}
   {%- set target_columns = adapter.get_columns_in_relation(target_relation) -%}
-
-  {#-
-    An empty source column list is a metadata failure, not a real schema. This materialization
-    just built and populated `source_relation`, so it necessarily has columns. If column
-    introspection comes back empty it means the adapter could not see the relation -- and
-    continuing would compute "every target column is missing from the source", which under
-    on_schema_change='sync_all_columns' drops every column in the target table.
-    Fail loudly instead of silently destroying the target schema.
-  -#}
-  {%- if source_columns | length == 0 -%}
-    {%- set empty_source_columns_msg -%}
-      Could not read any columns for {{ source_relation }} while checking for schema changes on
-      incremental model {{ target_relation }}.
-
-      This is a metadata failure rather than an empty schema: {{ source_relation }} was just built
-      by this run, so it does have columns. Continuing would treat every column in
-      {{ target_relation }} as removed and, with on_schema_change='sync_all_columns', drop them.
-
-      Common causes:
-        - the warehouse does not expose this intermediate/temporary relation to the catalog views
-          the adapter reads column metadata from
-        - the connection's database differs from the one the temporary relation was created in
-
-      Workarounds:
-        - set on_schema_change='ignore' to skip this check
-        - run the model with --full-refresh to rebuild it
-    {%- endset -%}
-    {%- do exceptions.raise_compiler_error(empty_source_columns_msg) -%}
-  {%- endif -%}
-
   {%- set source_not_in_target = diff_columns(source_columns, target_columns) -%}
   {%- set target_not_in_source = diff_columns(target_columns, source_columns) -%}
 
@@ -153,6 +123,47 @@
     {% else %}
 
       {% set schema_changes_dict = check_for_schema_changes(source_relation, target_relation) %}
+
+      {#-
+        An empty source column list is an introspection failure, not a real schema -- this run just
+        built source_relation. sync_all_columns would drop every target column and fail would report
+        a bogus diff, so both refuse. append_new_columns never drops, and the caller substitutes the
+        target's columns for our empty return, so it warns instead of breaking a working run.
+      -#}
+      {%- if schema_changes_dict['source_columns'] | length == 0 -%}
+        {%- set empty_source_columns_msg -%}
+          Could not read any columns for {{ source_relation }} while checking for schema changes on
+          incremental model {{ target_relation }} (on_schema_change='{{ on_schema_change }}').
+
+          This is a metadata failure rather than an empty schema: {{ source_relation }} was just
+          built by this run, so it does have columns.
+
+          Common causes:
+            - the warehouse does not expose this temporary relation to the catalog views the
+              adapter reads column metadata from
+            - the connection's database differs from the one the temporary relation was created in
+
+          {% if on_schema_change == 'append_new_columns' -%}
+          Continuing, because on_schema_change='append_new_columns' never drops columns and dbt
+          will insert using {{ target_relation }}'s existing columns. No new column can be
+          detected this run, so if the model added one it stays missing until introspection works
+          or you run with --full-refresh.
+          {%- else -%}
+          Refusing to continue: dbt cannot determine which columns changed, so it cannot safely
+          apply on_schema_change='{{ on_schema_change }}'. With 'sync_all_columns' this would
+          silently drop every column in {{ target_relation }}.
+
+          Workarounds:
+            - set on_schema_change='ignore' to skip this check
+            - run the model with --full-refresh to rebuild it
+          {%- endif %}
+        {%- endset -%}
+        {%- if on_schema_change == 'append_new_columns' -%}
+          {%- do exceptions.warn(empty_source_columns_msg) -%}
+        {%- else -%}
+          {%- do exceptions.raise_compiler_error(empty_source_columns_msg) -%}
+        {%- endif -%}
+      {%- endif -%}
 
       {% if schema_changes_dict['schema_changed'] %}
 

--- a/dbt-postgres/tests/functional/incremental_schema_tests/test_empty_source_columns.py
+++ b/dbt-postgres/tests/functional/incremental_schema_tests/test_empty_source_columns.py
@@ -1,18 +1,26 @@
 """
-Regression tests for the empty-source-columns guard in default__check_for_schema_changes.
+Regression tests for the empty-source-columns guard in default__process_schema_changes.
 
 When column introspection of the incremental temp relation returns no rows, dbt used to treat
-that as "the source has no columns" and, under on_schema_change='sync_all_columns', drop every
-column from the target table. This is reachable in the wild: on Redshift, connecting to a
-datashare consumer database makes temporary relations invisible to information_schema.columns,
-pg_attribute and svv_columns, while the relation itself remains fully queryable
-(dbt-labs/dbt-adapters#1947, #1991).
+that as "the source has no columns" and, under on_schema_change='sync_all_columns', issue
+`drop column` for every column in the target before failing on the resulting `insert into t ()`.
+This is reachable in the wild: on Redshift, connecting to a datashare consumer database makes
+temporary relations invisible to information_schema.columns, pg_attribute and svv_columns, while
+the relation itself remains fully queryable (dbt-labs/dbt-adapters#1947, #1991).
 
-These tests simulate that condition adapter-agnostically by overriding
+The guard's behaviour depends on on_schema_change, because only some values are destructive:
+
+  sync_all_columns   raises -- would otherwise drop every target column
+  fail               raises -- would otherwise report a bogus "out of sync" diff
+  append_new_columns warns  -- cannot drop anything, and the materialization substitutes the
+                              target's columns for the empty return, so the run still works
+  ignore             never reaches the guard (process_schema_changes returns early)
+
+These tests simulate the condition adapter-agnostically by overriding
 postgres__get_columns_in_relation to return an empty list for the temp relation only.
 """
 
-from dbt.tests.util import run_dbt
+from dbt.tests.util import run_dbt, run_dbt_and_capture, write_file
 import pytest
 
 _MODEL_SYNC_ALL_COLUMNS = """
@@ -38,9 +46,40 @@ where id not in (select id from {{ this }})
 """
 
 
-_MODEL_IGNORE = _MODEL_SYNC_ALL_COLUMNS.replace(
-    "on_schema_change='sync_all_columns'", "on_schema_change='ignore'"
+def _with_on_schema_change(value):
+    return _MODEL_SYNC_ALL_COLUMNS.replace(
+        "on_schema_change='sync_all_columns'", "on_schema_change='%s'" % value
+    )
+
+
+_MODEL_IGNORE = _with_on_schema_change("ignore")
+_MODEL_APPEND_NEW_COLUMNS = _with_on_schema_change("append_new_columns")
+_MODEL_FAIL = _with_on_schema_change("fail")
+
+
+# Same model as _MODEL_APPEND_NEW_COLUMNS with a third column added, so the second run has a
+# genuinely new column that append_new_columns would normally pick up.
+_MODEL_APPEND_NEW_COLUMNS_DRIFTED = """
+{{
+    config(
+        materialized='incremental',
+        unique_key='id',
+        on_schema_change='append_new_columns'
+    )
+}}
+
+with source_data as (
+    select 1 as id, 'aaa' as field_1, 'bbb' as field_2, 'ggg' as field_3
+    union all select 2 as id, 'ccc' as field_1, 'ddd' as field_2, 'hhh' as field_3
+    union all select 3 as id, 'eee' as field_1, 'fff' as field_2, 'iii' as field_3
 )
+
+select * from source_data
+
+{% if is_incremental() %}
+where id not in (select id from {{ this }})
+{% endif %}
+"""
 
 
 # Returns an empty column list for the incremental temp relation only, reproducing a warehouse
@@ -90,18 +129,20 @@ def _column_names(project, identifier):
     return [row[0] for row in rows]
 
 
-class TestEmptySourceColumnsRaises:
+class _EmptyTempColumns:
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"empty_temp_columns.sql": _MACRO_EMPTY_TEMP_COLUMNS}
+
+
+class TestEmptySourceColumnsRaises(_EmptyTempColumns):
     """sync_all_columns must fail loudly rather than drop every target column."""
 
     @pytest.fixture(scope="class")
     def models(self):
         return {"incremental_sync_all_columns.sql": _MODEL_SYNC_ALL_COLUMNS}
 
-    @pytest.fixture(scope="class")
-    def macros(self):
-        return {"empty_temp_columns.sql": _MACRO_EMPTY_TEMP_COLUMNS}
-
-    def test_raises_and_preserves_target_columns(self, project):
+    def test_raises_before_issuing_any_drop(self, project):
         # First run builds the table normally; the temp-relation override is not exercised
         # because a non-incremental build has no temp relation to introspect.
         run_dbt(["run", "--select", "incremental_sync_all_columns"])
@@ -113,12 +154,19 @@ class TestEmptySourceColumnsRaises:
 
         # Second run goes down the incremental path, where introspecting the temp relation
         # returns []. This must raise rather than proceed.
-        results = run_dbt(["run", "--select", "incremental_sync_all_columns"], expect_pass=False)
+        results, logs = run_dbt_and_capture(
+            ["--debug", "run", "--select", "incremental_sync_all_columns"], expect_pass=False
+        )
         assert len(results) == 1
         assert "Could not read any columns" in results[0].message
         assert "metadata failure" in results[0].message
 
-        # The target table must be untouched -- this is the actual regression.
+        # The load-bearing assertion: unguarded, dbt issues `drop column` for all three before
+        # failing on `insert into ... ()`. Postgres rolls that back with the failed transaction,
+        # so comparing column lists cannot tell the two runs apart -- on a warehouse that commits
+        # the DDL the columns stay gone.
+        assert "drop column" not in logs
+
         assert _column_names(project, "incremental_sync_all_columns") == [
             "id",
             "field_1",
@@ -126,16 +174,87 @@ class TestEmptySourceColumnsRaises:
         ]
 
 
-class TestEmptySourceColumnsIgnoreStillWorks:
+class TestEmptySourceColumnsFailRaises(_EmptyTempColumns):
+    """on_schema_change='fail' must report the metadata failure, not a bogus column diff."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"incremental_fail.sql": _MODEL_FAIL}
+
+    def test_reports_metadata_failure_not_out_of_sync(self, project):
+        run_dbt(["run", "--select", "incremental_fail"])
+
+        results = run_dbt(["run", "--select", "incremental_fail"], expect_pass=False)
+        assert len(results) == 1
+        assert "Could not read any columns" in results[0].message
+
+        # Without the guard this path raises the generic out-of-sync error, which lists every
+        # target column as removed and sends the user looking for a schema change that never
+        # happened. Asserting its absence is what distinguishes the two failures.
+        assert "out of sync" not in results[0].message
+
+        assert _column_names(project, "incremental_fail") == ["id", "field_1", "field_2"]
+
+
+class TestEmptySourceColumnsAppendNewColumnsWarns(_EmptyTempColumns):
+    """append_new_columns cannot drop anything, so it warns and the run still succeeds."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"incremental_append_new_columns.sql": _MODEL_APPEND_NEW_COLUMNS}
+
+    def test_warns_and_run_still_succeeds(self, project):
+        run_dbt(["run", "--select", "incremental_append_new_columns"])
+        assert _column_names(project, "incremental_append_new_columns") == [
+            "id",
+            "field_1",
+            "field_2",
+        ]
+
+        # Add a column, so this run has something append_new_columns would normally append.
+        write_file(
+            _MODEL_APPEND_NEW_COLUMNS_DRIFTED,
+            project.project_root,
+            "models",
+            "incremental_append_new_columns.sql",
+        )
+
+        results, logs = run_dbt_and_capture(["run", "--select", "incremental_append_new_columns"])
+        assert len(results) == 1
+        assert "Could not read any columns" in logs
+
+        # The accepted limitation of warning rather than raising: the new column cannot be
+        # detected, so it is not appended. The run succeeds using the target's columns.
+        assert _column_names(project, "incremental_append_new_columns") == [
+            "id",
+            "field_1",
+            "field_2",
+        ]
+
+
+class TestEmptySourceColumnsAppendNewColumnsWarnError(_EmptyTempColumns):
+    """--warn-error escalates the append_new_columns warning, for users who opt into strictness."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"incremental_warn_error.sql": _MODEL_APPEND_NEW_COLUMNS}
+
+    def test_warn_error_escalates_to_failure(self, project):
+        run_dbt(["run", "--select", "incremental_warn_error"])
+
+        results = run_dbt(
+            ["--warn-error", "run", "--select", "incremental_warn_error"], expect_pass=False
+        )
+        assert len(results) == 1
+        assert "Could not read any columns" in results[0].message
+
+
+class TestEmptySourceColumnsIgnoreStillWorks(_EmptyTempColumns):
     """on_schema_change='ignore' skips the check entirely, so it must remain unaffected."""
 
     @pytest.fixture(scope="class")
     def models(self):
         return {"incremental_ignore.sql": _MODEL_IGNORE}
-
-    @pytest.fixture(scope="class")
-    def macros(self):
-        return {"empty_temp_columns.sql": _MACRO_EMPTY_TEMP_COLUMNS}
 
     def test_ignore_is_unaffected(self, project):
         run_dbt(["run", "--select", "incremental_ignore"])

--- a/dbt-postgres/tests/functional/incremental_schema_tests/test_empty_source_columns.py
+++ b/dbt-postgres/tests/functional/incremental_schema_tests/test_empty_source_columns.py
@@ -1,0 +1,143 @@
+"""
+Regression tests for the empty-source-columns guard in default__check_for_schema_changes.
+
+When column introspection of the incremental temp relation returns no rows, dbt used to treat
+that as "the source has no columns" and, under on_schema_change='sync_all_columns', drop every
+column from the target table. This is reachable in the wild: on Redshift, connecting to a
+datashare consumer database makes temporary relations invisible to information_schema.columns,
+pg_attribute and svv_columns, while the relation itself remains fully queryable
+(dbt-labs/dbt-adapters#1947, #1991).
+
+These tests simulate that condition adapter-agnostically by overriding
+postgres__get_columns_in_relation to return an empty list for the temp relation only.
+"""
+
+from dbt.tests.util import run_dbt
+import pytest
+
+_MODEL_SYNC_ALL_COLUMNS = """
+{{
+    config(
+        materialized='incremental',
+        unique_key='id',
+        on_schema_change='sync_all_columns'
+    )
+}}
+
+with source_data as (
+    select 1 as id, 'aaa' as field_1, 'bbb' as field_2
+    union all select 2 as id, 'ccc' as field_1, 'ddd' as field_2
+    union all select 3 as id, 'eee' as field_1, 'fff' as field_2
+)
+
+select * from source_data
+
+{% if is_incremental() %}
+where id not in (select id from {{ this }})
+{% endif %}
+"""
+
+
+_MODEL_IGNORE = _MODEL_SYNC_ALL_COLUMNS.replace(
+    "on_schema_change='sync_all_columns'", "on_schema_change='ignore'"
+)
+
+
+# Returns an empty column list for the incremental temp relation only, reproducing a warehouse
+# whose catalog cannot see it. All other relations introspect normally.
+_MACRO_EMPTY_TEMP_COLUMNS = """
+{% macro postgres__get_columns_in_relation(relation) -%}
+
+  {% if '__dbt_tmp' in (relation.identifier or '') %}
+    {{ return([]) }}
+  {% endif %}
+
+  {% call statement('get_columns_in_relation', fetch_result=True) %}
+      select
+          column_name,
+          data_type,
+          character_maximum_length,
+          numeric_precision,
+          numeric_scale
+
+      from {{ relation.information_schema('columns') }}
+      where table_name = '{{ relation.identifier }}'
+        {% if relation.schema %}
+        and table_schema = '{{ relation.schema }}'
+        {% endif %}
+      order by ordinal_position
+
+  {% endcall %}
+  {% set table = load_result('get_columns_in_relation').table %}
+  {{ return(sql_convert_columns_in_relation(table)) }}
+{% endmacro %}
+"""
+
+
+def _column_names(project, identifier):
+    rows = project.run_sql(
+        """
+        select column_name
+        from information_schema.columns
+        where table_schema = '{schema}'
+          and table_name = '"""
+        + identifier
+        + """'
+        order by ordinal_position
+        """,
+        fetch="all",
+    )
+    return [row[0] for row in rows]
+
+
+class TestEmptySourceColumnsRaises:
+    """sync_all_columns must fail loudly rather than drop every target column."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"incremental_sync_all_columns.sql": _MODEL_SYNC_ALL_COLUMNS}
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"empty_temp_columns.sql": _MACRO_EMPTY_TEMP_COLUMNS}
+
+    def test_raises_and_preserves_target_columns(self, project):
+        # First run builds the table normally; the temp-relation override is not exercised
+        # because a non-incremental build has no temp relation to introspect.
+        run_dbt(["run", "--select", "incremental_sync_all_columns"])
+        assert _column_names(project, "incremental_sync_all_columns") == [
+            "id",
+            "field_1",
+            "field_2",
+        ]
+
+        # Second run goes down the incremental path, where introspecting the temp relation
+        # returns []. This must raise rather than proceed.
+        results = run_dbt(["run", "--select", "incremental_sync_all_columns"], expect_pass=False)
+        assert len(results) == 1
+        assert "Could not read any columns" in results[0].message
+        assert "metadata failure" in results[0].message
+
+        # The target table must be untouched -- this is the actual regression.
+        assert _column_names(project, "incremental_sync_all_columns") == [
+            "id",
+            "field_1",
+            "field_2",
+        ]
+
+
+class TestEmptySourceColumnsIgnoreStillWorks:
+    """on_schema_change='ignore' skips the check entirely, so it must remain unaffected."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"incremental_ignore.sql": _MODEL_IGNORE}
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"empty_temp_columns.sql": _MACRO_EMPTY_TEMP_COLUMNS}
+
+    def test_ignore_is_unaffected(self, project):
+        run_dbt(["run", "--select", "incremental_ignore"])
+        results = run_dbt(["run", "--select", "incremental_ignore"])
+        assert len(results) == 1

--- a/dbt-redshift/tests/functional/adapter/datashare_consumer/test_snapshot.py
+++ b/dbt-redshift/tests/functional/adapter/datashare_consumer/test_snapshot.py
@@ -6,7 +6,7 @@ Snapshots hit the identical root cause through a different door: `snapshot.sql` 
 `*__dbt_tmp` staging relation (via `make_temp_relation`, same shape as an incremental temp
 relation) and calls `adapter.get_columns_in_relation` / `adapter.get_missing_columns` on it
 directly -- there is no `on_schema_change` involved, so the guard added for incremental models
-(default__check_for_schema_changes) does not apply here and was never meant to.
+(default__process_schema_changes) does not apply here and was never meant to.
 
 Snapshots also fail *louder* than incremental's silent column drop: a zero-columns read on the
 staging relation makes `source_columns` empty, which renders `snapshot_merge_sql`'s insert


### PR DESCRIPTION
## Problem

`default__check_for_schema_changes` accepts an empty `source_columns` list as a legitimate schema:

```jinja
{%- set source_columns = adapter.get_columns_in_relation(source_relation) -%}   {# -> [] #}
{%- set target_columns = adapter.get_columns_in_relation(target_relation) -%}   {# -> N columns #}
{%- set target_not_in_source = diff_columns(target_columns, source_columns) -%} {# -> all N #}
```

Every caller of `process_schema_changes` passes a freshly-built temp relation as the source
(`incremental.sql`, and the snowflake / spark / athena materializations), so that relation always has
columns. An empty result is therefore always an introspection failure — and continuing makes
`sync_all_columns` conclude that every target column was removed and emit
`ALTER TABLE … DROP COLUMN` for all of them.

This is reachable in production, not theoretical. On Redshift, connecting with `dbname` set to a
datashare consumer database (`svv_redshift_databases.database_type = 'shared'`) leaves temporary
relations **invisible to `information_schema.columns`, `pg_attribute` and `svv_columns`** while the
relation itself stays fully queryable — so `redshift__get_columns_in_relation_legacy` returns zero
rows with statement status `FINISHED` and no error. Reported in #1947 and #1991, with a reproduction
and evidence tables in [this comment](https://github.com/dbt-labs/dbt-adapters/issues/1947#issuecomment-5108260475).

The user-visible symptom is confusing, because the failure surfaces one step later as
`column "<unique_key>" does not exist` from the incremental `DELETE`, which sends people looking at
their unique key rather than at metadata.

### What the unguarded path actually does

Traced against a live Postgres with introspection stubbed to return `[]`, `on_schema_change='sync_all_columns'`:

```
Schema changed: True
Target columns not in source: [id, field_1, field_2]
Columns removed: [id, field_1, field_2]
alter table "…"."incremental_preguard" drop column "id", drop column "field_1", drop column "field_2"
SQL status: ALTER TABLE in 0.001 seconds
… then: syntax error at or near ")"  ->  insert into "…"."incremental_preguard" ()
```

Worth recording precisely, because it corrects an assumption I had made in the first version of this
PR. The `DROP COLUMN` **is** issued and succeeds; the run then dies on the empty insert column list.
Postgres has transactional DDL, so that failed transaction rolls the drop back and the columns
survive **on Postgres**. On a warehouse that commits the DDL the columns stay gone — which is what
#1947 and #1991 report. This has a direct consequence for testing: comparing column lists before and
after cannot distinguish a guarded run from an unguarded one on Postgres, so the test asserts that
**no `drop column` is issued at all** instead.

## Fix

Guard in `default__process_schema_changes`, immediately after `check_for_schema_changes` returns.
Because `on_schema_change` is in scope there, the guard can be scoped to what is actually
destructive rather than failing every path:

| `on_schema_change` | unguarded behaviour | guarded behaviour |
|---|---|---|
| `sync_all_columns` | issues `drop column` for every target column, then fails on `insert into t ()` | **raises** |
| `fail` | raises the generic "out of sync" error listing every target column as removed | **raises**, naming the metadata failure |
| `append_new_columns` | no-op `ALTER`, returns `[]`, caller falls back to the target's columns — run passes | **warns**, run still passes |
| `ignore` | returns before the guard | unchanged |

The error names both relations and the active `on_schema_change` value, states that this is a
metadata failure rather than an empty schema, and lists causes and workarounds.

**`append_new_columns` deliberately warns rather than raises.** Every incremental materialization in
this repo (core, snowflake, athena, bigquery) has this immediately after the call:

```jinja
{% set dest_columns = process_schema_changes(...) %}
{% if not dest_columns %}
  {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}
{% endif %}
```

so an empty return is already absorbed and the run completes correctly using the target's columns.
Raising there would convert currently-passing runs into hard failures for no safety benefit — nothing
can be dropped under `append_new_columns`. The real cost is that a genuinely new column goes
undetected, which is what the warning says. `--warn-error` escalates it for anyone who wants the
failure.

Two honest caveats on that choice:

- `exceptions.warn` fires with `force_warn_or_error_handling=True`, so **`--warn-error` turns this
  into an error**. That is the desired escape hatch, but it does mean strict CI setups will see a
  new failure. Covered by a test.
- The warning appears in the log body but does **not** increment the run summary's `WARN` count —
  a warned run still reports `PASS=1 WARN=0`. That is how `exceptions.warn` behaves generally, not
  something this PR introduces, but it makes the warning easier to miss than the wording implies.

## Scope

- **No behaviour change on healthy runs** — the guard only fires when introspection returns nothing.
- **`default__check_for_schema_changes` is byte-identical to `main`.** The guard originally lived
  there; it moved per review. The net diff to the macro file is +41 lines, 0 deletions.
- **`on_schema_change='ignore'` is unaffected** — it returns from `process_schema_changes` before
  reaching the guard. Covered by a test.
- **BigQuery is untouched** — it defines both `bigquery__check_for_schema_changes` **and**
  `bigquery__process_schema_changes`, and the latter dispatches to the former, so it never reached
  the default guard before this change and still does not. Adapter coverage is therefore identical
  in both placements. It has the same unguarded shape and may want the same treatment, but I've left
  it out of scope rather than change an adapter I can't test here.
- Deliberately **not** guarding empty `target_columns`: that direction is additive (columns get added,
  not dropped), so it isn't destructive and the correct behaviour is less obvious.

The underlying Redshift introspection gap is now fixed on `main` by #2097, which describes temp
relations from the driver's cursor when the catalog cannot see them. So the condition this guard
catches is no longer reachable on Redshift through the reported path, and this PR is now
defense-in-depth: it keeps a metadata failure in **any** adapter from turning into a dropped schema,
rather than being the fix for a live outage.

## Tests

`dbt-postgres/tests/functional/incremental_schema_tests/test_empty_source_columns.py` reproduces the
condition adapter-agnostically by overriding `postgres__get_columns_in_relation` to return `[]` for
`*__dbt_tmp*` relations only. One class per `on_schema_change` value:

| test | asserts |
|---|---|
| `TestEmptySourceColumnsRaises` | raises, **and no `drop column` is issued** (see above for why that, not a column comparison, is the load-bearing check) |
| `TestEmptySourceColumnsFailRaises` | raises the metadata error and **not** the generic `out of sync` one |
| `TestEmptySourceColumnsAppendNewColumnsWarns` | run **passes**, warning is emitted, and the new column is not appended — the accepted limitation |
| `TestEmptySourceColumnsAppendNewColumnsWarnError` | `--warn-error` escalates the warning to a failure |
| `TestEmptySourceColumnsIgnoreStillWorks` | `ignore` is unaffected |

Verified against a local Postgres 16:

- **5/5 pass** with the guard.
- **4/5 fail** with the macro reverted to `main`. The `ignore` test passes either way, which is its
  purpose — it exists to prove the guard is *not* reached on that path.
- Full `dbt-postgres` functional suite: **570 passed, 12 skipped**, plus 2 errors in
  `test_simple_copy.py::TestSimpleCopyUppercase` and `test_mixed_case_db.py` that are
  `FailedToConnectError` against the mixed-case database in my local container and **reproduce
  identically with this change reverted** — environmental, not caused by this PR.

## Review response

@tauhid621 — both of your comments are addressed by the same move, and you were right that
`default__check_for_schema_changes` was the wrong home: it's an inspect-and-return macro, and raising
from it changed the contract for anyone calling it for introspection. The guard now sits beside the
existing `on_schema_change` error in `default__process_schema_changes`.

I checked whether moving it costs coverage, since either macro could be overridden — it doesn't;
BigQuery overrides both and is the only override in the repo, so the two placements protect exactly
the same set of adapters.

Your second point about `on_schema_change` being available is what led to the per-config table above.
Scoping by it is what makes it possible to keep `append_new_columns` runs working instead of failing
them, which turned out to matter more than I expected once I traced the `dest_columns` fallback.

## Checklist

- [x] Changelog entry added (`Fixes-20260728-114754.yaml`, updated to mention the `append_new_columns` warning)
- [x] `black` clean at line-length 99 (flake8's `exclude` covers `dbt-postgres/tests` and `dbt-redshift/tests`, so it does not lint these files)
- [x] Regression tests verified to fail without the fix
- [x] Rebuilt on top of `main` post-#2097
