### PR TITLE
fix(redshift): describe temp relations from the driver when the catalog cannot see them

### DIFF
--- a/dbt-redshift/.changes/unreleased/Fixes-20260728-120003.yaml
+++ b/dbt-redshift/.changes/unreleased/Fixes-20260728-120003.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Describe temporary relations from the driver when the connection targets a datashare
+    consumer database, where they are invisible to all catalog views. Previously this made
+    on_schema_change='sync_all_columns' drop every column in the target table.
+time: 2026-07-28T12:00:03.029795-07:00
+custom:
+    Author: will-sargent-dbtlabs
+    Issue: "1947 1991"

--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -253,32 +253,58 @@ class RedshiftAdapter(SQLAdapter):
         database context. Type codes are mapped back to the names ``SHOW COLUMNS`` reports
         so that columns described this way compare equal to columns of the target relation
         in ``check_for_schema_changes``.
+
+        Size/precision/scale cannot come from ``cursor.description``: ``redshift_connector``
+        (the version dbt-redshift depends on) hardcodes those PEP 249 fields to ``None`` --
+        verified directly against its source (``Cursor._getDescription``), not merely
+        undocumented. The real values are still on the wire: the driver parses the
+        Postgres-protocol row description into ``cursor.ps["row_desc"]``, which carries
+        ``type_modifier`` (``pg_attribute.atttypmod``) per column but never surfaces it
+        through the public API. Reading it directly is the only way to get real sizes;
+        without it, every sized string/numeric column looks "changed" against the target
+        on the very next run, and Redshift's add/copy/drop/rename response to that
+        reorders the column and can silently narrow its scale.
         """
         sql = f"select * from {self.quote(relation.identifier)} limit 0"
         _, cursor = self.connections.add_select_query(sql)
 
+        # `cursor.ps["row_desc"]` is an internal, undocumented structure of
+        # `redshift_connector`, not a public API -- there is no supported alternative for
+        # reaching `type_modifier`. `_getDescription` builds `cursor.description` from this
+        # same list, in the same order, so index-aligned lookup here is safe.
+        try:
+            row_descriptions = cursor.ps["row_desc"]
+        except (AttributeError, KeyError, TypeError):
+            row_descriptions = []
+
         columns = []
-        for description in cursor.description or []:
+        for i, description in enumerate(cursor.description or []):
             # PEP 249: (name, type_code, display_size, internal_size, precision, scale, null_ok)
             column_name = description[0]
             type_code = description[1]
-            internal_size = description[3] if len(description) > 3 else None
-            precision = description[4] if len(description) > 4 else None
-            scale = description[5] if len(description) > 5 else None
+
+            type_modifier = None
+            if i < len(row_descriptions):
+                type_modifier = row_descriptions[i].get("type_modifier")
 
             data_type = self._temp_relation_data_type(type_code)
 
             # Only string and exact-numeric types feed size into Column.data_type, which is
             # what schema comparison comes down to. For every other type the size fields are
-            # ignored, so leave them unset rather than propagate the driver's display widths.
+            # ignored, so leave them unset.
             char_size = None
             numeric_precision = None
             numeric_scale = None
-            if data_type in ("character varying", "character"):
-                char_size = next((s for s in (precision, internal_size) if s and s > 0), None)
-            elif data_type == "numeric":
-                numeric_precision = precision
-                numeric_scale = scale
+            if type_modifier is not None and type_modifier >= 0:
+                # Postgres wire-protocol convention: VARHDRSZ (4 bytes) is added to both a
+                # string's declared length and a numeric's packed (precision, scale) pair.
+                # -1 means "no modifier" (unconstrained/default size) and is left unset.
+                raw_modifier = type_modifier - 4
+                if data_type in ("character varying", "character"):
+                    char_size = raw_modifier if raw_modifier > 0 else None
+                elif data_type == "numeric":
+                    numeric_precision = raw_modifier >> 16
+                    numeric_scale = raw_modifier & 0xFFFF
 
             columns.append(
                 self.Column(

--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -42,6 +42,44 @@ for package in packages:
 GET_RELATIONS_MACRO_NAME = "redshift__get_relations"
 SHOW_TABLES_FROM_SCHEMA_MACRO_NAME = "redshift__show_tables_from_schema"
 
+# Redshift type OID -> the data type name SHOW COLUMNS reports for that type.
+#
+# Used to describe temporary relations from the driver's cursor description when the
+# catalog cannot see them (see RedshiftAdapter.get_columns_in_temp_relation). Keying on the
+# OID rather than on redshift_connector's own type labels keeps this independent of driver
+# label changes, and lets the values match SHOW COLUMNS exactly -- necessary because
+# incremental schema comparison diffs columns described this way against columns of the
+# target relation, which are described by SHOW COLUMNS.
+#
+# Verified against `SHOW COLUMNS FROM TABLE` on Redshift 1.0.358853. Note in particular
+# that bpchar reports as "character" (not "character varying") and varbyte reports as
+# "binary varying" (not "varbyte"); getting either wrong produces a spurious type change
+# on every run.
+TYPE_OID_TO_DATA_TYPE: Dict[int, str] = {
+    16: "boolean",  # bool
+    20: "bigint",  # int8
+    21: "smallint",  # int2
+    23: "integer",  # int4
+    25: "character varying",  # text
+    700: "real",  # float4
+    701: "double precision",  # float8
+    1042: "character",  # bpchar
+    1043: "character varying",  # varchar
+    1082: "date",  # date
+    1083: "time without time zone",  # time
+    1114: "timestamp without time zone",  # timestamp
+    1184: "timestamp with time zone",  # timestamptz
+    1188: "interval year to month",  # intervaly2m
+    1190: "interval day to second",  # intervald2s
+    1266: "time with time zone",  # timetz
+    1700: "numeric",  # numeric
+    2935: "hllsketch",  # hllsketch
+    3000: "geometry",  # geometry
+    3001: "geography",  # geography
+    4000: "super",  # super
+    6551: "binary varying",  # varbyte
+}
+
 REDSHIFT_SKIP_AUTOCOMMIT_TRANSACTION_STATEMENTS = BehaviorFlag(
     name="redshift_skip_autocommit_transaction_statements",
     default=False,
@@ -198,6 +236,78 @@ class RedshiftAdapter(SQLAdapter):
         Returns True when the ``datasharing`` profile config is enabled.
         """
         return bool(self.config.credentials.datasharing)
+
+    @available
+    def get_columns_in_temp_relation(self, relation: BaseRelation) -> List[Any]:
+        """Describe a temporary relation without consulting the catalog.
+
+        When the connection's database is a datashare consumer database
+        (``svv_redshift_databases.database_type = 'shared'``), temporary relations are
+        created and remain queryable but are invisible to ``information_schema.columns``,
+        ``pg_attribute`` and ``svv_columns`` alike -- the session's temp schema belongs to
+        the default database while catalog views resolve against the consumer database.
+        ``SHOW COLUMNS`` cannot address them either, since it requires a database and
+        schema and temporary relations carry neither.
+
+        Reading the driver's cursor description is the only route that does not depend on
+        database context. Type codes are mapped back to the names ``SHOW COLUMNS`` reports
+        so that columns described this way compare equal to columns of the target relation
+        in ``check_for_schema_changes``.
+        """
+        sql = f"select * from {self.quote(relation.identifier)} limit 0"
+        _, cursor = self.connections.add_select_query(sql)
+
+        columns = []
+        for description in cursor.description or []:
+            # PEP 249: (name, type_code, display_size, internal_size, precision, scale, null_ok)
+            column_name = description[0]
+            type_code = description[1]
+            internal_size = description[3] if len(description) > 3 else None
+            precision = description[4] if len(description) > 4 else None
+            scale = description[5] if len(description) > 5 else None
+
+            data_type = self._temp_relation_data_type(type_code)
+
+            # Only string and exact-numeric types feed size into Column.data_type, which is
+            # what schema comparison comes down to. For every other type the size fields are
+            # ignored, so leave them unset rather than propagate the driver's display widths.
+            char_size = None
+            numeric_precision = None
+            numeric_scale = None
+            if data_type in ("character varying", "character"):
+                char_size = next((s for s in (precision, internal_size) if s and s > 0), None)
+            elif data_type == "numeric":
+                numeric_precision = precision
+                numeric_scale = scale
+
+            columns.append(
+                self.Column(
+                    column=column_name,
+                    dtype=data_type,
+                    char_size=char_size,
+                    numeric_precision=numeric_precision,
+                    numeric_scale=numeric_scale,
+                )
+            )
+
+        return columns
+
+    def _temp_relation_data_type(self, type_code: Any) -> str:
+        """Map a driver type code onto the data type name ``SHOW COLUMNS`` reports."""
+        data_type = TYPE_OID_TO_DATA_TYPE.get(type_code)
+        if data_type is not None:
+            return data_type
+
+        # Unrecognised type code: the driver's own label is closer than nothing, but it is
+        # not guaranteed to match SHOW COLUMNS, so surface it.
+        fallback = str(self.connections.data_type_code_to_name(type_code)).lower()
+        logger.debug(
+            f"No known Redshift data type for type code {type_code}; "
+            f"falling back to {fallback!r}. Schema comparison for this column may be "
+            f"inaccurate -- please report this at "
+            f"https://github.com/dbt-labs/dbt-adapters/issues"
+        )
+        return fallback
 
     @available
     def drop_without_cascade(self) -> bool:

--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -69,7 +69,6 @@ TYPE_OID_TO_DATA_TYPE: Dict[int, str] = {
     2935: "hllsketch",  # hllsketch
     3000: "geometry",  # geometry
     3001: "geography",  # geography
-    3999: "geometry",  # geometryhex -- what the wire returns for a geometry column
     4000: "super",  # super
     6551: "binary varying",  # varbyte
 }

--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -42,19 +42,12 @@ for package in packages:
 GET_RELATIONS_MACRO_NAME = "redshift__get_relations"
 SHOW_TABLES_FROM_SCHEMA_MACRO_NAME = "redshift__show_tables_from_schema"
 
-# Redshift type OID -> the data type name SHOW COLUMNS reports for that type.
-#
-# Used to describe temporary relations from the driver's cursor description when the
-# catalog cannot see them (see RedshiftAdapter.get_columns_in_temp_relation). Keying on the
-# OID rather than on redshift_connector's own type labels keeps this independent of driver
-# label changes, and lets the values match SHOW COLUMNS exactly -- necessary because
-# incremental schema comparison diffs columns described this way against columns of the
-# target relation, which are described by SHOW COLUMNS.
-#
-# Verified against `SHOW COLUMNS FROM TABLE` on Redshift 1.0.358853. Note in particular
-# that bpchar reports as "character" (not "character varying") and varbyte reports as
-# "binary varying" (not "varbyte"); getting either wrong produces a spurious type change
-# on every run.
+# Redshift type OID -> SQL data type name, as reported by both the legacy path's
+# information_schema.columns.data_type and SHOW COLUMNS. Used to describe temp relations
+# from the driver's cursor description (see get_columns_in_temp_relation); the names have
+# to match whichever of those two paths described the target relation, or schema comparison
+# reports a type change on every run. Verified against SHOW COLUMNS on Redshift 1.0.358853
+# -- note bpchar reports as "character", and varbyte as "binary varying".
 TYPE_OID_TO_DATA_TYPE: Dict[int, str] = {
     16: "boolean",  # bool
     20: "bigint",  # int8
@@ -239,31 +232,18 @@ class RedshiftAdapter(SQLAdapter):
 
     @available
     def get_columns_in_temp_relation(self, relation: BaseRelation) -> List[Any]:
-        """Describe a temporary relation without consulting the catalog.
+        """Describe a temporary relation from the driver instead of the catalog.
 
-        When the connection's database is a datashare consumer database
-        (``svv_redshift_databases.database_type = 'shared'``), temporary relations are
-        created and remain queryable but are invisible to ``information_schema.columns``,
-        ``pg_attribute`` and ``svv_columns`` alike -- the session's temp schema belongs to
-        the default database while catalog views resolve against the consumer database.
-        ``SHOW COLUMNS`` cannot address them either, since it requires a database and
-        schema and temporary relations carry neither.
+        Needed when the connection's database is a datashare consumer database: temp
+        relations stay queryable but are invisible to ``information_schema.columns``,
+        ``pg_attribute`` and ``svv_columns`` alike, and ``SHOW COLUMNS`` cannot address
+        them because they carry no database or schema.
 
-        Reading the driver's cursor description is the only route that does not depend on
-        database context. Type codes are mapped back to the names ``SHOW COLUMNS`` reports
-        so that columns described this way compare equal to columns of the target relation
-        in ``check_for_schema_changes``.
-
-        Size/precision/scale cannot come from ``cursor.description``: ``redshift_connector``
-        (the version dbt-redshift depends on) hardcodes those PEP 249 fields to ``None`` --
-        verified directly against its source (``Cursor._getDescription``), not merely
-        undocumented. The real values are still on the wire: the driver parses the
-        Postgres-protocol row description into ``cursor.ps["row_desc"]``, which carries
-        ``type_modifier`` (``pg_attribute.atttypmod``) per column but never surfaces it
-        through the public API. Reading it directly is the only way to get real sizes;
-        without it, every sized string/numeric column looks "changed" against the target
-        on the very next run, and Redshift's add/copy/drop/rename response to that
-        reorders the column and can silently narrow its scale.
+        Sizes come from ``cursor.ps["row_desc"]``'s ``type_modifier``, not from
+        ``cursor.description``: ``redshift_connector`` hardcodes the PEP 249
+        size/precision/scale fields to ``None`` (see its ``Cursor._getDescription``).
+        Without real sizes, every sized column looks changed against the target on the
+        next run and gets needlessly rewritten.
         """
         sql = f"select * from {self.quote(relation.identifier)} limit 0"
         _, cursor = self.connections.add_select_query(sql)
@@ -319,14 +299,25 @@ class RedshiftAdapter(SQLAdapter):
         return columns
 
     def _temp_relation_data_type(self, type_code: Any) -> str:
-        """Map a driver type code onto the data type name ``SHOW COLUMNS`` reports."""
+        """Map a driver type code onto its SQL data type name."""
         data_type = TYPE_OID_TO_DATA_TYPE.get(type_code)
         if data_type is not None:
             return data_type
 
-        # Unrecognised type code: the driver's own label is closer than nothing, but it is
-        # not guaranteed to match SHOW COLUMNS, so surface it.
-        fallback = str(self.connections.data_type_code_to_name(type_code)).lower()
+        # Unmapped OID. The driver's own label is closer than nothing, but its lookup is an
+        # IntEnum call that raises for codes it doesn't recognise either -- and a column
+        # whose type cannot be named at all is better reported than described with an
+        # invented name, which would only fail later as invalid DDL.
+        try:
+            fallback = str(self.connections.data_type_code_to_name(type_code)).lower()
+        except Exception as exc:
+            raise dbt_common.exceptions.DbtRuntimeError(
+                f"Cannot describe temporary relation column: Redshift returned type code "
+                f"{type_code}, which neither dbt-redshift nor redshift_connector "
+                f"recognises. Please report this at "
+                f"https://github.com/dbt-labs/dbt-adapters/issues"
+            ) from exc
+
         logger.debug(
             f"No known Redshift data type for type code {type_code}; "
             f"falling back to {fallback!r}. Schema comparison for this column may be "

--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -69,8 +69,18 @@ TYPE_OID_TO_DATA_TYPE: Dict[int, str] = {
     2935: "hllsketch",  # hllsketch
     3000: "geometry",  # geometry
     3001: "geography",  # geography
+    3999: "geometry",  # geometryhex -- what the wire returns for a geometry column
     4000: "super",  # super
     6551: "binary varying",  # varbyte
+}
+
+# information_schema reports its internal type name where SHOW COLUMNS reports the SQL name,
+# so a fallback column only compares equal if it follows whichever path described the target.
+# Everything else in the map above agrees across both; these are the exceptions, verified in
+# tests/functional/test_type_oid_mapping.py.
+TYPE_OID_TO_INFORMATION_SCHEMA_DATA_TYPE: Dict[int, str] = {
+    1188: "intervaly2m",  # SHOW COLUMNS: interval year to month
+    1190: "intervald2s",  # SHOW COLUMNS: interval day to second
 }
 
 REDSHIFT_SKIP_AUTOCOMMIT_TRANSACTION_STATEMENTS = BehaviorFlag(
@@ -299,7 +309,16 @@ class RedshiftAdapter(SQLAdapter):
         return columns
 
     def _temp_relation_data_type(self, type_code: Any) -> str:
-        """Map a driver type code onto its SQL data type name."""
+        """Map a driver type code onto the name the target relation's describer reports.
+
+        The target goes through SHOW COLUMNS when ``datasharing`` is on and through
+        information_schema when it is off, and the two disagree on a few type names.
+        """
+        if not self.use_show_apis():
+            data_type = TYPE_OID_TO_INFORMATION_SCHEMA_DATA_TYPE.get(type_code)
+            if data_type is not None:
+                return data_type
+
         data_type = TYPE_OID_TO_DATA_TYPE.get(type_code)
         if data_type is not None:
             return data_type

--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
@@ -130,7 +130,26 @@
   {% if redshift__use_show_apis() and relation.database and relation.schema %}
     {{ return(redshift__get_columns_in_relation_show(relation)) }}
   {% else %}
-    {{ return(redshift__get_columns_in_relation_legacy(relation)) }}
+    {%- set columns = redshift__get_columns_in_relation_legacy(relation) -%}
+
+    {#-
+      A relation with no columns means the catalog could not see it, not that it has none.
+      This happens to temporary relations when the connection's database is a datashare
+      consumer database: the relation is created and stays queryable, but it is absent from
+      information_schema.columns, pg_attribute and svv_columns, because the session's temp
+      schema belongs to the default database while those views resolve against the consumer
+      database. SHOW COLUMNS cannot address it either -- it needs a database and schema, and
+      temporary relations have neither.
+
+      Left unhandled, an empty list makes on_schema_change='sync_all_columns' treat every
+      column in the target as removed and drop it. Fall back to describing the relation
+      through the driver, which does not depend on database context.
+    -#}
+    {%- if columns | length == 0 -%}
+      {{ return(adapter.get_columns_in_temp_relation(relation)) }}
+    {%- endif -%}
+
+    {{ return(columns) }}
   {% endif %}
 {% endmacro %}
 

--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
@@ -133,19 +133,17 @@
     {%- set columns = redshift__get_columns_in_relation_legacy(relation) -%}
 
     {#-
-      A relation with no columns means the catalog could not see it, not that it has none.
-      This happens to temporary relations when the connection's database is a datashare
-      consumer database: the relation is created and stays queryable, but it is absent from
-      information_schema.columns, pg_attribute and svv_columns, because the session's temp
-      schema belongs to the default database while those views resolve against the consumer
-      database. SHOW COLUMNS cannot address it either -- it needs a database and schema, and
-      temporary relations have neither.
+      A temp relation with no columns means the catalog could not see it, not that it has
+      none: when the connection's database is a datashare consumer database, temp relations
+      stay queryable but are absent from information_schema.columns, pg_attribute and
+      svv_columns. Left unhandled, an empty list makes on_schema_change='sync_all_columns'
+      treat every column in the target as removed and drop it.
 
-      Left unhandled, an empty list makes on_schema_change='sync_all_columns' treat every
-      column in the target as removed and drop it. Fall back to describing the relation
-      through the driver, which does not depend on database context.
+      Only temp relations are affected, and only they can be described this way: the driver
+      query is unqualified, so it resolves to the right relation only when there is no
+      database or schema to qualify it with.
     -#}
-    {%- if columns | length == 0 -%}
+    {%- if columns | length == 0 and not relation.database and not relation.schema -%}
       {{ return(adapter.get_columns_in_temp_relation(relation)) }}
     {%- endif -%}
 

--- a/dbt-redshift/tests/functional/adapter/datashare_consumer/conftest.py
+++ b/dbt-redshift/tests/functional/adapter/datashare_consumer/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+from tests.functional.adapter.datashare_consumer.fixtures import (
+    REDSHIFT_TEST_DATASHARE_DBNAME,
+)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _skip_without_datashare_db():
+    """Skip every test in this directory when the env var is not set."""
+    if not REDSHIFT_TEST_DATASHARE_DBNAME:
+        pytest.skip("REDSHIFT_TEST_DATASHARE_DBNAME not set")

--- a/dbt-redshift/tests/functional/adapter/datashare_consumer/fixtures.py
+++ b/dbt-redshift/tests/functional/adapter/datashare_consumer/fixtures.py
@@ -8,6 +8,16 @@ import pytest
 #
 # Setting one up (Redshift Serverless, two namespaces):
 #
+#   for role in producer consumer; do
+#     aws redshift-serverless create-namespace --namespace-name rs-$role \
+#       --admin-username admin --admin-user-password '<password>' --db-name dev
+#     aws redshift-serverless create-workgroup --workgroup-name rs-$role-wg \
+#       --namespace-name rs-$role --base-capacity 8 --publicly-accessible
+#   done
+#
+# Both workgroups need inbound 5439 from the test runner. The namespace GUIDs below come from
+# `get-namespace --query namespace.namespaceId`. Then:
+#
 #   -- producer namespace, database `dev`
 #   create schema shared_sch;
 #   create table shared_sch.orders (id int);

--- a/dbt-redshift/tests/functional/adapter/datashare_consumer/fixtures.py
+++ b/dbt-redshift/tests/functional/adapter/datashare_consumer/fixtures.py
@@ -1,0 +1,50 @@
+import os
+
+import pytest
+
+# Name of a database created FROM A DATASHARE on the cluster under test, i.e. one that
+# svv_redshift_databases reports with database_type = 'shared'. The connection's dbname is
+# pointed directly at it, which is the configuration these tests exist to cover.
+#
+# Setting one up (Redshift Serverless, two namespaces):
+#
+#   -- producer namespace, database `dev`
+#   create schema shared_sch;
+#   create table shared_sch.orders (id int);
+#   create datashare repro_share;
+#   alter datashare repro_share add schema shared_sch;
+#   alter datashare repro_share add table shared_sch.orders;
+#   grant usage on datashare repro_share to namespace '<consumer-namespace-guid>';
+#
+#   -- consumer namespace
+#   create database ds_consumer from datashare repro_share of namespace '<producer-guid>';
+#
+# then set REDSHIFT_TEST_DATASHARE_DBNAME=ds_consumer and point the test profile's host at
+# the consumer workgroup.
+REDSHIFT_TEST_DATASHARE_DBNAME = os.getenv("REDSHIFT_TEST_DATASHARE_DBNAME", "")
+
+
+class DatashareConsumerMixin:
+    """Connect directly to a datashare consumer database, with datasharing enabled.
+
+    This is deliberately different from CrossDatabaseMixin, which leaves the connection on
+    the default database and only retargets models via `+database`. That arrangement works;
+    connecting straight at the consumer database is the one that breaks, because temporary
+    relations are then invisible to every catalog view.
+    """
+
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target, unique_schema):
+        return {
+            "test": {
+                "outputs": {
+                    "default": {
+                        **dbt_profile_target,
+                        "schema": unique_schema,
+                        "dbname": REDSHIFT_TEST_DATASHARE_DBNAME,
+                        "datasharing": True,
+                    }
+                },
+                "target": "default",
+            }
+        }

--- a/dbt-redshift/tests/functional/adapter/datashare_consumer/test_incremental_on_schema_change.py
+++ b/dbt-redshift/tests/functional/adapter/datashare_consumer/test_incremental_on_schema_change.py
@@ -1,0 +1,100 @@
+"""
+Incremental on_schema_change against a connection pointed directly at a datashare consumer
+database -- the configuration that reproduces dbt-labs/dbt-adapters#1947 and #1991.
+
+The existing coverage passes because it never exercises this arrangement:
+
+    | test                                       | connection dbname | model database        |
+    |--------------------------------------------|-------------------|-----------------------|
+    | TestIncrementalOnSchemaChangeWithDatasharing | default           | same as connection    |
+    | TestIncrementalCrossDatabase*                | default           | cross-db via +database|
+    | these tests                                  | consumer database | same as connection    |
+
+In the last row, temporary relations are created and stay queryable but are absent from
+information_schema.columns, pg_attribute and svv_columns, so column introspection returns
+nothing. Before the driver-based fallback, sync_all_columns read that as "the source has no
+columns" and dropped every column in the target.
+"""
+
+from dbt.tests.adapter.incremental.test_incremental_on_schema_change import (
+    BaseIncrementalOnSchemaChange,
+)
+from dbt.tests.util import get_connection, run_dbt
+import pytest
+
+from tests.functional.adapter.datashare_consumer.fixtures import DatashareConsumerMixin
+
+
+class TestIncrementalOnSchemaChangeDatashareConsumer(
+    DatashareConsumerMixin, BaseIncrementalOnSchemaChange
+):
+    """The full on_schema_change suite, run against a datashare consumer database."""
+
+
+_MODEL_SYNC_ALL_COLUMNS = """
+{{
+    config(
+        materialized='incremental',
+        unique_key='id',
+        on_schema_change='sync_all_columns'
+    )
+}}
+
+with source_data as (
+    select 1 as id, 'aaa' as field_1, 2.5::numeric(18,2) as field_2, 'x'::char(5) as field_3
+    union all select 2 as id, 'bbb' as field_1, 3.5::numeric(18,2) as field_2, 'y'::char(5) as field_3
+)
+
+select * from source_data
+
+{% if is_incremental() %}
+where id not in (select id from {{ this }})
+{% endif %}
+"""
+
+
+class TestIncrementalTempRelationColumnsPreserved(DatashareConsumerMixin):
+    """Targeted regression test: an incremental run must not drop the target's columns.
+
+    Also guards the type mapping: because the source relation is described from the driver
+    and the target from SHOW COLUMNS, any disagreement in reported data types shows up as a
+    perpetual schema change. Running twice and asserting a stable column set catches that --
+    char and numeric columns are included specifically because they are the ones whose
+    reported type carries a size.
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"incremental_sync_all_columns.sql": _MODEL_SYNC_ALL_COLUMNS}
+
+    def _columns(self, project):
+        relation = project.adapter.Relation.create(
+            database=project.database,
+            schema=project.test_schema,
+            identifier="incremental_sync_all_columns",
+        )
+        with get_connection(project.adapter):
+            return project.adapter.get_columns_in_relation(relation)
+
+    def test_columns_survive_incremental_run(self, project):
+        run_dbt(["run", "--select", "incremental_sync_all_columns"])
+        before = self._columns(project)
+        assert [c.name for c in before] == ["id", "field_1", "field_2", "field_3"]
+
+        run_dbt(["run", "--select", "incremental_sync_all_columns"])
+        after = self._columns(project)
+
+        assert [c.name for c in after] == ["id", "field_1", "field_2", "field_3"]
+        # Data types must be stable too, otherwise the driver-described source and the
+        # SHOW COLUMNS-described target disagree and dbt alters the column type every run.
+        assert [c.dtype for c in after] == [c.dtype for c in before]
+
+    def test_third_run_is_still_stable(self, project):
+        """A type-mapping mismatch would keep re-triggering; a third run pins that down."""
+        run_dbt(["run", "--select", "incremental_sync_all_columns"])
+        run_dbt(["run", "--select", "incremental_sync_all_columns"])
+        first = self._columns(project)
+        run_dbt(["run", "--select", "incremental_sync_all_columns"])
+        assert [(c.name, c.dtype) for c in self._columns(project)] == [
+            (c.name, c.dtype) for c in first
+        ]

--- a/dbt-redshift/tests/functional/adapter/datashare_consumer/test_snapshot.py
+++ b/dbt-redshift/tests/functional/adapter/datashare_consumer/test_snapshot.py
@@ -1,0 +1,38 @@
+"""
+Snapshots against a connection pointed directly at a datashare consumer database -- the same
+configuration that reproduces dbt-labs/dbt-adapters#1947 and #1991 for incremental models.
+
+Snapshots hit the identical root cause through a different door: `snapshot.sql` builds a
+`*__dbt_tmp` staging relation (via `make_temp_relation`, same shape as an incremental temp
+relation) and calls `adapter.get_columns_in_relation` / `adapter.get_missing_columns` on it
+directly -- there is no `on_schema_change` involved, so the guard added for incremental models
+(default__check_for_schema_changes) does not apply here and was never meant to.
+
+Snapshots also fail *louder* than incremental's silent column drop: a zero-columns read on the
+staging relation makes `source_columns` empty, which renders `snapshot_merge_sql`'s insert
+column list empty too, producing:
+
+    insert into "<target>" ()
+    select
+    from "<staging>__dbt_tmp..." as DBT_INTERNAL_SOURCE
+    where DBT_INTERNAL_SOURCE.dbt_change_type::text = 'insert'::text;
+
+...a Redshift syntax error at the empty `()`. This is not a synthetic scenario -- it is the exact
+failure a production snapshot hit against a real datashare consumer connection (see the customer
+debug log referenced in the engagement note for issue 122399). `test_new_column_captured_by_snapshot`
+and `test_inserts_are_captured_by_snapshot` below are the two cases in the shared snapshot test
+base that exercise this path (a genuine new column, and a genuine new row respectively); both
+would have hit that syntax error before the driver-based `get_columns_in_temp_relation` fallback.
+"""
+
+from dbt.tests.adapter.simple_snapshot.test_snapshot import BaseSimpleSnapshot, BaseSnapshotCheck
+
+from tests.functional.adapter.datashare_consumer.fixtures import DatashareConsumerMixin
+
+
+class TestSnapshotDatashareConsumer(DatashareConsumerMixin, BaseSimpleSnapshot):
+    """Timestamp-strategy snapshot suite, run against a datashare consumer database."""
+
+
+class TestSnapshotCheckDatashareConsumer(DatashareConsumerMixin, BaseSnapshotCheck):
+    """Check-strategy snapshot suite, run against a datashare consumer database."""

--- a/dbt-redshift/tests/functional/test_type_oid_mapping.py
+++ b/dbt-redshift/tests/functional/test_type_oid_mapping.py
@@ -1,36 +1,19 @@
 """
-Pins TYPE_OID_TO_DATA_TYPE against the catalogs that actually describe target relations.
+Pins TYPE_OID_TO_DATA_TYPE against the catalogs that describe target relations.
 
-``get_columns_in_temp_relation`` describes a temp relation from the driver's cursor
-description, mapping type OIDs through ``TYPE_OID_TO_DATA_TYPE``. Those columns are then
-diffed against the target relation, which is described by one of two *other* paths depending
-on the ``datasharing`` profile flag:
+get_columns_in_temp_relation maps type OIDs through TYPE_OID_TO_DATA_TYPE, and those columns
+are diffed against a target described by SHOW COLUMNS (when `datasharing` is on) or by
+information_schema (when it is off). The map has to agree with both, or every column of that
+type reads as changed on every run. Its values were captured from SHOW COLUMNS, so this is
+what establishes that information_schema agrees.
 
-    | datasharing | target described by                      | reports            |
-    |-------------|------------------------------------------|--------------------|
-    | true        | redshift__get_columns_in_relation_show   | SHOW COLUMNS       |
-    | false       | redshift__get_columns_in_relation_legacy | information_schema |
-
-The map has to agree with whichever one ran, or every column of that type reads as changed
-on every run. Its values were captured from SHOW COLUMNS, so this test is what establishes
-that information_schema agrees rather than assuming it does.
-
-Comparing information_schema directly is faithful to the legacy macro: for a regular table
-its ``bound_views`` CTE selects ``data_type`` from information_schema and the final select
-passes it through unchanged.
-
-Types are declared with DDL rather than built from casts so the declared type is
-unambiguous. Unit coverage for the map itself is in tests/unit/test_temp_relation_columns.py.
+Unit coverage for the map itself is in tests/unit/test_temp_relation_columns.py.
 """
 
 from dbt.adapters.redshift import RedshiftRelation
 from dbt.adapters.redshift.impl import TYPE_OID_TO_DATA_TYPE
 
-# (column name, DDL type, data type name the catalogs are expected to report, type OID)
-#
-# SQL standard types. Both catalogs report the standard name for these, and the legacy macro
-# already depends on that -- its unbound_views CTE normalizes to the literal strings
-# 'character varying' and 'numeric'.
+# (column name, DDL type, expected data type name, type OID)
 STANDARD_TYPES = [
     ("c_boolean", "boolean", "boolean", 16),
     ("c_bigint", "bigint", "bigint", 20),
@@ -48,11 +31,8 @@ STANDARD_TYPES = [
     ("c_numeric", "numeric(18,2)", "numeric", 1700),
 ]
 
-# Redshift-proprietary types. These are the entries in doubt: information_schema is inherited
-# from Postgres 8.0.2, which reports 'USER-DEFINED' for types it does not recognize, so
-# agreement with SHOW COLUMNS is exactly what needs demonstrating rather than assuming.
-# Kept in their own probe table so an unsupported type on an older cluster cannot mask a
-# divergence among the standard types above.
+# Probed in a separate table so an unsupported type on an older cluster cannot mask a
+# divergence among the standard types.
 REDSHIFT_TYPES = [
     ("c_interval_y2m", "interval year to month", "interval year to month", 1188),
     ("c_interval_d2s", "interval day to second", "interval day to second", 1190),
@@ -63,10 +43,8 @@ REDSHIFT_TYPES = [
     ("c_varbyte", "varbyte(16)", "binary varying", 6551),
 ]
 
-# OID 25 (text) is deliberately absent from both lists: Redshift treats TEXT as an alias for
-# VARCHAR(256), so no stored column ever carries that OID and there is no catalog row to
-# compare against. The driver only produces it for expression results, which is why the map's
-# entry for it is an inference rather than a capture.
+# Redshift aliases TEXT to VARCHAR(256), so no stored column carries OID 25 and there is no
+# catalog row to compare against.
 UNPROBEABLE_OIDS = {25}
 
 
@@ -75,17 +53,12 @@ def _column_ddl(types):
 
 
 def _show_columns_data_types(project, relation):
-    """data_type per column as SHOW COLUMNS reports it, keyed by column name."""
     with project.adapter.connection_named("_test"):
-        _, table = project.adapter.execute(
-            f"show columns from table {relation}",
-            fetch=True,
-        )
+        _, table = project.adapter.execute(f"show columns from table {relation}", fetch=True)
     return {row["column_name"]: row["data_type"] for row in table.rows}
 
 
 def _information_schema_data_types(project, identifier):
-    """data_type per column as information_schema reports it, keyed by column name."""
     rows = project.run_sql(
         f"""
         select column_name, data_type
@@ -99,11 +72,7 @@ def _information_schema_data_types(project, identifier):
 
 
 def _driver_data_types(project, identifier, column_ddl):
-    """dtype per column as the driver-based fallback reports it, keyed by column name.
-
-    The temp relation has to be created and described on the same connection, since temp
-    relations are session-scoped.
-    """
+    # Temp relations are session-scoped, so create and describe on the same connection.
     relation = RedshiftRelation.create(identifier=identifier).include(database=False, schema=False)
     with project.adapter.connection_named("_test"):
         project.adapter.execute(f"create temp table {identifier} ({column_ddl})")
@@ -131,8 +100,6 @@ class TestTypeOidMappingMatchesCatalogs:
         for name, ddl, expected, oid in types:
             reported = {"TYPE_OID_TO_DATA_TYPE": TYPE_OID_TO_DATA_TYPE.get(oid)}
             reported.update({source: names.get(name) for source, names in described.items()})
-            # Any disagreement matters, including all three catalogs agreeing on a name the
-            # map does not carry -- that is still a type change on every run.
             if len(set(reported.values())) > 1:
                 divergences.append((ddl, oid, expected, reported))
 
@@ -149,7 +116,6 @@ class TestTypeOidMappingMatchesCatalogs:
         self._assert_describers_agree(project, REDSHIFT_TYPES, "type_probe_redshift")
 
     def test_every_mapped_oid_is_probed(self):
-        """A new entry in the map must come with evidence, or be explicitly exempted."""
         probed = {oid for _, _, _, oid in STANDARD_TYPES + REDSHIFT_TYPES}
         unprobed = set(TYPE_OID_TO_DATA_TYPE) - probed - UNPROBEABLE_OIDS
         assert not unprobed, (

--- a/dbt-redshift/tests/functional/test_type_oid_mapping.py
+++ b/dbt-redshift/tests/functional/test_type_oid_mapping.py
@@ -1,0 +1,158 @@
+"""
+Pins TYPE_OID_TO_DATA_TYPE against the catalogs that actually describe target relations.
+
+``get_columns_in_temp_relation`` describes a temp relation from the driver's cursor
+description, mapping type OIDs through ``TYPE_OID_TO_DATA_TYPE``. Those columns are then
+diffed against the target relation, which is described by one of two *other* paths depending
+on the ``datasharing`` profile flag:
+
+    | datasharing | target described by                      | reports            |
+    |-------------|------------------------------------------|--------------------|
+    | true        | redshift__get_columns_in_relation_show   | SHOW COLUMNS       |
+    | false       | redshift__get_columns_in_relation_legacy | information_schema |
+
+The map has to agree with whichever one ran, or every column of that type reads as changed
+on every run. Its values were captured from SHOW COLUMNS, so this test is what establishes
+that information_schema agrees rather than assuming it does.
+
+Comparing information_schema directly is faithful to the legacy macro: for a regular table
+its ``bound_views`` CTE selects ``data_type`` from information_schema and the final select
+passes it through unchanged.
+
+Types are declared with DDL rather than built from casts so the declared type is
+unambiguous. Unit coverage for the map itself is in tests/unit/test_temp_relation_columns.py.
+"""
+
+from dbt.adapters.redshift import RedshiftRelation
+from dbt.adapters.redshift.impl import TYPE_OID_TO_DATA_TYPE
+
+# (column name, DDL type, data type name the catalogs are expected to report, type OID)
+#
+# SQL standard types. Both catalogs report the standard name for these, and the legacy macro
+# already depends on that -- its unbound_views CTE normalizes to the literal strings
+# 'character varying' and 'numeric'.
+STANDARD_TYPES = [
+    ("c_boolean", "boolean", "boolean", 16),
+    ("c_bigint", "bigint", "bigint", 20),
+    ("c_smallint", "smallint", "smallint", 21),
+    ("c_integer", "integer", "integer", 23),
+    ("c_real", "real", "real", 700),
+    ("c_double", "double precision", "double precision", 701),
+    ("c_char", "char(5)", "character", 1042),
+    ("c_varchar", "varchar(20)", "character varying", 1043),
+    ("c_date", "date", "date", 1082),
+    ("c_time", "time", "time without time zone", 1083),
+    ("c_timestamp", "timestamp", "timestamp without time zone", 1114),
+    ("c_timestamptz", "timestamptz", "timestamp with time zone", 1184),
+    ("c_timetz", "timetz", "time with time zone", 1266),
+    ("c_numeric", "numeric(18,2)", "numeric", 1700),
+]
+
+# Redshift-proprietary types. These are the entries in doubt: information_schema is inherited
+# from Postgres 8.0.2, which reports 'USER-DEFINED' for types it does not recognize, so
+# agreement with SHOW COLUMNS is exactly what needs demonstrating rather than assuming.
+# Kept in their own probe table so an unsupported type on an older cluster cannot mask a
+# divergence among the standard types above.
+REDSHIFT_TYPES = [
+    ("c_interval_y2m", "interval year to month", "interval year to month", 1188),
+    ("c_interval_d2s", "interval day to second", "interval day to second", 1190),
+    ("c_hllsketch", "hllsketch", "hllsketch", 2935),
+    ("c_geometry", "geometry", "geometry", 3000),
+    ("c_geography", "geography", "geography", 3001),
+    ("c_super", "super", "super", 4000),
+    ("c_varbyte", "varbyte(16)", "binary varying", 6551),
+]
+
+# OID 25 (text) is deliberately absent from both lists: Redshift treats TEXT as an alias for
+# VARCHAR(256), so no stored column ever carries that OID and there is no catalog row to
+# compare against. The driver only produces it for expression results, which is why the map's
+# entry for it is an inference rather than a capture.
+UNPROBEABLE_OIDS = {25}
+
+
+def _column_ddl(types):
+    return ", ".join(f"{name} {ddl}" for name, ddl, _, _ in types)
+
+
+def _show_columns_data_types(project, relation):
+    """data_type per column as SHOW COLUMNS reports it, keyed by column name."""
+    with project.adapter.connection_named("_test"):
+        _, table = project.adapter.execute(
+            f"show columns from table {relation}",
+            fetch=True,
+        )
+    return {row["column_name"]: row["data_type"] for row in table.rows}
+
+
+def _information_schema_data_types(project, identifier):
+    """data_type per column as information_schema reports it, keyed by column name."""
+    rows = project.run_sql(
+        f"""
+        select column_name, data_type
+        from information_schema.columns
+        where table_schema = '{project.test_schema}'
+          and table_name = '{identifier}'
+        """,
+        fetch="all",
+    )
+    return {name: data_type for name, data_type in rows}
+
+
+def _driver_data_types(project, identifier, column_ddl):
+    """dtype per column as the driver-based fallback reports it, keyed by column name.
+
+    The temp relation has to be created and described on the same connection, since temp
+    relations are session-scoped.
+    """
+    relation = RedshiftRelation.create(identifier=identifier).include(database=False, schema=False)
+    with project.adapter.connection_named("_test"):
+        project.adapter.execute(f"create temp table {identifier} ({column_ddl})")
+        columns = project.adapter.get_columns_in_temp_relation(relation)
+    return {column.column: column.dtype for column in columns}
+
+
+class TestTypeOidMappingMatchesCatalogs:
+    def _assert_describers_agree(self, project, types, identifier):
+        column_ddl = _column_ddl(types)
+        relation = RedshiftRelation.create(
+            database=project.database,
+            schema=project.test_schema,
+            identifier=identifier,
+        )
+        project.run_sql(f"create table {relation} ({column_ddl})")
+
+        described = {
+            "SHOW COLUMNS": _show_columns_data_types(project, relation),
+            "information_schema": _information_schema_data_types(project, identifier),
+            "driver": _driver_data_types(project, f"{identifier}__dbt_tmp", column_ddl),
+        }
+
+        divergences = []
+        for name, ddl, expected, oid in types:
+            reported = {"TYPE_OID_TO_DATA_TYPE": TYPE_OID_TO_DATA_TYPE.get(oid)}
+            reported.update({source: names.get(name) for source, names in described.items()})
+            # Any disagreement matters, including all three catalogs agreeing on a name the
+            # map does not carry -- that is still a type change on every run.
+            if len(set(reported.values())) > 1:
+                divergences.append((ddl, oid, expected, reported))
+
+        assert not divergences, "describers disagree:\n" + "\n".join(
+            f"  {ddl} (OID {oid}, captured as {expected!r}): "
+            + ", ".join(f"{source}={value!r}" for source, value in reported.items())
+            for ddl, oid, expected, reported in divergences
+        )
+
+    def test_standard_types_agree(self, project):
+        self._assert_describers_agree(project, STANDARD_TYPES, "type_probe_standard")
+
+    def test_redshift_types_agree(self, project):
+        self._assert_describers_agree(project, REDSHIFT_TYPES, "type_probe_redshift")
+
+    def test_every_mapped_oid_is_probed(self):
+        """A new entry in the map must come with evidence, or be explicitly exempted."""
+        probed = {oid for _, _, _, oid in STANDARD_TYPES + REDSHIFT_TYPES}
+        unprobed = set(TYPE_OID_TO_DATA_TYPE) - probed - UNPROBEABLE_OIDS
+        assert not unprobed, (
+            f"OIDs {sorted(unprobed)} are mapped but not probed against the catalogs. Add "
+            f"them to STANDARD_TYPES/REDSHIFT_TYPES, or to UNPROBEABLE_OIDS with a reason."
+        )

--- a/dbt-redshift/tests/functional/test_type_oid_mapping.py
+++ b/dbt-redshift/tests/functional/test_type_oid_mapping.py
@@ -1,124 +1,141 @@
 """
-Pins TYPE_OID_TO_DATA_TYPE against the catalogs that describe target relations.
+Requires a driver-described temp relation to match however the target relation is described.
 
 get_columns_in_temp_relation maps type OIDs through TYPE_OID_TO_DATA_TYPE, and those columns
-are diffed against a target described by SHOW COLUMNS (when `datasharing` is on) or by
-information_schema (when it is off). The map has to agree with both, or every column of that
-type reads as changed on every run. Its values were captured from SHOW COLUMNS, so this is
-what establishes that information_schema agrees.
+are diffed against a target described by SHOW COLUMNS (`datasharing` on) or information_schema
+(off). Rather than pin captured names, these tests describe the same columns both ways and
+require the reported data_type to agree -- get_columns_in_relation already dispatches on the
+flag, so each subclass below exercises the pairing that actually occurs.
+
+The two catalogs do not agree on every name (information_schema calls
+`interval year to month` `intervaly2m`), which is why the mapping is selected on the flag.
 
 Unit coverage for the map itself is in tests/unit/test_temp_relation_columns.py.
 """
 
+import pytest
+
 from dbt.adapters.redshift import RedshiftRelation
 from dbt.adapters.redshift.impl import TYPE_OID_TO_DATA_TYPE
 
-# (column name, DDL type, expected data type name, type OID)
+# (column name, DDL type, type OID the driver reports for it)
 STANDARD_TYPES = [
-    ("c_boolean", "boolean", "boolean", 16),
-    ("c_bigint", "bigint", "bigint", 20),
-    ("c_smallint", "smallint", "smallint", 21),
-    ("c_integer", "integer", "integer", 23),
-    ("c_real", "real", "real", 700),
-    ("c_double", "double precision", "double precision", 701),
-    ("c_char", "char(5)", "character", 1042),
-    ("c_varchar", "varchar(20)", "character varying", 1043),
-    ("c_date", "date", "date", 1082),
-    ("c_time", "time", "time without time zone", 1083),
-    ("c_timestamp", "timestamp", "timestamp without time zone", 1114),
-    ("c_timestamptz", "timestamptz", "timestamp with time zone", 1184),
-    ("c_timetz", "timetz", "time with time zone", 1266),
-    ("c_numeric", "numeric(18,2)", "numeric", 1700),
+    ("c_boolean", "boolean", 16),
+    ("c_bigint", "bigint", 20),
+    ("c_smallint", "smallint", 21),
+    ("c_integer", "integer", 23),
+    ("c_real", "real", 700),
+    ("c_double", "double precision", 701),
+    ("c_char", "char(5)", 1042),
+    ("c_varchar", "varchar(20)", 1043),
+    ("c_date", "date", 1082),
+    ("c_time", "time", 1083),
+    ("c_timestamp", "timestamp", 1114),
+    ("c_timestamptz", "timestamptz", 1184),
+    ("c_timetz", "timetz", 1266),
+    ("c_numeric", "numeric(18,2)", 1700),
 ]
 
 # Probed in a separate table so an unsupported type on an older cluster cannot mask a
-# divergence among the standard types.
+# divergence among the standard types. A geometry column reports OID 3999 (GEOMETRYHEX) on the
+# wire, never 3000 -- 3999 is a wire representation rather than a declarable type.
 REDSHIFT_TYPES = [
-    ("c_interval_y2m", "interval year to month", "interval year to month", 1188),
-    ("c_interval_d2s", "interval day to second", "interval day to second", 1190),
-    ("c_hllsketch", "hllsketch", "hllsketch", 2935),
-    ("c_geometry", "geometry", "geometry", 3000),
-    ("c_geography", "geography", "geography", 3001),
-    ("c_super", "super", "super", 4000),
-    ("c_varbyte", "varbyte(16)", "binary varying", 6551),
+    ("c_interval_y2m", "interval year to month", 1188),
+    ("c_interval_d2s", "interval day to second", 1190),
+    ("c_hllsketch", "hllsketch", 2935),
+    ("c_geometry", "geometry", 3999),
+    ("c_geography", "geography", 3001),
+    ("c_super", "super", 4000),
+    ("c_varbyte", "varbyte(16)", 6551),
 ]
 
-# Redshift aliases TEXT to VARCHAR(256), so no stored column carries OID 25 and there is no
-# catalog row to compare against.
-UNPROBEABLE_OIDS = {25}
+# OID 3000 is the geometry type in pg_type but never appears in a cursor description; Redshift
+# aliases TEXT to VARCHAR(256), so no stored column carries OID 25 either.
+UNPROBEABLE_OIDS = {25, 3000}
 
 
 def _column_ddl(types):
-    return ", ".join(f"{name} {ddl}" for name, ddl, _, _ in types)
+    return ", ".join(f"{name} {ddl}" for name, ddl, _ in types)
 
 
-def _show_columns_data_types(project, relation):
-    with project.adapter.connection_named("_test"):
-        _, table = project.adapter.execute(f"show columns from table {relation}", fetch=True)
-    return {row["column_name"]: row["data_type"] for row in table.rows}
+def _data_types(columns):
+    # Column.data_type, not dtype: it folds in size and precision, and is what
+    # diff_column_data_types actually compares during schema comparison.
+    return {column.column: column.data_type for column in columns}
 
 
-def _information_schema_data_types(project, identifier):
-    rows = project.run_sql(
-        f"""
-        select column_name, data_type
-        from information_schema.columns
-        where table_schema = '{project.test_schema}'
-          and table_name = '{identifier}'
-        """,
-        fetch="all",
-    )
-    return {name: data_type for name, data_type in rows}
+class DescribersAgree:
+    """Describe the same columns via the target's path and via the driver, and compare."""
 
-
-def _driver_data_types(project, identifier, column_ddl):
-    # Temp relations are session-scoped, so create and describe on the same connection.
-    relation = RedshiftRelation.create(identifier=identifier).include(database=False, schema=False)
-    with project.adapter.connection_named("_test"):
-        project.adapter.execute(f"create temp table {identifier} ({column_ddl})")
-        columns = project.adapter.get_columns_in_temp_relation(relation)
-    return {column.column: column.dtype for column in columns}
-
-
-class TestTypeOidMappingMatchesCatalogs:
-    def _assert_describers_agree(self, project, types, identifier):
+    def _assert_agree(self, project, types, identifier):
         column_ddl = _column_ddl(types)
-        relation = RedshiftRelation.create(
+        target = RedshiftRelation.create(
             database=project.database,
             schema=project.test_schema,
             identifier=identifier,
         )
-        project.run_sql(f"create table {relation} ({column_ddl})")
+        project.run_sql(f"create table {target} ({column_ddl})")
 
-        described = {
-            "SHOW COLUMNS": _show_columns_data_types(project, relation),
-            "information_schema": _information_schema_data_types(project, identifier),
-            "driver": _driver_data_types(project, f"{identifier}__dbt_tmp", column_ddl),
+        temp_identifier = f"{identifier}__dbt_tmp"
+        temp = RedshiftRelation.create(identifier=temp_identifier).include(
+            database=False, schema=False
+        )
+        with project.adapter.connection_named("_test"):
+            # get_columns_in_relation dispatches on datasharing, so this is whichever
+            # describer the incremental materialization would have used for the target.
+            from_target = _data_types(project.adapter.get_columns_in_relation(target))
+            # Temp relations are session-scoped: create and describe on the same connection.
+            project.adapter.execute(f"create temp table {temp_identifier} ({column_ddl})")
+            from_driver = _data_types(project.adapter.get_columns_in_temp_relation(temp))
+
+        divergences = {
+            name: (from_target.get(name), from_driver.get(name))
+            for name, _, _ in types
+            if from_target.get(name) != from_driver.get(name)
         }
-
-        divergences = []
-        for name, ddl, expected, oid in types:
-            reported = {"TYPE_OID_TO_DATA_TYPE": TYPE_OID_TO_DATA_TYPE.get(oid)}
-            reported.update({source: names.get(name) for source, names in described.items()})
-            if len(set(reported.values())) > 1:
-                divergences.append((ddl, oid, expected, reported))
-
-        assert not divergences, "describers disagree:\n" + "\n".join(
-            f"  {ddl} (OID {oid}, captured as {expected!r}): "
-            + ", ".join(f"{source}={value!r}" for source, value in reported.items())
-            for ddl, oid, expected, reported in divergences
+        assert not divergences, "target and driver disagree:\n" + "\n".join(
+            f"  {name}: target={target_type!r} driver={driver_type!r}"
+            for name, (target_type, driver_type) in divergences.items()
         )
 
     def test_standard_types_agree(self, project):
-        self._assert_describers_agree(project, STANDARD_TYPES, "type_probe_standard")
+        self._assert_agree(project, STANDARD_TYPES, "type_probe_standard")
 
     def test_redshift_types_agree(self, project):
-        self._assert_describers_agree(project, REDSHIFT_TYPES, "type_probe_redshift")
+        self._assert_agree(project, REDSHIFT_TYPES, "type_probe_redshift")
 
-    def test_every_mapped_oid_is_probed(self):
-        probed = {oid for _, _, _, oid in STANDARD_TYPES + REDSHIFT_TYPES}
-        unprobed = set(TYPE_OID_TO_DATA_TYPE) - probed - UNPROBEABLE_OIDS
-        assert not unprobed, (
-            f"OIDs {sorted(unprobed)} are mapped but not probed against the catalogs. Add "
-            f"them to STANDARD_TYPES/REDSHIFT_TYPES, or to UNPROBEABLE_OIDS with a reason."
-        )
+
+class TestDescribersAgreeDatasharingOff(DescribersAgree):
+    """Target described by information_schema, via the legacy path."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"name": "test_type_oid_mapping_datasharing_off"}
+
+
+class TestDescribersAgreeDatasharingOn(DescribersAgree):
+    """Target described by SHOW COLUMNS."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"name": "test_type_oid_mapping_datasharing_on"}
+
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target, unique_schema):
+        return {
+            "test": {
+                "outputs": {
+                    "default": {**dbt_profile_target, "schema": unique_schema, "datasharing": True}
+                },
+                "target": "default",
+            }
+        }
+
+
+def test_every_mapped_oid_is_probed():
+    probed = {oid for _, _, oid in STANDARD_TYPES + REDSHIFT_TYPES}
+    unprobed = set(TYPE_OID_TO_DATA_TYPE) - probed - UNPROBEABLE_OIDS
+    assert not unprobed, (
+        f"OIDs {sorted(unprobed)} are mapped but not probed against the catalogs. Add them "
+        f"to STANDARD_TYPES/REDSHIFT_TYPES, or to UNPROBEABLE_OIDS with a reason."
+    )

--- a/dbt-redshift/tests/functional/test_type_oid_mapping.py
+++ b/dbt-redshift/tests/functional/test_type_oid_mapping.py
@@ -37,21 +37,24 @@ STANDARD_TYPES = [
 ]
 
 # Probed in a separate table so an unsupported type on an older cluster cannot mask a
-# divergence among the standard types. A geometry column reports OID 3999 (GEOMETRYHEX) on the
-# wire, never 3000 -- 3999 is a wire representation rather than a declarable type.
+# divergence among the standard types.
 REDSHIFT_TYPES = [
     ("c_interval_y2m", "interval year to month", 1188),
     ("c_interval_d2s", "interval day to second", 1190),
     ("c_hllsketch", "hllsketch", 2935),
-    ("c_geometry", "geometry", 3999),
     ("c_geography", "geography", 3001),
     ("c_super", "super", 4000),
     ("c_varbyte", "varbyte(16)", 6551),
 ]
 
-# OID 3000 is the geometry type in pg_type but never appears in a cursor description; Redshift
-# aliases TEXT to VARCHAR(256), so no stored column carries OID 25 either.
-UNPROBEABLE_OIDS = {25, 3000}
+# Redshift aliases TEXT to VARCHAR(256), so no stored column carries OID 25.
+UNPROBEABLE_OIDS = {25}
+
+# Probed and known to diverge: a geometry column reports OID 3999 (GEOMETRYHEX) on the wire
+# while both catalogs report `geometry`, so the driver yields `geometryhex`. Pre-dates this
+# fallback and is out of scope here -- tracked in dbt-labs/dbt-adapters#2108. Add
+# ("c_geometry", "geometry", 3999) to REDSHIFT_TYPES to reproduce.
+KNOWN_DIVERGENT_OIDS = {3000, 3999}
 
 
 def _column_ddl(types):
@@ -134,8 +137,9 @@ class TestDescribersAgreeDatasharingOn(DescribersAgree):
 
 def test_every_mapped_oid_is_probed():
     probed = {oid for _, _, oid in STANDARD_TYPES + REDSHIFT_TYPES}
-    unprobed = set(TYPE_OID_TO_DATA_TYPE) - probed - UNPROBEABLE_OIDS
+    unprobed = set(TYPE_OID_TO_DATA_TYPE) - probed - UNPROBEABLE_OIDS - KNOWN_DIVERGENT_OIDS
     assert not unprobed, (
-        f"OIDs {sorted(unprobed)} are mapped but not probed against the catalogs. Add them "
-        f"to STANDARD_TYPES/REDSHIFT_TYPES, or to UNPROBEABLE_OIDS with a reason."
+        f"OIDs {sorted(unprobed)} are mapped but not probed against the catalogs. Add them to "
+        f"STANDARD_TYPES/REDSHIFT_TYPES, or to UNPROBEABLE_OIDS/KNOWN_DIVERGENT_OIDS with a "
+        f"reason."
     )

--- a/dbt-redshift/tests/unit/test_temp_relation_columns.py
+++ b/dbt-redshift/tests/unit/test_temp_relation_columns.py
@@ -5,15 +5,12 @@ Needed when the connection's database is a datashare consumer database, where te
 relations are invisible to information_schema.columns, pg_attribute and svv_columns
 (dbt-labs/dbt-adapters#1947, #1991).
 
-The expected data type names below are ground truth captured from `SHOW COLUMNS FROM TABLE`
-on Redshift 1.0.358853. They must match the catalog exactly: schema comparison diffs
-temp-relation columns (described here) against target-relation columns (described by the
-catalog), so any mismatch produces a spurious type change on every run.
+The expected data type names are ground truth captured from `SHOW COLUMNS FROM TABLE` on
+Redshift 1.0.358853, and must match the catalog exactly or every column of that type reads as
+changed on every run. tests/functional/test_type_oid_mapping.py checks that live.
 
-The cursor stub mirrors the real driver's split -- PEP 249 size/precision/scale fields
-hardcoded to None on `description`, real type_modifier on `ps["row_desc"]`, and a type-name
-lookup that raises rather than returning a label for an unrecognised OID -- so a regression
-in the decode logic fails here the same way it would against the real driver.
+The cursor stub mirrors the real driver: dead PEP 249 size fields on `description`, real
+type_modifier on `ps["row_desc"]`, and a type-name lookup that raises for an unknown OID.
 """
 
 from unittest import mock
@@ -92,23 +89,15 @@ class _StubConnections:
 
     @staticmethod
     def data_type_code_to_name(type_code):
-        # The real implementation is `RedshiftOID(oid).name` -- an IntEnum call, so it
-        # raises for any OID missing from the driver's own table rather than returning a
-        # label for it.
+        # The real implementation is `RedshiftOID(oid).name`, an IntEnum call, so it raises
+        # rather than returning a label for an OID the driver doesn't know.
         if type_code not in DRIVER_ONLY_TYPES:
             raise ValueError(f"{type_code} is not a valid RedshiftOID")
         return DRIVER_ONLY_TYPES[type_code]
 
 
 class _StubAdapter:
-    """Minimal stand-in exposing only what get_columns_in_temp_relation touches.
-
-    Mirrors the real ``redshift_connector`` cursor: ``description`` carries the PEP 249
-    tuple with size/precision/scale hardcoded to ``None`` (verified against the driver's
-    source -- these fields are never populated), and ``ps["row_desc"]`` carries the real
-    per-column ``type_modifier`` the driver parses off the wire but doesn't surface
-    through the public API.
-    """
+    """Minimal stand-in exposing only what get_columns_in_temp_relation touches."""
 
     Column = None  # set below to _FakeColumn
 

--- a/dbt-redshift/tests/unit/test_temp_relation_columns.py
+++ b/dbt-redshift/tests/unit/test_temp_relation_columns.py
@@ -10,6 +10,13 @@ The expected data type names below are ground truth captured from
 incremental schema comparison diffs temp-relation columns (described here) against
 target-relation columns (described by SHOW COLUMNS); any mismatch produces a spurious
 type change on every run.
+
+Size/precision/scale cannot come from cursor.description's PEP 249 fields: verified
+directly against redshift_connector's source, those are hardcoded to None -- not merely
+undocumented, dead on every version dbt-redshift depends on. The real values come from
+cursor.ps["row_desc"]'s type_modifier (pg_attribute.atttypmod), which the driver parses
+off the wire but never surfaces through the public API. The stub below mirrors that split
+so these tests fail the same way the real driver would if the decode logic regresses.
 """
 
 from unittest import mock
@@ -63,6 +70,16 @@ class TestTypeOidMapping:
         assert TYPE_OID_TO_DATA_TYPE[6551] == "binary varying"
 
 
+def _varlen_modifier(length):
+    """Postgres/Redshift wire-protocol atttypmod for a declared string length."""
+    return length + 4
+
+
+def _numeric_modifier(precision, scale):
+    """Postgres/Redshift wire-protocol atttypmod for a declared numeric(precision, scale)."""
+    return ((precision << 16) | scale) + 4
+
+
 class _StubConnections:
     def __init__(self, cursor):
         self._cursor = cursor
@@ -77,13 +94,31 @@ class _StubConnections:
 
 
 class _StubAdapter:
-    """Minimal stand-in exposing only what get_columns_in_temp_relation touches."""
+    """Minimal stand-in exposing only what get_columns_in_temp_relation touches.
+
+    Mirrors the real ``redshift_connector`` cursor: ``description`` carries the PEP 249
+    tuple with size/precision/scale hardcoded to ``None`` (verified against the driver's
+    source -- these fields are never populated), and ``ps["row_desc"]`` carries the real
+    per-column ``type_modifier`` the driver parses off the wire but doesn't surface
+    through the public API.
+    """
 
     Column = None  # set below to _FakeColumn
 
-    def __init__(self, description):
+    def __init__(self, columns):
+        # columns: list of (name, type_code, type_modifier_or_None)
         cursor = mock.Mock()
-        cursor.description = description
+        cursor.description = (
+            [(name, type_code, None, None, None, None, None) for name, type_code, _ in columns]
+            if columns is not None
+            else None
+        )
+        cursor.ps = {
+            "row_desc": [
+                {"type_modifier": modifier if modifier is not None else -1}
+                for _, _, modifier in (columns or [])
+            ]
+        }
         self.connections = _StubConnections(cursor)
 
     @staticmethod
@@ -94,28 +129,27 @@ class _StubAdapter:
 
 
 class TestGetColumnsInTempRelation:
-    def _adapter_with_description(self, description):
-        adapter = _StubAdapter(description)
+    def _adapter_with_columns(self, columns):
+        adapter = _StubAdapter(columns)
         adapter.Column = _FakeColumn
         return adapter
 
     def test_describes_columns_with_sizes_only_where_they_matter(self):
-        # (name, type_code, display_size, internal_size, precision, scale, null_ok)
-        description = [
-            ("id", 23, None, None, 10, 0, True),  # int4  -> integer
-            ("name", 1043, None, None, 256, 0, True),  # varchar -> character varying(256)
-            ("code", 1042, None, None, 10, 0, True),  # bpchar  -> character(10)
-            ("amount", 1700, None, None, 18, 4, True),  # numeric -> numeric(18,4)
-            ("ratio", 701, None, None, 17, 17, True),  # float8  -> double precision
-            ("payload", 6551, None, None, 50, 0, True),  # varbyte -> binary varying
+        columns = [
+            ("id", 23, None),  # int4  -> integer, no modifier
+            ("name", 1043, _varlen_modifier(256)),  # varchar(256) -> character varying(256)
+            ("code", 1042, _varlen_modifier(10)),  # bpchar(10)  -> character(10)
+            ("amount", 1700, _numeric_modifier(18, 4)),  # numeric(18,4)
+            ("ratio", 701, None),  # float8  -> double precision, no modifier
+            ("payload", 6551, None),  # varbyte -> binary varying, no modifier
         ]
-        adapter = self._adapter_with_description(description)
+        adapter = self._adapter_with_columns(columns)
 
-        columns = RedshiftAdapter.get_columns_in_temp_relation(
+        result = RedshiftAdapter.get_columns_in_temp_relation(
             adapter, mock.Mock(identifier="model__dbt_tmp123")
         )
 
-        assert [(c.column, c.dtype) for c in columns] == [
+        assert [(c.column, c.dtype) for c in result] == [
             ("id", "integer"),
             ("name", "character varying"),
             ("code", "character"),
@@ -124,33 +158,61 @@ class TestGetColumnsInTempRelation:
             ("payload", "binary varying"),
         ]
 
-        by_name = {c.column: c for c in columns}
-        # string types carry char_size
+        by_name = {c.column: c for c in result}
+        # string types carry char_size, decoded from type_modifier
         assert by_name["name"].char_size == 256
         assert by_name["code"].char_size == 10
-        # exact numerics carry precision and scale
+        # exact numerics carry precision and scale, decoded from type_modifier
         assert by_name["amount"].numeric_precision == 18
         assert by_name["amount"].numeric_scale == 4
-        # everything else leaves sizes unset -- the driver reports display widths for these
-        # (int4 -> 10, float8 -> 17/17) which are not the values SHOW COLUMNS reports
+        # everything else leaves sizes unset
         assert by_name["id"].numeric_precision is None
         assert by_name["ratio"].numeric_precision is None
         assert by_name["ratio"].numeric_scale is None
         assert by_name["payload"].char_size is None
 
+    def test_unconstrained_string_and_numeric_leave_size_unset(self):
+        # type_modifier == -1 means "no modifier" (unconstrained/default size).
+        columns = [("name", 1043, -1), ("amount", 1700, -1)]
+        adapter = self._adapter_with_columns(columns)
+
+        result = RedshiftAdapter.get_columns_in_temp_relation(
+            adapter, mock.Mock(identifier="model__dbt_tmp123")
+        )
+
+        by_name = {c.column: c for c in result}
+        assert by_name["name"].char_size is None
+        assert by_name["amount"].numeric_precision is None
+        assert by_name["amount"].numeric_scale is None
+
     def test_falls_back_to_driver_label_for_unknown_type_code(self):
-        adapter = self._adapter_with_description([("mystery", 999999, None, None, 0, 0, True)])
+        adapter = self._adapter_with_columns([("mystery", 999999, None)])
         columns = RedshiftAdapter.get_columns_in_temp_relation(
             adapter, mock.Mock(identifier="model__dbt_tmp123")
         )
         assert [c.dtype for c in columns] == ["unknown"]
 
     def test_empty_description_yields_no_columns(self):
-        adapter = self._adapter_with_description(None)
+        adapter = self._adapter_with_columns(None)
         columns = RedshiftAdapter.get_columns_in_temp_relation(
             adapter, mock.Mock(identifier="model__dbt_tmp123")
         )
         assert columns == []
+
+    def test_missing_row_desc_falls_back_to_no_size_info(self):
+        # cursor.ps["row_desc"] is undocumented driver internals; if a future driver
+        # version removes or restructures it, columns should still come back (without
+        # sizes) rather than raising.
+        adapter = self._adapter_with_columns([("amount", 1700, _numeric_modifier(18, 4))])
+        adapter.connections._cursor.ps = {}
+
+        columns = RedshiftAdapter.get_columns_in_temp_relation(
+            adapter, mock.Mock(identifier="model__dbt_tmp123")
+        )
+
+        assert columns[0].dtype == "numeric"
+        assert columns[0].numeric_precision is None
+        assert columns[0].numeric_scale is None
 
 
 class _FakeColumn:

--- a/dbt-redshift/tests/unit/test_temp_relation_columns.py
+++ b/dbt-redshift/tests/unit/test_temp_relation_columns.py
@@ -46,7 +46,6 @@ VERIFIED_TYPES = [
     (2935, "hllsketch", "hllsketch"),
     (3000, "geometry", "geometry"),
     (3001, "geography", "geography"),
-    (3999, "geometryhex", "geometry"),
     (4000, "super", "super"),
     (6551, "varbyte", "binary varying"),
 ]
@@ -68,11 +67,6 @@ class TestTypeOidMapping:
     def test_varbyte_is_binary_varying(self):
         # SHOW COLUMNS reports 'binary varying', not 'varbyte'.
         assert TYPE_OID_TO_DATA_TYPE[6551] == "binary varying"
-
-    def test_geometry_is_mapped_under_the_oid_the_wire_uses(self):
-        # A geometry column reports GEOMETRYHEX (3999) in the cursor description, never 3000,
-        # so mapping only 3000 sends every geometry column down the unknown-type fallback.
-        assert TYPE_OID_TO_DATA_TYPE[3999] == "geometry"
 
     def test_information_schema_overrides_only_where_the_catalogs_differ(self):
         # SHOW COLUMNS gives the SQL name, information_schema its internal one. Only the two

--- a/dbt-redshift/tests/unit/test_temp_relation_columns.py
+++ b/dbt-redshift/tests/unit/test_temp_relation_columns.py
@@ -5,27 +5,25 @@ Needed when the connection's database is a datashare consumer database, where te
 relations are invisible to information_schema.columns, pg_attribute and svv_columns
 (dbt-labs/dbt-adapters#1947, #1991).
 
-The expected data type names below are ground truth captured from
-`SHOW COLUMNS FROM TABLE` on Redshift 1.0.358853. They must match exactly, because
-incremental schema comparison diffs temp-relation columns (described here) against
-target-relation columns (described by SHOW COLUMNS); any mismatch produces a spurious
-type change on every run.
+The expected data type names below are ground truth captured from `SHOW COLUMNS FROM TABLE`
+on Redshift 1.0.358853. They must match the catalog exactly: schema comparison diffs
+temp-relation columns (described here) against target-relation columns (described by the
+catalog), so any mismatch produces a spurious type change on every run.
 
-Size/precision/scale cannot come from cursor.description's PEP 249 fields: verified
-directly against redshift_connector's source, those are hardcoded to None -- not merely
-undocumented, dead on every version dbt-redshift depends on. The real values come from
-cursor.ps["row_desc"]'s type_modifier (pg_attribute.atttypmod), which the driver parses
-off the wire but never surfaces through the public API. The stub below mirrors that split
-so these tests fail the same way the real driver would if the decode logic regresses.
+The cursor stub mirrors the real driver's split -- PEP 249 size/precision/scale fields
+hardcoded to None on `description`, real type_modifier on `ps["row_desc"]`, and a type-name
+lookup that raises rather than returning a label for an unrecognised OID -- so a regression
+in the decode logic fails here the same way it would against the real driver.
 """
 
 from unittest import mock
 
 import pytest
+from dbt_common.exceptions import DbtRuntimeError
 
 from dbt.adapters.redshift.impl import TYPE_OID_TO_DATA_TYPE, RedshiftAdapter
 
-# (oid, typname, data type name reported by SHOW COLUMNS)
+# (oid, typname, data type name reported by the catalog)
 VERIFIED_TYPES = [
     (16, "bool", "boolean"),
     (20, "int8", "bigint"),
@@ -54,10 +52,10 @@ VERIFIED_TYPES = [
 
 class TestTypeOidMapping:
     @pytest.mark.parametrize("oid,typname,expected", VERIFIED_TYPES)
-    def test_oid_maps_to_show_columns_data_type(self, oid, typname, expected):
+    def test_oid_maps_to_catalog_data_type(self, oid, typname, expected):
         assert (
             TYPE_OID_TO_DATA_TYPE[oid] == expected
-        ), f"OID {oid} ({typname}) must map to the name SHOW COLUMNS reports"
+        ), f"OID {oid} ({typname}) must map to the name the catalog reports"
 
     def test_bpchar_is_character_not_character_varying(self):
         # char(n) and varchar(n) both satisfy Column.is_string(), so confusing them yields
@@ -80,6 +78,10 @@ def _numeric_modifier(precision, scale):
     return ((precision << 16) | scale) + 4
 
 
+# OIDs redshift_connector names but this adapter does not map, and the labels it gives them.
+DRIVER_ONLY_TYPES = {1015: "VARCHAR_ARRAY", 28: "XID"}
+
+
 class _StubConnections:
     def __init__(self, cursor):
         self._cursor = cursor
@@ -90,7 +92,12 @@ class _StubConnections:
 
     @staticmethod
     def data_type_code_to_name(type_code):
-        return "UNKNOWN"
+        # The real implementation is `RedshiftOID(oid).name` -- an IntEnum call, so it
+        # raises for any OID missing from the driver's own table rather than returning a
+        # label for it.
+        if type_code not in DRIVER_ONLY_TYPES:
+            raise ValueError(f"{type_code} is not a valid RedshiftOID")
+        return DRIVER_ONLY_TYPES[type_code]
 
 
 class _StubAdapter:
@@ -185,12 +192,23 @@ class TestGetColumnsInTempRelation:
         assert by_name["amount"].numeric_precision is None
         assert by_name["amount"].numeric_scale is None
 
-    def test_falls_back_to_driver_label_for_unknown_type_code(self):
-        adapter = self._adapter_with_columns([("mystery", 999999, None)])
+    def test_falls_back_to_driver_label_for_unmapped_type_code(self):
+        # An OID this adapter doesn't map but the driver can still name.
+        adapter = self._adapter_with_columns([("tags", 1015, None)])
         columns = RedshiftAdapter.get_columns_in_temp_relation(
             adapter, mock.Mock(identifier="model__dbt_tmp123")
         )
-        assert [c.dtype for c in columns] == ["unknown"]
+        assert [c.dtype for c in columns] == ["varchar_array"]
+
+    def test_raises_for_type_code_neither_side_recognises(self):
+        # The driver's lookup raises rather than yielding a label, and a column whose type
+        # cannot be named at all would only fail later as invalid DDL -- so fail here, with
+        # the offending type code in the message.
+        adapter = self._adapter_with_columns([("mystery", 999999, None)])
+        with pytest.raises(DbtRuntimeError, match="999999"):
+            RedshiftAdapter.get_columns_in_temp_relation(
+                adapter, mock.Mock(identifier="model__dbt_tmp123")
+            )
 
     def test_empty_description_yields_no_columns(self):
         adapter = self._adapter_with_columns(None)

--- a/dbt-redshift/tests/unit/test_temp_relation_columns.py
+++ b/dbt-redshift/tests/unit/test_temp_relation_columns.py
@@ -1,0 +1,162 @@
+"""
+Unit tests for describing temporary relations from the driver's cursor description.
+
+Needed when the connection's database is a datashare consumer database, where temporary
+relations are invisible to information_schema.columns, pg_attribute and svv_columns
+(dbt-labs/dbt-adapters#1947, #1991).
+
+The expected data type names below are ground truth captured from
+`SHOW COLUMNS FROM TABLE` on Redshift 1.0.358853. They must match exactly, because
+incremental schema comparison diffs temp-relation columns (described here) against
+target-relation columns (described by SHOW COLUMNS); any mismatch produces a spurious
+type change on every run.
+"""
+
+from unittest import mock
+
+import pytest
+
+from dbt.adapters.redshift.impl import TYPE_OID_TO_DATA_TYPE, RedshiftAdapter
+
+# (oid, typname, data type name reported by SHOW COLUMNS)
+VERIFIED_TYPES = [
+    (16, "bool", "boolean"),
+    (20, "int8", "bigint"),
+    (21, "int2", "smallint"),
+    (23, "int4", "integer"),
+    (25, "text", "character varying"),
+    (700, "float4", "real"),
+    (701, "float8", "double precision"),
+    (1042, "bpchar", "character"),
+    (1043, "varchar", "character varying"),
+    (1082, "date", "date"),
+    (1083, "time", "time without time zone"),
+    (1114, "timestamp", "timestamp without time zone"),
+    (1184, "timestamptz", "timestamp with time zone"),
+    (1188, "intervaly2m", "interval year to month"),
+    (1190, "intervald2s", "interval day to second"),
+    (1266, "timetz", "time with time zone"),
+    (1700, "numeric", "numeric"),
+    (2935, "hllsketch", "hllsketch"),
+    (3000, "geometry", "geometry"),
+    (3001, "geography", "geography"),
+    (4000, "super", "super"),
+    (6551, "varbyte", "binary varying"),
+]
+
+
+class TestTypeOidMapping:
+    @pytest.mark.parametrize("oid,typname,expected", VERIFIED_TYPES)
+    def test_oid_maps_to_show_columns_data_type(self, oid, typname, expected):
+        assert (
+            TYPE_OID_TO_DATA_TYPE[oid] == expected
+        ), f"OID {oid} ({typname}) must map to the name SHOW COLUMNS reports"
+
+    def test_bpchar_is_character_not_character_varying(self):
+        # char(n) and varchar(n) both satisfy Column.is_string(), so confusing them yields
+        # 'character varying(n)' vs 'character(n)' and a type change that never converges.
+        assert TYPE_OID_TO_DATA_TYPE[1042] == "character"
+        assert TYPE_OID_TO_DATA_TYPE[1043] == "character varying"
+
+    def test_varbyte_is_binary_varying(self):
+        # SHOW COLUMNS reports 'binary varying', not 'varbyte'.
+        assert TYPE_OID_TO_DATA_TYPE[6551] == "binary varying"
+
+
+class _StubConnections:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def add_select_query(self, sql):
+        self.last_sql = sql
+        return None, self._cursor
+
+    @staticmethod
+    def data_type_code_to_name(type_code):
+        return "UNKNOWN"
+
+
+class _StubAdapter:
+    """Minimal stand-in exposing only what get_columns_in_temp_relation touches."""
+
+    Column = None  # set below to _FakeColumn
+
+    def __init__(self, description):
+        cursor = mock.Mock()
+        cursor.description = description
+        self.connections = _StubConnections(cursor)
+
+    @staticmethod
+    def quote(identifier):
+        return f'"{identifier}"'
+
+    _temp_relation_data_type = RedshiftAdapter._temp_relation_data_type
+
+
+class TestGetColumnsInTempRelation:
+    def _adapter_with_description(self, description):
+        adapter = _StubAdapter(description)
+        adapter.Column = _FakeColumn
+        return adapter
+
+    def test_describes_columns_with_sizes_only_where_they_matter(self):
+        # (name, type_code, display_size, internal_size, precision, scale, null_ok)
+        description = [
+            ("id", 23, None, None, 10, 0, True),  # int4  -> integer
+            ("name", 1043, None, None, 256, 0, True),  # varchar -> character varying(256)
+            ("code", 1042, None, None, 10, 0, True),  # bpchar  -> character(10)
+            ("amount", 1700, None, None, 18, 4, True),  # numeric -> numeric(18,4)
+            ("ratio", 701, None, None, 17, 17, True),  # float8  -> double precision
+            ("payload", 6551, None, None, 50, 0, True),  # varbyte -> binary varying
+        ]
+        adapter = self._adapter_with_description(description)
+
+        columns = RedshiftAdapter.get_columns_in_temp_relation(
+            adapter, mock.Mock(identifier="model__dbt_tmp123")
+        )
+
+        assert [(c.column, c.dtype) for c in columns] == [
+            ("id", "integer"),
+            ("name", "character varying"),
+            ("code", "character"),
+            ("amount", "numeric"),
+            ("ratio", "double precision"),
+            ("payload", "binary varying"),
+        ]
+
+        by_name = {c.column: c for c in columns}
+        # string types carry char_size
+        assert by_name["name"].char_size == 256
+        assert by_name["code"].char_size == 10
+        # exact numerics carry precision and scale
+        assert by_name["amount"].numeric_precision == 18
+        assert by_name["amount"].numeric_scale == 4
+        # everything else leaves sizes unset -- the driver reports display widths for these
+        # (int4 -> 10, float8 -> 17/17) which are not the values SHOW COLUMNS reports
+        assert by_name["id"].numeric_precision is None
+        assert by_name["ratio"].numeric_precision is None
+        assert by_name["ratio"].numeric_scale is None
+        assert by_name["payload"].char_size is None
+
+    def test_falls_back_to_driver_label_for_unknown_type_code(self):
+        adapter = self._adapter_with_description([("mystery", 999999, None, None, 0, 0, True)])
+        columns = RedshiftAdapter.get_columns_in_temp_relation(
+            adapter, mock.Mock(identifier="model__dbt_tmp123")
+        )
+        assert [c.dtype for c in columns] == ["unknown"]
+
+    def test_empty_description_yields_no_columns(self):
+        adapter = self._adapter_with_description(None)
+        columns = RedshiftAdapter.get_columns_in_temp_relation(
+            adapter, mock.Mock(identifier="model__dbt_tmp123")
+        )
+        assert columns == []
+
+
+class _FakeColumn:
+    def __init__(self, column, dtype, char_size=None, numeric_precision=None, numeric_scale=None):
+        self.column = column
+        self.dtype = dtype
+        self.char_size = char_size
+        self.numeric_precision = numeric_precision
+        self.numeric_scale = numeric_scale

--- a/dbt-redshift/tests/unit/test_temp_relation_columns.py
+++ b/dbt-redshift/tests/unit/test_temp_relation_columns.py
@@ -18,7 +18,11 @@ from unittest import mock
 import pytest
 from dbt_common.exceptions import DbtRuntimeError
 
-from dbt.adapters.redshift.impl import TYPE_OID_TO_DATA_TYPE, RedshiftAdapter
+from dbt.adapters.redshift.impl import (
+    TYPE_OID_TO_DATA_TYPE,
+    TYPE_OID_TO_INFORMATION_SCHEMA_DATA_TYPE,
+    RedshiftAdapter,
+)
 
 # (oid, typname, data type name reported by the catalog)
 VERIFIED_TYPES = [
@@ -42,6 +46,7 @@ VERIFIED_TYPES = [
     (2935, "hllsketch", "hllsketch"),
     (3000, "geometry", "geometry"),
     (3001, "geography", "geography"),
+    (3999, "geometryhex", "geometry"),
     (4000, "super", "super"),
     (6551, "varbyte", "binary varying"),
 ]
@@ -63,6 +68,19 @@ class TestTypeOidMapping:
     def test_varbyte_is_binary_varying(self):
         # SHOW COLUMNS reports 'binary varying', not 'varbyte'.
         assert TYPE_OID_TO_DATA_TYPE[6551] == "binary varying"
+
+    def test_geometry_is_mapped_under_the_oid_the_wire_uses(self):
+        # A geometry column reports GEOMETRYHEX (3999) in the cursor description, never 3000,
+        # so mapping only 3000 sends every geometry column down the unknown-type fallback.
+        assert TYPE_OID_TO_DATA_TYPE[3999] == "geometry"
+
+    def test_information_schema_overrides_only_where_the_catalogs_differ(self):
+        # SHOW COLUMNS gives the SQL name, information_schema its internal one. Only the two
+        # interval types diverge; anything else here would be a silent behaviour change.
+        assert TYPE_OID_TO_INFORMATION_SCHEMA_DATA_TYPE == {
+            1188: "intervaly2m",
+            1190: "intervald2s",
+        }
 
 
 def _varlen_modifier(length):
@@ -100,6 +118,10 @@ class _StubAdapter:
     """Minimal stand-in exposing only what get_columns_in_temp_relation touches."""
 
     Column = None  # set below to _FakeColumn
+    datasharing = True  # SHOW COLUMNS names; flip to get information_schema names
+
+    def use_show_apis(self):
+        return self.datasharing
 
     def __init__(self, columns):
         # columns: list of (name, type_code, type_modifier_or_None)
@@ -180,6 +202,24 @@ class TestGetColumnsInTempRelation:
         assert by_name["name"].char_size is None
         assert by_name["amount"].numeric_precision is None
         assert by_name["amount"].numeric_scale is None
+
+    def test_interval_follows_the_describer_the_target_used(self):
+        # datasharing off means the target was described by information_schema, which names the
+        # interval types differently -- following SHOW COLUMNS there is a type change per run.
+        columns = [("span", 1188, -1)]
+
+        adapter = self._adapter_with_columns(columns)
+        relation = mock.Mock(identifier="model__dbt_tmp123")
+        assert RedshiftAdapter.get_columns_in_temp_relation(adapter, relation)[0].dtype == (
+            "interval year to month"
+        )
+
+        adapter = self._adapter_with_columns(columns)
+        adapter.datasharing = False
+        assert (
+            RedshiftAdapter.get_columns_in_temp_relation(adapter, relation)[0].dtype
+            == "intervaly2m"
+        )
 
     def test_falls_back_to_driver_label_for_unmapped_type_code(self):
         # An OID this adapter doesn't map but the driver can still name.


### PR DESCRIPTION
Fixes #1947, #1991.

## Root cause

When the connection's database is a **datashare consumer database**
(`svv_redshift_databases.database_type = 'shared'`), temporary relations are created and remain
fully queryable, but they are absent from **every** catalog view. Verified on a purpose-built
producer/consumer datashare (Redshift 1.0.358853), one session each, identical statements:

| Catalog queried | control `dev` (local) | `ds_consumer` (datashare) |
|---|---|---|
| `information_schema.columns` | 3 columns | **0 rows** |
| `pg_attribute` via `pg_class` | 3 columns | **0 rows** |
| `svv_columns` | 3 columns | **0 rows** |
| `select count(*)` from the relation | 1 row | **1 row** |

The session's temp schema belongs to the *default* database, while catalog views resolve against
the consumer database. `SHOW COLUMNS` can't address the relation either — it requires a database
and schema, and temp relations are built with `relation.include(database=False, schema=False)`.

So `redshift__get_columns_in_relation_legacy` returned zero rows **with statement status
`FINISHED`** — a silent empty result. `on_schema_change='sync_all_columns'` read that as "the
source has no columns" and issued `ALTER TABLE … DROP COLUMN` for every column in the target. The
incremental `DELETE` then failed on the now-missing unique key, which is the error users report.

**There is no alternative catalog to switch to.** I checked all of these from a consumer-db session:

| Attempt | Result |
|---|---|
| `pg_namespace` temp schemas | 0 rows (despite `search_path` = `{pg_temp_4,…}`) |
| `SHOW COLUMNS` w/ default db + temp schema | 0 rows |
| `SHOW COLUMNS` w/ consumer db + `public` | 0 rows |
| `dev.information_schema.columns` (3-part) | `ERROR: Only user perm tables supported in producer views` |
| `dev.pg_catalog.pg_attribute` (3-part) | `ERROR: Schema pg_catalog does not exist in the database` |

Reading the driver's cursor description is the only route that doesn't depend on database context.
Full write-up: https://github.com/dbt-labs/dbt-adapters/issues/1947#issuecomment-5108260475

## Fix

`RedshiftAdapter.get_columns_in_temp_relation()` runs `select * from <identifier> limit 0` and builds
columns from `cursor.description`.

Two deliberate design choices:

**1. Fallback only, never a replacement.** The macro keeps using the legacy catalog query and only
falls back when it returns *zero* columns, **and only for a relation with no database or schema**
— i.e. a temp relation. The same `else` branch is taken for fully qualified relations whenever
`datasharing` is off, and the driver query is unqualified, so without that gate a qualified relation
that legitimately returns zero rows would be described from whatever `search_path` resolves the bare
identifier to. Setups that work today are bit-for-bit unaffected; the driver path engages exactly
where the catalog has already failed.

**2. Map by type OID, and follow whichever catalog described the target.** Schema comparison diffs
these columns against the target relation, so the reported data type has to match *exactly* or
`diff_column_data_types` reports a change on every run and `ALTER COLUMN TYPE` churns forever.
`TYPE_OID_TO_DATA_TYPE` is keyed on OID (stable) rather than `redshift_connector`'s labels. Two
values are easy to get wrong:

| OID | pg type | catalog reports | naive guess |
|---|---|---|---|
| 1042 | `bpchar` | **`character`** | `character varying` ✗ |
| 6551 | `varbyte` | **`binary varying`** | `varbyte` ✗ |

`bpchar` mistaken for `character varying` yields `character varying(n)` vs `character(n)`; `varbyte`
mistaken for `varbyte` mismatches outright. Either produces a type change that never converges.

**Which catalog describes the target depends on `datasharing`**: `SHOW COLUMNS` when it is on,
`information_schema` when it is off — and it defaults to `False`, with nothing forcing it on when
`dbname` points at a consumer database. Those two do not agree everywhere. `information_schema`
reports `intervaly2m`/`intervald2s` where `SHOW COLUMNS` reports `interval year to month`/`interval
day to second`, so one static map cannot satisfy both.
`TYPE_OID_TO_INFORMATION_SCHEMA_DATA_TYPE` carries exactly those two, selected on `use_show_apis()`;
a unit test pins its contents so it cannot widen silently. Every other mapped type agrees across both
catalogs — established by the probe below rather than assumed.

Size fields are only populated where they actually affect `Column.data_type` — `char_size` for
string types, precision/scale for `numeric`/`decimal`. `is_numeric()` covers only `numeric`/`decimal`,
so for ints and floats the size fields are left unset regardless of source.

**3. Size comes from `type_modifier`, not `cursor.description`.** An earlier version of this fix read
`precision`/`internal_size` off the PEP 249 `description` tuple. Verified directly against the
installed `redshift_connector` source (`Cursor._getDescription`): those fields are hardcoded to `None`
on every version dbt-redshift depends on — not merely undocumented, dead code. Caught this by running
the new gated suite live: a `numeric(18,2)` column got silently altered to `numeric(18,0)` and moved
to the end of the table on the very next run, because an unset precision/scale rendered as Redshift's
bare-numeric default, which didn't match the target's declared `numeric(18,2)` and triggered exactly
the "type change that never converges" failure this fix exists to prevent.

The real value is still on the wire, just not exposed through the public API: the driver parses
`cursor.ps["row_desc"]`'s `type_modifier` (`pg_attribute.atttypmod`) per column but never surfaces it.
Reading it directly and decoding with the standard Postgres convention (`length = type_modifier - 4`
for strings; `precision, scale = (m - 4) >> 16, (m - 4) & 0xFFFF` for numeric) is the only way to get
real sizes. `cursor.ps` is undocumented driver internals, not a stable public API — there's no
supported alternative, and a future driver version could restructure it. `get_columns_in_temp_relation`
falls back to no size info rather than raising if it does.

An OID the map doesn't cover falls back to the driver's own label with a debug log. If
`redshift_connector` cannot name it either — its lookup is `RedshiftOID(oid).name`, an `IntEnum` call
that raises — then the column cannot be described at all, so it raises with the offending type code
rather than inventing a name that only resurfaces later as invalid DDL.

## Snapshots are also affected, not just incremental models

The zero-columns condition isn't specific to `on_schema_change='sync_all_columns'`. Snapshots hit
the same root cause through a different door: `snapshot.sql` builds a `__dbt_tmp` staging relation
and calls `adapter.get_columns_in_relation`/`get_missing_columns` on it directly — there's no
`on_schema_change` involved, so #2096's guard doesn't apply to this path and isn't meant to.

A zero-columns read on the staging relation empties `snapshot_merge_sql`'s insert column list,
producing:

```sql
insert into <target> ()
select
from <staging>__dbt_tmp... as DBT_INTERNAL_SOURCE
where DBT_INTERNAL_SOURCE.dbt_change_type::text = 'insert'::text;
```

— a Redshift syntax error at the empty `()`, rather than incremental's silent column drop. Louder
failure, same root cause. This is not a synthetic scenario: it's the shape of a real production
snapshot job failing against a datashare consumer connection.

This fix covers snapshots too without any snapshot-specific change, since it's implemented at the
`redshift__get_columns_in_relation` macro level — every caller benefits, not just the incremental
materialization. Added `TestSnapshotDatashareConsumer`/`TestSnapshotCheckDatashareConsumer` to the
gated suite below to actually exercise that rather than rely on the trace.

## Tests

**Unit** (`tests/unit/test_temp_relation_columns.py`, 32 tests, all passing) — pins all OID
mappings against the values captured from `SHOW COLUMNS`, with explicit regression tests for the
`bpchar` and `varbyte` cases, plus column-construction tests covering which size fields get
populated, unknown type codes, an empty description, and a missing/malformed `cursor.ps` (the
stub mirrors the real driver's split: dead size fields on `description`, real `type_modifier` on
`ps["row_desc"]`, so a regression here fails the same way the real driver would).

**Functional — describer agreement** (`tests/functional/test_type_oid_mapping.py`, 5 tests) — builds
a table with one column per mapped type and requires `SHOW COLUMNS`, `information_schema` and the
driver to report the same `Column.data_type`, once with `datasharing` on and once off. It needs no
datashare, so unlike the gated suite below it runs in ordinary integration CI. A third test fails if
an OID is added to the map without either a probe or an explicit exemption, so the agreement claim
can't rot.

**Functional — datashare consumer** (`tests/functional/adapter/datashare_consumer/`) — a gated suite for the topology
that currently has **no coverage at all**:

| test | connection `dbname` | model database | covered before |
|---|---|---|---|
| `TestIncrementalOnSchemaChangeWithDatasharing` | default | same | yes |
| `TestIncrementalCrossDatabase*` | default | cross-db via `+database` | yes |
| **`datashare_consumer/`** | **consumer database** | same | **no** |

`CrossDatabaseMixin` keeps the connection on the default database and only retargets models via
`+database` — which is the documented *workaround*. That's why this shipped with green CI. The new
`DatashareConsumerMixin` points `dbname` straight at the consumer database. Gated behind
`REDSHIFT_TEST_DATASHARE_DBNAME` (skips when unset), following the existing `cross_database/` pattern;
`fixtures.py` documents the full producer/consumer setup SQL.

Beyond asserting columns survive, `test_incremental_on_schema_change.py` runs the model three times
and asserts the column set *and* dtypes are stable, which is what would catch a type-mapping
regression. `test_snapshot.py` adds `TestSnapshotDatashareConsumer` (timestamp strategy) and
`TestSnapshotCheckDatashareConsumer` (check strategy), reusing dbt's existing `BaseSimpleSnapshot`/
`BaseSnapshotCheck` suites — 12 tests total in the directory now.

## Verified live against a real datashare cluster

Stood up a fresh producer/consumer pair (Redshift Serverless, `1.0.384821`) with a write-enabled
datashare (`GRANT CREATE, USAGE ON SCHEMA ... TO DATASHARE`) and ran the full gated suite over the
real Python driver (`redshift_connector==2.1.16`), not just the Data API used to trace the original
root cause. Result: **12/12 pass**, including `TestIncrementalTempRelationColumnsPreserved`'s 3-run
stability check and both snapshot strategies. Confirmed via `SHOW COLUMNS` that a `numeric(18,2)` and
a `character(5)` column keep their exact declared type, size, and ordinal position across three runs.

This live run is what caught the `cursor.description` issue described above — the fix in this PR
reflects that finding, not the version that was originally run. One unrelated flake surfaced and was
run down separately: `test_deletes_are_captured_by_snapshot` hit an internal Redshift engine assertion
(`federation_api.cpp:1341`, `CanLinkStorageOid`) — but only on a schema that had gone through
`DROP SCHEMA CASCADE` + recreate churn from my own repeated test iterations. The identical test passes
cleanly on a genuinely untouched schema, and this is a storage-bookkeeping quirk of the write-datashare
feature itself under drop/recreate churn, not something a real environment's stable schemas would hit.

A second live run, against a plain Serverless workgroup with no datashare, exercised the
describer-agreement probe: **5/5 pass** in both `datasharing` modes. That run is what surfaced the
interval divergence described above, and the geometry finding now split out to #2108. CI's
`integration-tests-redshift` job is green on the head commit, so the probe has since run in CI too.

One caveat remains: `cursor.ps["row_desc"]` is undocumented driver internals, so if a future
`redshift_connector` release restructures it, size extraction silently degrades to "unset" rather than
erroring (by design — see `get_columns_in_temp_relation`'s try/except). Worth a periodic sanity check
against new driver releases; not blocking.

## Related

#2096 adds an adapter-agnostic guard so an empty source column list raises instead of dropping
columns. That's the backstop; this is the actual repair. They're independent and complementary — with
both, a warehouse that hides temp relations gets fixed here, and any *other* adapter hitting the same
class of metadata failure fails loudly instead of silently.

#2108 records a pre-existing bug this PR deliberately does **not** fix. A `geometry` column reports
OID 3999 (`GEOMETRYHEX`) on the wire while both catalogs report `geometry`, so any driver-derived type
name disagrees with the target. It breaks `sync_all_columns` on `main` independently of this fallback
and needs its own coverage, so it is recorded in the probe's `KNOWN_DIVERGENT_OIDS` with a one-line
reproduction instead of being fixed here.


