### PR TITLE
feat(snowflake): omit base_location for Snowflake-managed storage Iceberg tables

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Features-20260730-123746.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260730-123746.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Omit base_location from Iceberg DDL when no external_volume is configured (Snowflake-managed storage)
+time: 2026-07-30T12:37:46.043851+05:30
+custom:
+    Author: aahelguha
+    Issue: "2100"

--- a/dbt-snowflake/.changes/unreleased/Features-20260730-123746.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260730-123746.yaml
@@ -2,5 +2,5 @@ kind: Features
 body: Omit base_location from Iceberg DDL when no external_volume is configured (Snowflake-managed storage)
 time: 2026-07-30T12:37:46.043851+05:30
 custom:
-    Author: aahelguha
+    Author: aahel
     Issue: "2100"

--- a/dbt-snowflake/.changes/unreleased/Features-20260730-123746.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260730-123746.yaml
@@ -3,4 +3,4 @@ body: Omit base_location from Iceberg DDL when no external_volume is configured 
 time: 2026-07-30T12:37:46.043851+05:30
 custom:
     Author: aahel
-    Issue: "2100"
+    Issue: "1911"

--- a/dbt-snowflake/.changes/unreleased/Features-20260730-123746.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260730-123746.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Emit `external_volume = 'SNOWFLAKE_MANAGED'` and suppress `base_location` when no external_volume is configured or external_volume is set to SNOWFLAKE_MANAGED, enabling Snowflake Horizon managed storage Iceberg tables to work out of the box
+body: Add `snowflake_managed_iceberg_default` behavior flag. When enabled, Iceberg tables without an explicit `external_volume` emit `external_volume = 'SNOWFLAKE_MANAGED'` and suppress `base_location`, enabling Snowflake Horizon managed storage out of the box. Setting `external_volume = 'SNOWFLAKE_MANAGED'` explicitly in model config always suppresses `base_location` regardless of the flag.
 time: 2026-07-30T12:37:46.043851+05:30
 custom:
     Author: aahel

--- a/dbt-snowflake/.changes/unreleased/Features-20260730-123746.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260730-123746.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Omit base_location from Iceberg DDL when no external_volume is configured (Snowflake-managed storage)
+body: Emit `external_volume = 'SNOWFLAKE_MANAGED'` and suppress `base_location` when no external_volume is configured or external_volume is set to SNOWFLAKE_MANAGED, enabling Snowflake Horizon managed storage Iceberg tables to work out of the box
 time: 2026-07-30T12:37:46.043851+05:30
 custom:
     Author: aahel

--- a/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
@@ -118,9 +118,9 @@ class BuiltInCatalogIntegration(CatalogIntegration):
         iceberg_version = parse_model.iceberg_version(model) or self.iceberg_version
 
         ev = parse_model.external_volume(model) or self.external_volume
-        # Normalize: absent or SNOWFLAKE_MANAGED → always emit SNOWFLAKE_MANAGED, never base_location
+        # Suppress base_location when no external_volume is configured or when
+        # SNOWFLAKE_MANAGED is set — both indicate Snowflake-managed storage.
         if not ev or ev.upper() == "SNOWFLAKE_MANAGED":
-            ev = "SNOWFLAKE_MANAGED"
             base_loc = None
         else:
             base_loc = parse_model.base_location(model)

--- a/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
@@ -59,6 +59,8 @@ class BuiltInCatalogIntegration(CatalogIntegration):
     storage_serialization_policy = None
     change_tracking = None
     iceberg_version: Optional[int] = None
+    # Set by SnowflakeAdapter.build_catalog_relation from the behavior flag.
+    use_snowflake_managed_storage_default: bool = True
 
     def __init__(self, config: CatalogIntegrationConfig) -> None:
         # we overwrite this because the base provides too much config
@@ -118,11 +120,15 @@ class BuiltInCatalogIntegration(CatalogIntegration):
         iceberg_version = parse_model.iceberg_version(model) or self.iceberg_version
 
         ev = parse_model.external_volume(model) or self.external_volume
-        # Snowflake managed storage rejects base_location; emit SNOWFLAKE_MANAGED explicitly.
-        if not ev or ev.upper() == "SNOWFLAKE_MANAGED":
+        if ev and ev.upper() == "SNOWFLAKE_MANAGED":
+            # Explicit SNOWFLAKE_MANAGED: always suppress base_location.
+            base_loc = None
+        elif not ev and self.use_snowflake_managed_storage_default:
+            # No external_volume configured + behavior flag ON: default to managed storage.
             ev = "SNOWFLAKE_MANAGED"
             base_loc = None
         else:
+            # Real external_volume, or no ev with flag OFF (Snowflake resolves schema/account default).
             base_loc = parse_model.base_location(model)
 
         return BuiltInCatalogRelation(

--- a/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
@@ -117,9 +117,17 @@ class BuiltInCatalogIntegration(CatalogIntegration):
 
         iceberg_version = parse_model.iceberg_version(model) or self.iceberg_version
 
+        ev = parse_model.external_volume(model) or self.external_volume
+        # Normalize: absent or SNOWFLAKE_MANAGED → always emit SNOWFLAKE_MANAGED, never base_location
+        if not ev or ev.upper() == "SNOWFLAKE_MANAGED":
+            ev = "SNOWFLAKE_MANAGED"
+            base_loc = None
+        else:
+            base_loc = parse_model.base_location(model)
+
         return BuiltInCatalogRelation(
-            base_location=parse_model.base_location(model),
-            external_volume=parse_model.external_volume(model) or self.external_volume,
+            base_location=base_loc,
+            external_volume=ev,
             cluster_by=parse_model.cluster_by(model),
             partition_by=parse_model.partition_by(model),
             automatic_clustering=parse_model.automatic_clustering(model),

--- a/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/catalogs/_built_in.py
@@ -118,9 +118,9 @@ class BuiltInCatalogIntegration(CatalogIntegration):
         iceberg_version = parse_model.iceberg_version(model) or self.iceberg_version
 
         ev = parse_model.external_volume(model) or self.external_volume
-        # Suppress base_location when no external_volume is configured or when
-        # SNOWFLAKE_MANAGED is set — both indicate Snowflake-managed storage.
+        # Snowflake managed storage rejects base_location; emit SNOWFLAKE_MANAGED explicitly.
         if not ev or ev.upper() == "SNOWFLAKE_MANAGED":
+            ev = "SNOWFLAKE_MANAGED"
             base_loc = None
         else:
             base_loc = parse_model.base_location(model)

--- a/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
@@ -72,6 +72,17 @@ SNOWFLAKE_DEFAULT_TRANSIENT_DYNAMIC_TABLES = BehaviorFlag(
     ),
 )
 
+SNOWFLAKE_MANAGED_ICEBERG_DEFAULT = BehaviorFlag(
+    name="snowflake_managed_iceberg_default",
+    default=False,
+    description=(
+        "When enabled, Iceberg tables without an explicit external_volume emit "
+        "external_volume = 'SNOWFLAKE_MANAGED' and suppress base_location, enabling "
+        "Snowflake Horizon managed storage out of the box. When disabled (default), no "
+        "external_volume clause is emitted and Snowflake resolves the schema or account default."
+    ),
+)
+
 # Guard against older dbt-adapters that don't have Capability.CatalogsV2 yet.
 # Remove once dbt-adapters lower bound is bumped to the version that adds it.
 _CATALOGS_V2_CAPABILITY = getattr(Capability, "CatalogsV2", None)  # type: ignore[attr-defined]
@@ -157,7 +168,7 @@ class SnowflakeAdapter(SQLAdapter):
 
     @property
     def _behavior_flags(self) -> list[BehaviorFlag]:
-        return [SNOWFLAKE_DEFAULT_TRANSIENT_DYNAMIC_TABLES]
+        return [SNOWFLAKE_DEFAULT_TRANSIENT_DYNAMIC_TABLES, SNOWFLAKE_MANAGED_ICEBERG_DEFAULT]
 
     def __init__(self, config, mp_context) -> None:
         super().__init__(config, mp_context)
@@ -645,6 +656,10 @@ CALL {proc_name}();
         """
         if catalog := parse_model.catalog_name(model):
             catalog_integration = self.get_catalog_integration(catalog)
+            if isinstance(catalog_integration, BuiltInCatalogIntegration):
+                catalog_integration.use_snowflake_managed_storage_default = (
+                    self.behavior.snowflake_managed_iceberg_default.no_warn
+                )
             return catalog_integration.build_relation(model)
         return None
 

--- a/dbt-snowflake/src/dbt/adapters/snowflake/parse_model.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/parse_model.py
@@ -35,9 +35,11 @@ def base_location(model: RelationConfig) -> Optional[str]:
     if not model.config:
         return None
 
+    # Suppress base_location when SNOWFLAKE_MANAGED is explicitly set in model config.
+    # The "no external_volume" case is handled upstream in _built_in.py where the
+    # fully-resolved external_volume (including catalog integration defaults) is known.
     ev = model.config.get("external_volume")
-    # Snowflake-managed storage does not accept base_location
-    if not ev or ev.upper() == "SNOWFLAKE_MANAGED":
+    if ev and ev.upper() == "SNOWFLAKE_MANAGED":
         return None
 
     prefix = (

--- a/dbt-snowflake/src/dbt/adapters/snowflake/parse_model.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/parse_model.py
@@ -35,8 +35,9 @@ def base_location(model: RelationConfig) -> Optional[str]:
     if not model.config:
         return None
 
-    # Snowflake-managed storage (no external_volume) does not accept base_location
-    if not model.config.get("external_volume"):
+    ev = model.config.get("external_volume")
+    # Snowflake-managed storage does not accept base_location
+    if not ev or ev.upper() == "SNOWFLAKE_MANAGED":
         return None
 
     prefix = (

--- a/dbt-snowflake/src/dbt/adapters/snowflake/parse_model.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/parse_model.py
@@ -35,6 +35,10 @@ def base_location(model: RelationConfig) -> Optional[str]:
     if not model.config:
         return None
 
+    # Snowflake-managed storage (no external_volume) does not accept base_location
+    if not model.config.get("external_volume"):
+        return None
+
     prefix = (
         model.config.get("base_location_root") or "_dbt"
     )  # use "_dbt" even when users pass in None

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create.sql
@@ -87,7 +87,7 @@
         {{ optional('initialization_warehouse', dynamic_table.snowflake_initialization_warehouse) }}
         {{ optional('external_volume', catalog_relation.external_volume, "'") }}
         catalog = 'SNOWFLAKE'  -- required, and always SNOWFLAKE for built-in Iceberg tables
-        base_location = '{{ catalog_relation.base_location }}'
+        {{ optional('base_location', catalog_relation.base_location, "'") }}
         {{ optional('iceberg_version', catalog_relation.iceberg_version) }}
         {{ optional('refresh_mode', dynamic_table.refresh_mode) }}
         {{ optional('initialize', dynamic_table.initialize) }}

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/table/create.sql
@@ -198,7 +198,7 @@ create or replace iceberg table {{ relation }}
     {% if partition_by_string -%} partition by ({{ partition_by_string }}) {%- endif %}
     {{ optional('external_volume', catalog_relation.external_volume, "'") }}
     catalog = 'SNOWFLAKE'  -- required, and always SNOWFLAKE for built-in Iceberg tables
-    base_location = '{{ catalog_relation.base_location }}'
+    {{ optional('base_location', catalog_relation.base_location, "'") }}
     {{ optional('iceberg_version', catalog_relation.iceberg_version) }}
     {{ optional('storage_serialization_policy', catalog_relation.storage_serialization_policy, "'")}}
     {{ optional('max_data_extension_time_in_days', catalog_relation.max_data_extension_time_in_days)}}

--- a/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
@@ -11,6 +11,11 @@ def get_cleaned_model_ddl_from_file(file_name: str) -> str:
         return re.sub(r"\s+", " ", ddl_file.read())
 
 
+def get_cleaned_compiled_ddl_from_file(file_name: str) -> str:
+    with open(f"target/compiled/test/models/{file_name}", "r") as ddl_file:
+        return re.sub(r"\s+", " ", ddl_file.read())
+
+
 MODEL__BASIC_ICEBERG_TABLE = """
                             {{ config(materialized='table', catalog_name='basic_iceberg_catalog') }}
                             select 1 as id
@@ -69,6 +74,8 @@ class TestSnowflakeBuiltInCatalogIntegration(BaseCatalogIntegrationValidation):
         assert "max_data_extension_time_in_days = 60" in iceberg_sql
         assert "change_tracking = TRUE" in iceberg_sql
         assert "data_retention_time_in_days = 0" in iceberg_sql
+        # external_volume present → base_location must be emitted
+        assert "base_location" in iceberg_sql
         iceberg_table_with_configs_sql = get_cleaned_model_ddl_from_file(
             "iceberg_table_with_configs.sql"
         )
@@ -77,3 +84,56 @@ class TestSnowflakeBuiltInCatalogIntegration(BaseCatalogIntegrationValidation):
         # change_tracking=false is ignored for Iceberg (Snowflake forbids turning it off)
         assert "change_tracking" not in iceberg_table_with_configs_sql
         assert "data_retention_time_in_days = 1" in iceberg_table_with_configs_sql
+
+
+MODEL__MANAGED_STORAGE_ICEBERG_TABLE = """
+    {{ config(materialized='table', table_format='iceberg') }}
+    select 1 as id
+    """
+
+SEED = """
+id,value
+1,100
+2,200
+""".strip()
+
+MODEL__MANAGED_STORAGE_DYNAMIC_ICEBERG_TABLE = """
+    {{ config(
+        materialized='dynamic_table',
+        snowflake_warehouse='DBT_TESTING',
+        target_lag='2 minutes',
+        table_format='iceberg',
+    ) }}
+    select * from {{ ref('seed') }}
+    """
+
+
+class TestSnowflakeManagedStorageIcebergDDL:
+    """
+    Verifies that base_location is omitted when no external_volume is configured
+    (Snowflake-managed storage / Horizon). A successful run proves the DDL was
+    accepted by Snowflake — it rejects base_location for managed storage.
+    """
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"seed.csv": SEED}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "managed_iceberg.sql": MODEL__MANAGED_STORAGE_ICEBERG_TABLE,
+            "managed_dynamic_iceberg.sql": MODEL__MANAGED_STORAGE_DYNAMIC_ICEBERG_TABLE,
+        }
+
+    def test_managed_storage_omits_base_location(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+
+        table_sql = get_cleaned_model_ddl_from_file("managed_iceberg.sql")
+        assert "base_location" not in table_sql
+        assert "catalog = 'SNOWFLAKE'" in table_sql
+
+        dynamic_sql = get_cleaned_model_ddl_from_file("managed_dynamic_iceberg.sql")
+        assert "base_location" not in dynamic_sql
+        assert "catalog = 'SNOWFLAKE'" in dynamic_sql

--- a/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
@@ -133,7 +133,9 @@ class TestSnowflakeManagedStorageIcebergDDL:
         table_sql = get_cleaned_model_ddl_from_file("managed_iceberg.sql")
         assert "base_location" not in table_sql
         assert "catalog = 'SNOWFLAKE'" in table_sql
+        assert "external_volume = 'SNOWFLAKE_MANAGED'" in table_sql
 
         dynamic_sql = get_cleaned_model_ddl_from_file("managed_dynamic_iceberg.sql")
         assert "base_location" not in dynamic_sql
         assert "catalog = 'SNOWFLAKE'" in dynamic_sql
+        assert "external_volume = 'SNOWFLAKE_MANAGED'" in dynamic_sql

--- a/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
@@ -133,9 +133,7 @@ class TestSnowflakeManagedStorageIcebergDDL:
         table_sql = get_cleaned_model_ddl_from_file("managed_iceberg.sql")
         assert "base_location" not in table_sql
         assert "catalog = 'SNOWFLAKE'" in table_sql
-        assert "external_volume = 'SNOWFLAKE_MANAGED'" in table_sql
 
         dynamic_sql = get_cleaned_model_ddl_from_file("managed_dynamic_iceberg.sql")
         assert "base_location" not in dynamic_sql
         assert "catalog = 'SNOWFLAKE'" in dynamic_sql
-        assert "external_volume = 'SNOWFLAKE_MANAGED'" in dynamic_sql

--- a/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_integrations/test_catalog_integrations.py
@@ -116,6 +116,10 @@ class TestSnowflakeManagedStorageIcebergDDL:
     """
 
     @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"snowflake_managed_iceberg_default": True}}
+
+    @pytest.fixture(scope="class")
     def seeds(self):
         return {"seed.csv": SEED}
 

--- a/dbt-snowflake/tests/unit/test_catalog_relation_built_in.py
+++ b/dbt-snowflake/tests/unit/test_catalog_relation_built_in.py
@@ -168,3 +168,55 @@ def test_iceberg_version_model_overrides_catalog():
     model.config.update({"iceberg_version": 3})
     relation = integration.build_relation(model)
     assert relation.iceberg_version == 3
+
+
+# --- managed storage default behavior flag ---
+
+
+def _make_no_ev_model():
+    """Model with table_format=iceberg but no external_volume in config or catalog."""
+    return SimpleNamespace(
+        database="my_database",
+        schema="my_schema",
+        identifier="my_table",
+        config={"table_format": "iceberg"},
+    )
+
+
+def _make_no_ev_integration():
+    catalog_config = SimpleNamespace(
+        name="SNOWFLAKE",
+        catalog_type="BUILT_IN",
+        external_volume=None,
+        file_format=None,
+        adapter_properties=None,
+    )
+    return BuiltInCatalogIntegration(catalog_config)
+
+
+def test_managed_storage_default_on_emits_snowflake_managed():
+    integration = _make_no_ev_integration()
+    integration.use_snowflake_managed_storage_default = True
+    relation = integration.build_relation(_make_no_ev_model())
+    assert relation.external_volume == "SNOWFLAKE_MANAGED"
+    assert relation.base_location is None
+
+
+def test_managed_storage_default_off_omits_external_volume():
+    integration = _make_no_ev_integration()
+    integration.use_snowflake_managed_storage_default = False
+    relation = integration.build_relation(_make_no_ev_model())
+    assert relation.external_volume is None
+    assert relation.base_location is not None  # generated from schema/identifier
+
+
+def test_explicit_snowflake_managed_in_model_config_always_suppresses_base_location():
+    """Explicit SNOWFLAKE_MANAGED in model config suppresses base_location regardless of the flag."""
+    integration = _make_no_ev_integration()
+    model = _make_no_ev_model()
+    model.config = {"table_format": "iceberg", "external_volume": "SNOWFLAKE_MANAGED"}
+    for flag in (True, False):
+        integration.use_snowflake_managed_storage_default = flag
+        relation = integration.build_relation(model)
+        assert relation.external_volume == "SNOWFLAKE_MANAGED"
+        assert relation.base_location is None

--- a/dbt-snowflake/tests/unit/test_parse_model.py
+++ b/dbt-snowflake/tests/unit/test_parse_model.py
@@ -28,6 +28,9 @@ def make_model(config: Dict[str, Optional[str]]) -> RelationConfig:
         # No external_volume → Snowflake-managed storage → base_location suppressed
         ({"fake_attr": "fake_value"}, None),
         ({"base_location_root": None, "base_location_subpath": None}, None),
+        # SNOWFLAKE_MANAGED (case-insensitive) → managed storage → base_location suppressed
+        ({"external_volume": "SNOWFLAKE_MANAGED"}, None),
+        ({"external_volume": "snowflake_managed"}, None),
         # external_volume present → user-defined storage → base_location generated
         (
             {

--- a/dbt-snowflake/tests/unit/test_parse_model.py
+++ b/dbt-snowflake/tests/unit/test_parse_model.py
@@ -25,24 +25,32 @@ def make_model(config: Dict[str, Optional[str]]) -> RelationConfig:
 @pytest.mark.parametrize(
     "config,expected",
     [
+        # No external_volume → Snowflake-managed storage → base_location suppressed
+        ({"fake_attr": "fake_value"}, None),
+        ({"base_location_root": None, "base_location_subpath": None}, None),
+        # external_volume present → user-defined storage → base_location generated
         (
-            {"fake_attr": "fake_value"},  # we check if not model.config
+            {
+                "external_volume": "s3_vol",
+                "base_location_root": None,
+                "base_location_subpath": None,
+            },
             "_dbt/fake_schema/fake_table",
         ),
         (
-            {"base_location_root": None, "base_location_subpath": None},
-            "_dbt/fake_schema/fake_table",
-        ),
-        (
-            {"base_location_root": "root_path", "base_location_subpath": "subpath"},
+            {
+                "external_volume": "s3_vol",
+                "base_location_root": "root_path",
+                "base_location_subpath": "subpath",
+            },
             "root_path/fake_schema/fake_table/subpath",
         ),
         (
-            {"base_location_subpath": "subpath"},
+            {"external_volume": "s3_vol", "base_location_subpath": "subpath"},
             "_dbt/fake_schema/fake_table/subpath",
         ),
         (
-            {"base_location_root": "root_path"},
+            {"external_volume": "s3_vol", "base_location_root": "root_path"},
             "root_path/fake_schema/fake_table",
         ),
     ],

--- a/dbt-snowflake/tests/unit/test_parse_model.py
+++ b/dbt-snowflake/tests/unit/test_parse_model.py
@@ -25,10 +25,14 @@ def make_model(config: Dict[str, Optional[str]]) -> RelationConfig:
 @pytest.mark.parametrize(
     "config,expected",
     [
-        # No external_volume → Snowflake-managed storage → base_location suppressed
-        ({"fake_attr": "fake_value"}, None),
-        ({"base_location_root": None, "base_location_subpath": None}, None),
-        # SNOWFLAKE_MANAGED (case-insensitive) → managed storage → base_location suppressed
+        # No external_volume in model config → path generated; _built_in.py decides
+        # whether to use it based on the fully-resolved external_volume
+        ({"fake_attr": "fake_value"}, "_dbt/fake_schema/fake_table"),
+        (
+            {"base_location_root": None, "base_location_subpath": None},
+            "_dbt/fake_schema/fake_table",
+        ),
+        # SNOWFLAKE_MANAGED explicitly in model config → suppressed here
         ({"external_volume": "SNOWFLAKE_MANAGED"}, None),
         ({"external_volume": "snowflake_managed"}, None),
         # external_volume present → user-defined storage → base_location generated


### PR DESCRIPTION
resolves dbt-labs/dbt-adapters#1911
related dbt-labs/dbt-core#15659
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#N/A

### Problem

Snowflake-managed storage Iceberg tables (Snowflake Horizon) reject `BASE_LOCATION` in DDL with:

```
SQL Compilation Error: BASE_LOCATION property is not supported for Iceberg tables using Snowflake Managed Storage.
```

This affected users whether they used the simple legacy path or configured `external_volume: SNOWFLAKE_MANAGED` in `catalogs.yml`. The simplest Iceberg config — `{{ config(materialized='table', table_format='iceberg') }}` — failed on Horizon accounts.

### Solution

Adds a `snowflake_managed_iceberg_default` behavior flag (default `false`). When enabled:
- Iceberg tables without an explicit `external_volume` emit `external_volume = 'SNOWFLAKE_MANAGED'` in DDL and suppress `base_location`
- Setting `external_volume = 'SNOWFLAKE_MANAGED'` explicitly in model config always suppresses `base_location` regardless of the flag

When `external_volume` is a real user-defined volume (S3, Azure, GCS), behavior is unchanged — `external_volume` and `base_location` are emitted as before.

**Opting in** (`dbt_project.yml`):
```yaml
flags:
  snowflake_managed_iceberg_default: true
```

The flag defaults to `false` to protect users who rely on a schema or account-level default external volume.

### Changes

- **`_built_in.py` `build_relation()`** — three-way branch on `external_volume`: explicit `SNOWFLAKE_MANAGED` (always suppress `base_location`), no ev + flag ON (default to `SNOWFLAKE_MANAGED`), real ev or flag OFF (generate `base_location`)
- **`impl.py` `build_catalog_relation()`** — injects `use_snowflake_managed_storage_default` from the behavior flag onto the `BuiltInCatalogIntegration` before calling `build_relation`
- **`parse_model.base_location()`** — returns `None` when `external_volume` is explicitly set to `SNOWFLAKE_MANAGED` in model config

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX