### PR TITLE
optimisation(redshift): skip late-binding view lookup for temp tables

### DIFF
--- a/dbt-redshift/.changes/unreleased/Under the Hood-20260803-120000.yaml
+++ b/dbt-redshift/.changes/unreleased/Under the Hood-20260803-120000.yaml
@@ -1,0 +1,8 @@
+kind: Under the Hood
+body: Skip the late-binding view and external table lookups when reading columns for
+    temporary tables, which can never be views, falling back to the full lookup if
+    nothing matches
+time: 2026-08-03T12:00:00.000000-03:00
+custom:
+    Author: tauhidanjum
+    Issue: "2096"

--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
@@ -127,11 +127,40 @@
   {# relation from temp tables does not have a database or schema. #}
   {# use legacy pattern until SHOW COLUMNS supports temp tables #}
 
-  {% if redshift__use_show_apis() and relation.database and relation.schema %}
+  {% if not relation.database and not relation.schema %}
+    {{ return(redshift__get_columns_in_relation_unqualified(relation)) }}
+  {% elif redshift__use_show_apis() %}
     {{ return(redshift__get_columns_in_relation_show(relation)) }}
   {% else %}
     {{ return(redshift__get_columns_in_relation_legacy(relation)) }}
   {% endif %}
+{% endmacro %}
+
+
+{% macro redshift__get_columns_in_relation_unqualified(relation) -%}
+  {# An unqualified relation is a temp table, which can never be a late-binding or #}
+  {# external view, so skip pg_get_late_binding_view_cols() -- it expands every #}
+  {# late-binding view in the session and dominates the legacy query's runtime. #}
+  {# Fall back to the legacy query if nothing matches, for any other caller. #}
+  {% call statement('get_columns_in_relation', fetch_result=True) %}
+      select
+        column_name,
+        data_type,
+        character_maximum_length,
+        numeric_precision,
+        numeric_scale
+
+      from information_schema."columns"
+      where table_name = '{{ relation.identifier }}'
+      order by ordinal_position
+  {% endcall %}
+  {% set table = load_result('get_columns_in_relation').table %}
+  {% set columns = sql_convert_columns_in_relation(table) %}
+
+  {% if columns %}
+    {{ return(columns) }}
+  {% endif %}
+  {{ return(redshift__get_columns_in_relation_legacy(relation)) }}
 {% endmacro %}
 
 

--- a/dbt-redshift/tests/unit/test_get_columns_in_relation_macro.py
+++ b/dbt-redshift/tests/unit/test_get_columns_in_relation_macro.py
@@ -1,0 +1,114 @@
+from types import SimpleNamespace
+
+import jinja2
+import pytest
+
+A_COLUMN = SimpleNamespace(name="my_col")
+
+
+class MacroReturn(Exception):
+    """Mirrors dbt's `return()`, which unwinds the macro rather than emitting a value."""
+
+    def __init__(self, value):
+        self.value = value
+
+
+def _load_macros(use_show_apis, captured_sql, columns_per_call=None):
+    """Render adapters.sql with `statement` stubbed out so we can inspect the emitted SQL.
+
+    `columns_per_call` is the list of column-lists that successive
+    sql_convert_columns_in_relation() calls return, letting a test simulate the
+    unqualified lookup finding nothing.
+    """
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader("src/dbt/include/redshift/macros"),
+        extensions=["jinja2.ext.do"],
+    )
+    template = env.get_template("adapters.sql")
+
+    def fake_statement(name, caller=None, **kwargs):
+        """Stands in for the `statement` call block: records the SQL in its body."""
+        captured_sql.append(caller())
+        return ""
+
+    remaining = list(columns_per_call if columns_per_call is not None else [[A_COLUMN]])
+
+    def fake_convert(table):
+        return remaining.pop(0) if remaining else []
+
+    def fake_return(value):
+        raise MacroReturn(value)
+
+    return template.make_module(
+        {
+            "statement": fake_statement,
+            "load_result": lambda name: SimpleNamespace(table=[]),
+            "sql_convert_columns_in_relation": fake_convert,
+            "redshift__use_show_apis": lambda: use_show_apis,
+            "adapter": SimpleNamespace(quote=lambda value: f'"{value}"'),
+            "return": fake_return,
+        }
+    )
+
+
+def _get_columns(macros, relation):
+    try:
+        macros.redshift__get_columns_in_relation(relation)
+    except MacroReturn as macro_return:
+        return macro_return.value
+    raise AssertionError("macro did not return")
+
+
+def _relation(database, schema, identifier="my_model__dbt_tmp"):
+    return SimpleNamespace(database=database, schema=schema, identifier=identifier)
+
+
+@pytest.mark.parametrize("use_show_apis", [True, False])
+def test_temp_relation_skips_late_binding_view_lookup(use_show_apis):
+    """Temp relations carry no database/schema and are never views, in either datasharing mode."""
+    captured_sql = []
+    macros = _load_macros(use_show_apis, captured_sql)
+
+    columns = _get_columns(macros, _relation(database=None, schema=None))
+
+    assert len(captured_sql) == 1
+    sql = captured_sql[0]
+    assert "pg_get_late_binding_view_cols" not in sql
+    assert "svv_external_columns" not in sql
+    assert "SHOW COLUMNS" not in sql
+    assert 'from information_schema."columns"' in sql
+    assert "where table_name = 'my_model__dbt_tmp'" in sql
+    assert columns == [A_COLUMN]
+
+
+def test_unqualified_relation_falls_back_to_legacy_when_nothing_matches():
+    """Any non-temp caller that passes an unqualified relation keeps the old behavior."""
+    captured_sql = []
+    macros = _load_macros(False, captured_sql, columns_per_call=[[], [A_COLUMN]])
+
+    columns = _get_columns(macros, _relation(database=None, schema=None, identifier="some_lbv"))
+
+    assert len(captured_sql) == 2
+    assert "pg_get_late_binding_view_cols" not in captured_sql[0]
+    assert "pg_get_late_binding_view_cols" in captured_sql[1]
+    assert columns == [A_COLUMN]
+
+
+def test_regular_relation_uses_show_columns_when_datasharing_on():
+    captured_sql = []
+    macros = _load_macros(True, captured_sql)
+
+    _get_columns(macros, _relation(database="db", schema="my_schema"))
+
+    assert len(captured_sql) == 1
+    assert "SHOW COLUMNS FROM TABLE" in captured_sql[0]
+
+
+def test_regular_relation_uses_legacy_query_when_datasharing_off():
+    captured_sql = []
+    macros = _load_macros(False, captured_sql)
+
+    _get_columns(macros, _relation(database="db", schema="my_schema"))
+
+    assert len(captured_sql) == 1
+    assert "pg_get_late_binding_view_cols" in captured_sql[0]


### PR DESCRIPTION
`get_columns_in_relation` falls through to the legacy union query for temp relations, which carry no database or schema. Two of that query's three branches cannot match a temp table, and one of them calls `pg_get_late_binding_view_cols()` — a leader-node function that expands every late-binding view visible to the session. It dominates the query's runtime and fails outright when any of those views references a dropped object. This runs on every column lookup against the temp table during an incremental build.

Unqualified relations now use the bound-table lookup alone, falling back to the full legacy query when nothing matches so any other caller keeps its previous behavior.

Unit tests cover both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)