### PR TITLE
fix(snowflake): preserve NUMBER precision/scale in catalog.json

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20260811-032000.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260811-032000.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Include precision and scale in Snowflake catalog column types for NUMBER
+  columns so catalog.json reports NUMBER(p,s) instead of bare NUMBER
+time: 2026-08-11T03:20:00.000000-05:00
+custom:
+  Author: dgvj-work
+  Issue: "2114"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
@@ -349,7 +349,11 @@ class SnowflakeAdapter(SQLAdapter):
         }
 
         catalog_columns = {
-            c.column: ColumnMetadata(type=c.dtype, index=i + 1, name=c.column)
+            c.column: ColumnMetadata(
+                type=c.data_type if c.is_numeric() else c.dtype,
+                index=i + 1,
+                name=c.column,
+            )
             for i, c in enumerate(self.get_columns_in_relation(relation))
         }
 

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/catalog.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/catalog.sql
@@ -81,7 +81,12 @@
 
         column_name as "column_name",
         ordinal_position as "column_index",
-        data_type as "column_type",
+        -- data_type is bare NUMBER; compose precision/scale for catalog consumers
+        case
+            when data_type = 'NUMBER' and numeric_precision is not null
+                then 'NUMBER(' || numeric_precision || ',' || coalesce(numeric_scale, 0) || ')'
+            else data_type
+        end as "column_type",
         comment as "column_comment"
     from {{ information_schema }}.columns
 {%- endmacro %}

--- a/dbt-snowflake/tests/functional/adapter/catalog_tests/files.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_tests/files.py
@@ -30,3 +30,14 @@ MY_DYNAMIC_TABLE = """
 ) }}
 select * from {{ ref('my_seed') }}
 """
+
+
+MY_NUMERIC_TABLE = """
+{{ config(
+    materialized='table',
+) }}
+select
+    cast(901.75 as number(12,2)) as retail_price,
+    cast(42 as number(38,0)) as whole_number,
+    cast('hello' as varchar(16)) as label
+"""

--- a/dbt-snowflake/tests/functional/adapter/catalog_tests/test_numeric_column_types.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_tests/test_numeric_column_types.py
@@ -1,0 +1,32 @@
+from dbt.contracts.results import CatalogArtifact
+from dbt.tests.util import run_dbt
+import pytest
+
+from tests.functional.adapter.catalog_tests import files
+
+
+class TestCatalogNumericColumnTypes:
+    """
+    Regression coverage for dbt-labs/dbt-adapters#2114.
+
+    Snowflake's information_schema.columns.data_type is bare NUMBER for every
+    fixed-point numeric column. Catalog generation must compose precision and
+    scale into column_type so downstream consumers can round-trip decimals.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"my_numeric_table.sql": files.MY_NUMERIC_TABLE}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def docs(self, project):
+        run_dbt(["run"])
+        yield run_dbt(["docs", "generate"])
+
+    def test_numeric_columns_include_precision_and_scale(self, docs: CatalogArtifact):
+        node = docs.nodes["model.test.my_numeric_table"]
+
+        assert node.columns["RETAIL_PRICE"].type == "NUMBER(12,2)"
+        assert node.columns["WHOLE_NUMBER"].type == "NUMBER(38,0)"
+        # Non-numeric types keep the information_schema data_type value.
+        assert node.columns["LABEL"].type == "TEXT"

--- a/dbt-snowflake/tests/functional/adapter/test_basic.py
+++ b/dbt-snowflake/tests/functional/adapter/test_basic.py
@@ -59,7 +59,7 @@ class TestGetCatalogForSingleRelationSnowflake(BaseGetCatalogForSingleRelation):
                 owner=current_role,
             ),
             columns={
-                "ID": ColumnMetadata(type="NUMBER", index=1, name="ID", comment=None),
+                "ID": ColumnMetadata(type="NUMBER(38,0)", index=1, name="ID", comment=None),
                 "FIRST_NAME": ColumnMetadata(
                     type="VARCHAR", index=2, name="FIRST_NAME", comment=None
                 ),
@@ -109,7 +109,7 @@ class TestGetCatalogForSingleRelationSnowflake(BaseGetCatalogForSingleRelation):
                 owner=current_role,
             ),
             columns={
-                "ID": ColumnMetadata(type="NUMBER", index=1, name="ID", comment=None),
+                "ID": ColumnMetadata(type="NUMBER(38,0)", index=1, name="ID", comment=None),
                 "FIRST_NAME": ColumnMetadata(
                     type="VARCHAR", index=2, name="FIRST_NAME", comment=None
                 ),
@@ -159,7 +159,7 @@ class TestGetCatalogForSingleRelationSnowflake(BaseGetCatalogForSingleRelation):
                 owner=current_role,
             ),
             columns={
-                "ID": ColumnMetadata(type="NUMBER", index=1, name="ID", comment=None),
+                "ID": ColumnMetadata(type="NUMBER(38,0)", index=1, name="ID", comment=None),
                 "FIRST_NAME": ColumnMetadata(
                     type="VARCHAR", index=2, name="FIRST_NAME", comment=None
                 ),
@@ -242,7 +242,7 @@ class TestDocsGenerateSnowflake(BaseDocsGenerate):
         return base_expected_catalog(
             project,
             role=get_role,
-            id_type="NUMBER",
+            id_type="NUMBER(38,0)",
             text_type="TEXT",
             time_type="TIMESTAMP_NTZ",
             view_type="VIEW",

--- a/dbt-snowflake/tests/unit/test_catalog_columns_sql_macro.py
+++ b/dbt-snowflake/tests/unit/test_catalog_columns_sql_macro.py
@@ -1,0 +1,56 @@
+import os
+import re
+import unittest
+from unittest import mock
+
+from jinja2 import Environment, FileSystemLoader
+
+MACROS_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "../../src/dbt/include/snowflake/macros")
+)
+
+
+class TestSnowflakeGetCatalogColumnsSqlMacro(unittest.TestCase):
+    def setUp(self):
+        self.jinja_env = Environment(
+            loader=FileSystemLoader(MACROS_DIR),
+            extensions=["jinja2.ext.do"],
+        )
+        self.default_context = {
+            "validation": mock.Mock(),
+            "model": mock.Mock(),
+            "exceptions": mock.Mock(),
+            "config": mock.Mock(),
+            "adapter": mock.Mock(),
+            "return": lambda r: r,
+        }
+
+    def _get_template(self):
+        return self.jinja_env.get_template("catalog.sql", globals=self.default_context)
+
+    def _render_columns_sql(self, information_schema="test_db.information_schema"):
+        template = self._get_template()
+        sql = template.module.snowflake__get_catalog_columns_sql(information_schema)
+        return re.sub(r"\s+", " ", sql.strip())
+
+    def test_macros_load(self):
+        self.jinja_env.get_template("catalog.sql")
+
+    def test_composes_number_precision_and_scale(self):
+        sql = self._render_columns_sql()
+
+        self.assertIn(
+            "when data_type = 'NUMBER' and numeric_precision is not null "
+            "then 'NUMBER(' || numeric_precision || ',' || coalesce(numeric_scale, 0) || ')'",
+            sql,
+        )
+        self.assertIn('end as "column_type"', sql)
+        self.assertNotIn('data_type as "column_type"', sql)
+
+    def test_selects_from_information_schema_columns(self):
+        sql = self._render_columns_sql("analytics.information_schema")
+
+        self.assertIn("from analytics.information_schema.columns", sql)
+        self.assertIn('column_name as "column_name"', sql)
+        self.assertIn('ordinal_position as "column_index"', sql)
+        self.assertIn('comment as "column_comment"', sql)


### PR DESCRIPTION
resolves #2114
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

### Problem

`snowflake__get_catalog_columns_sql` selected bare `data_type` from `INFORMATION_SCHEMA.COLUMNS`. For Snowflake, that value is `NUMBER` for every fixed-point numeric column, so `catalog.json` dropped precision and scale even though `numeric_precision` / `numeric_scale` were already on the same row. Downstream consumers that rebuild tables from the catalog then treat decimals as scale 0 and silently round.

### Solution

Compose `NUMBER(p,s)` in the catalog columns SQL when precision is present, matching what `DESCRIBE` returns. Also use expanded numeric `data_type` in `get_catalog_for_single_relation` so the single-relation catalog path stays consistent. Adds unit coverage for the macro, a functional regression test, and updates docs/catalog expectations that previously asserted bare `NUMBER`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX