### PR TITLE
Compare BigQuery clustering fields case-insensitively in is_replaceab…

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fixes-20260807-000000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20260807-000000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Compare clustering fields case-insensitively in `is_replaceable` so a `cluster_by`
+    config that differs only by letter case no longer forces an unnecessary drop and
+    recreate of the table
+time: 2026-08-07T00:00:00.000000+00:00
+custom:
+    Author: ddamart
+    Issue: "2111"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
@@ -724,12 +724,15 @@ class BigQueryAdapter(BaseAdapter):
         """
         Check if the actual and configured clustering columns for a table
         are a match. BigQuery tables can be replaced if clustering columns
-        match exactly.
+        match exactly. Names are compared case-insensitively because BigQuery
+        column identifiers are not case-sensitive.
         """
         if isinstance(conf_cluster, str):
             conf_cluster = [conf_cluster]
 
-        return table.clustering_fields == conf_cluster
+        return [c.lower() for c in (table.clustering_fields or [])] == [
+            c.lower() for c in (conf_cluster or [])
+        ]
 
     @available.parse(lambda *a, **k: True)
     @record_function(

--- a/dbt-bigquery/tests/unit/test_bigquery_adapter.py
+++ b/dbt-bigquery/tests/unit/test_bigquery_adapter.py
@@ -1304,3 +1304,24 @@ class TestPartitionConfigRenderWrappedInt64Range:
         """int64 without range config should return the raw field name."""
         config = PartitionConfig(field="id", data_type="int64")
         assert config.render_wrapped() == "id"
+
+
+class TestClustersMatch:
+    @pytest.mark.parametrize(
+        "table_fields,conf_cluster,expected",
+        [
+            # case-only difference must still match (BigQuery identifiers are case-insensitive)
+            (["A"], ["a"], True),
+            (["a", "b"], ["a", "b"], True),
+            (["a"], "a", True),  # str config is wrapped into a list
+            (["a"], ["b"], False),
+            (["a", "b"], ["b", "a"], False),  # clustering order is significant
+            (None, None, True),
+            ([], None, True),
+            (None, ["a"], False),
+        ],
+    )
+    def test_clusters_match(self, table_fields, conf_cluster, expected):
+        table = MagicMock()
+        table.clustering_fields = table_fields
+        assert BigQueryAdapter._clusters_match(table, conf_cluster) is expected


### PR DESCRIPTION
resolves #2111

docs N/A

### Problem

The static method `_clusters_match` compares the configured and the stored clustering fields with a case-sensitive test (`table.clustering_fields == conf_cluster`).

A model can set `cluster_by` in a different letter case than the stored column. For example, the config gives `ExternalCustomerId`, but BigQuery stores the column as `externalcustomerid`.

In this condition, `is_replaceable()` returns `False` on every run, although the clustering did not change. The `table` materialization then drops the table with `tables.delete` before the rebuild query. It does not use an atomic `create or replace table`.

This behavior causes two problems:

1. dbt drops and recreates the table on every run. This adds cost. It also creates a period when the table does not exist.
2. dbt loses atomicity. dbt drops the table before the rebuild query runs. If the model SELECT fails, no table remains. An atomic `create or replace` keeps the previous table after a failure.

The related method `_partitions_match` already changes both sides to lower case. The method `_clusters_match` did not. This difference is an oversight, not an intentional design. The same case-sensitive comparison exists back to v1.4.0.

### Solution

Change both sides to lower case in `_clusters_match`. Keep the field order, because clustering uses an ordered list. Accept an empty list or `None`.

BigQuery column names are not case-sensitive. Therefore `externalcustomerid` and `ExternalCustomerId` refer to the same column, and `is_replaceable()` returns `True`. dbt then replaces the model with an atomic `create or replace table` and does not drop it first.

I added a unit test (`TestClustersMatch`) that covers the case-only difference, an exact match, a true mismatch, the order of the fields, an empty list, and a `None` value.

Alternatives and tradeoffs: I considered case normalization at config-parse time. I kept the change in the comparison, because `_partitions_match` uses the same approach. This choice keeps the fix small and does not change the config path.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
