### PR TITLE
Fix dbt-spark snapshots with list unique keys

### DIFF
--- a/dbt-spark/.changes/unreleased/Fixes-20260731-144331.yaml
+++ b/dbt-spark/.changes/unreleased/Fixes-20260731-144331.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Prevent snapshot helper columns from being persisted for list-valued unique keys
+time: 2026-07-31T14:43:31.078436+02:00
+custom:
+    Author: giacus
+    Issue: "2101"

--- a/dbt-spark/src/dbt/include/spark/macros/materializations/snapshot.sql
+++ b/dbt-spark/src/dbt/include/spark/macros/materializations/snapshot.sql
@@ -150,20 +150,22 @@
       {% do adapter.expand_target_column_types(from_relation=staging_table,
                                                to_relation=target_relation) %}
 
+      {% set remove_columns = ['dbt_change_type', 'DBT_CHANGE_TYPE', 'dbt_unique_key', 'DBT_UNIQUE_KEY'] %}
+      {% if unique_key | is_list %}
+          {% for key in strategy.unique_key %}
+              {{ remove_columns.append('dbt_unique_key_' + loop.index|string) }}
+              {{ remove_columns.append('DBT_UNIQUE_KEY_' + loop.index|string) }}
+          {% endfor %}
+      {% endif %}
+
       {% set missing_columns = adapter.get_missing_columns(staging_table, target_relation)
-                                   | rejectattr('name', 'equalto', 'dbt_change_type')
-                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')
-                                   | rejectattr('name', 'equalto', 'dbt_unique_key')
-                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')
+                                   | rejectattr('name', 'in', remove_columns)
                                    | list %}
 
       {% do create_columns(target_relation, missing_columns) %}
 
       {% set source_columns = adapter.get_columns_in_relation(staging_table)
-                                   | rejectattr('name', 'equalto', 'dbt_change_type')
-                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')
-                                   | rejectattr('name', 'equalto', 'dbt_unique_key')
-                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')
+                                   | rejectattr('name', 'in', remove_columns)
                                    | list %}
 
       {% set quoted_source_columns = [] %}

--- a/dbt-spark/tests/functional/adapter/simple_snapshot/test_various_configs.py
+++ b/dbt-spark/tests/functional/adapter/simple_snapshot/test_various_configs.py
@@ -1,0 +1,52 @@
+import pytest
+
+from dbt.tests.adapter.simple_snapshot.fixtures import (
+    create_multi_key_seed_sql,
+    create_multi_key_snapshot_expected_sql,
+    invalidate_multi_key_sql,
+    model_seed_sql,
+    populate_multi_key_snapshot_expected_sql,
+    ref_snapshot_sql,
+    seed_multi_key_insert_sql,
+    snapshots_multi_key_yml,
+    update_multi_key_sql,
+)
+from dbt.tests.util import check_relations_equal, run_dbt
+
+
+def spark_sql(sql):
+    return sql.replace("TEXT", "STRING").replace("text", "string")
+
+
+@pytest.mark.skip_profile("apache_spark", "spark_session")
+class TestSparkSnapshotMultiUniqueKey:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "seed.sql": model_seed_sql,
+            "ref_snapshot.sql": ref_snapshot_sql,
+            "snapshots.yml": snapshots_multi_key_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"snapshots": {"+file_format": "delta"}}
+
+    def test_multi_column_unique_key(self, project):
+        project.run_sql(spark_sql(create_multi_key_seed_sql))
+        project.run_sql(spark_sql(create_multi_key_snapshot_expected_sql))
+        project.run_sql(seed_multi_key_insert_sql)
+        project.run_sql(spark_sql(populate_multi_key_snapshot_expected_sql))
+
+        results = run_dbt(["snapshot"])
+        assert len(results) == 1
+
+        for statement in spark_sql(invalidate_multi_key_sql).split(";"):
+            if statement.strip():
+                project.run_sql(statement)
+        project.run_sql(spark_sql(update_multi_key_sql))
+
+        results = run_dbt(["snapshot"])
+        assert len(results) == 1
+
+        check_relations_equal(project.adapter, ["snapshot_actual", "snapshot_expected"])

--- a/dbt-spark/tests/functional/adapter/test_simple_snapshot.py
+++ b/dbt-spark/tests/functional/adapter/test_simple_snapshot.py
@@ -14,12 +14,12 @@ from dbt.tests.adapter.simple_snapshot.fixtures import (
 from dbt.tests.util import check_relations_equal, run_dbt
 
 
-def spark_sql(sql):
+def spark_sql(sql: str) -> str:
     return sql.replace("TEXT", "STRING").replace("text", "string")
 
 
 @pytest.mark.skip_profile("apache_spark", "spark_session")
-class TestSparkSnapshotMultiUniqueKey:
+class TestSnapshotMultiUniqueKeySpark:
     @pytest.fixture(scope="class")
     def models(self):
         return {
@@ -49,4 +49,8 @@ class TestSparkSnapshotMultiUniqueKey:
         results = run_dbt(["snapshot"])
         assert len(results) == 1
 
-        check_relations_equal(project.adapter, ["snapshot_actual", "snapshot_expected"])
+        check_relations_equal(
+            project.adapter,
+            ["snapshot_actual", "snapshot_expected"],
+            compare_snapshot_cols=True,
+        )


### PR DESCRIPTION
resolves #2101
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

### Problem

The dbt-spark snapshot materialization filters the scalar `dbt_unique_key` staging helper, but not the numbered `dbt_unique_key_N` helpers generated for a list-valued `unique_key`. This affects lists of any length, including a one-item list such as `[id]`.

On the first run, the snapshot target is created normally. On the next run, the numbered helper in the staging relation is treated as a missing/source column and leaks into the target operation. On a later run, the persisted helper and the newly generated helper can collide, producing an ambiguous-column or invalid compiled merge failure.

The reported production case used the `check` strategy, an explicit source projection, a one-item list key, and three consecutive snapshot runs. The underlying helper-column path is strategy-independent, so the repository's existing timestamp snapshot scenario with a composite list exercises the same defect without introducing domain-specific fixtures. Because dbt-spark overrides the global snapshot materialization, dbt-core's existing fix does not reach it automatically.

This is separate from Delta's `MULTIPLE_SOURCE_ROW_MATCHING_TARGET_ROW_IN_MERGE` error, which is not addressed by this PR.

### Related reports and prior art

- [dbt-labs/dbt-spark#157](https://github.com/dbt-labs/dbt-spark/issues/157) documented the same three-run helper leak in dbt-spark's older scalar-key merge implementation. It was closed by the stale bot without a linked fix. This PR addresses the present, distinct numbered-helper path for list keys.
- [#940](https://github.com/dbt-labs/dbt-adapters/issues/940) and [#1703](https://github.com/dbt-labs/dbt-adapters/issues/1703) describe the same numbered-helper failure class in dbt-athena; they need a separate adapter-specific change.
- [databricks/dbt-databricks#901](https://github.com/databricks/dbt-databricks/issues/901) reported the equivalent dbt-databricks regression, fixed by [databricks/dbt-databricks#904](https://github.com/databricks/dbt-databricks/pull/904).

### Solution

Build the same helper-column exclusion list used by dbt-core and filter `dbt_unique_key_1...N` from both schema evolution (`missing_columns`) and merge source columns (`source_columns`). The implementation intentionally mirrors the global materialization and dbt-databricks behavior.

Enable the existing shared multi-key snapshot scenario for dbt-spark in `dbt-spark/tests/functional/adapter/test_simple_snapshot.py`. The test reuses the shared seed, snapshot configuration, expected relation, mutations, and comparison utility from `dbt-tests-adapter`, applying only the minimal Spark SQL type and statement adaptations.

The comparison opts into snapshot columns because the shared equality helper normally ignores `dbt_*` columns. This makes the existing scenario detect any leaked `dbt_unique_key_N` helpers while also verifying the expected snapshot history.

The test uses Delta on the four CI profiles that support it and is skipped on `apache_spark` and `spark_session`, consistent with existing dbt-spark Delta snapshot coverage.

### Validation

- `hatch run unit-tests` — 68 passed
- `hatch run code-quality` — passed (YAML, whitespace, case conflicts, adapter/core boundary check, Black, Flake8, MyPy)
- focused functional test collection — 1 test collected
- `CHANGIE_CORE_TEAM=dbt-bot changie batch patch --dry-run` — passed

The Delta functional test was not executed locally because this machine does not have the Docker/Dagger runtime or Databricks test credentials. The repository CI matrix is configured to execute it once a maintainer approves CI for the public fork.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code against a live Spark/Databricks development target and it appears to resolve the stated issue
- [x] This PR includes tests
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
