### PR TITLE
fix(spark): use relation in list_relations_without_caching

### DIFF
--- a/dbt-spark/.changes/unreleased/Fixes-20260811-034800.yaml
+++ b/dbt-spark/.changes/unreleased/Fixes-20260811-034800.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Use the relation (not relation.schema) in list_relations macros so schema
+  name strings and Spark 3.2+ namespaces render correctly
+time: 2026-08-11T03:48:00.000000-05:00
+custom:
+  Author: dgvj-work
+  Issue: "480"

--- a/dbt-spark/src/dbt/include/spark/macros/adapters.sql
+++ b/dbt-spark/src/dbt/include/spark/macros/adapters.sql
@@ -294,7 +294,7 @@
 
 {% macro spark__list_relations_without_caching(relation) %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
-    show table extended in {{ relation.schema }} like '*'
+    show table extended in {{ relation }} like '*'
   {% endcall %}
 
   {% do return(load_result('list_relations_without_caching').table) %}
@@ -305,7 +305,7 @@
   {#-- V2 iceberg tables #}
   {#-- https://issues.apache.org/jira/browse/SPARK-33393 #}
   {% call statement('list_relations_without_caching_show_tables', fetch_result=True) -%}
-    show tables in {{ schema_relation.schema }} like '*'
+    show tables in {{ schema_relation }} like '*'
   {% endcall %}
 
   {% do return(load_result('list_relations_without_caching_show_tables').table) %}

--- a/dbt-spark/tests/unit/test_macros.py
+++ b/dbt-spark/tests/unit/test_macros.py
@@ -208,3 +208,21 @@ class TestSparkMacros(unittest.TestCase):
             sql,
             "create table my_table using hudi partitioned by (partition_1,partition_2) clustered by (cluster_1,cluster_2) into 1 buckets location '/mnt/root/my_table' comment 'Description Test' as select 1",
         )
+
+    def test_list_relations_without_caching_uses_relation_not_schema_attr(self):
+        """Regression for dbt-labs/dbt-adapters#480.
+
+        Callers (and spark-utils) may pass a schema/database name string. Using
+        relation.schema then yields an empty namespace and invalid Spark SQL.
+        """
+        with open("src/dbt/include/spark/macros/adapters.sql") as handle:
+            adapters_src = handle.read()
+
+        self.assertIn("show table extended in {{ relation }} like '*'", adapters_src)
+        self.assertNotIn(
+            "show table extended in {{ relation.schema }} like '*'", adapters_src
+        )
+        self.assertIn("show tables in {{ schema_relation }} like '*'", adapters_src)
+        self.assertNotIn(
+            "show tables in {{ schema_relation.schema }} like '*'", adapters_src
+        )


### PR DESCRIPTION
resolves #480
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

### Problem

`spark__list_relations_without_caching` used `{{ relation.schema }}`. When callers pass a schema/database name string (for example spark-utils iterating `SHOW DATABASES` results), `.schema` is empty and Spark gets invalid SQL like `show table extended in  like '*'`.

### Solution

Use `{{ relation }}` / `{{ schema_relation }}` in the list-relations macros so both Relation objects and plain schema name strings render correctly. Adds a unit regression check and changelog entry.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
