### PR TITLE
Fix describe_relation record to stop failing on initialization

### DIFF
--- a/dbt-bigquery/src/dbt/adapters/bigquery/record/record_types.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/record/record_types.py
@@ -66,7 +66,7 @@ class BigQueryAdapterDescribeRelationResult:
     def __init__(self, return_val):
         # Handle BigQueryBaseRelationConfig by converting to dict
         if return_val is not None and not isinstance(return_val, dict):
-            self.return_val = dataclasses.asdict(return_val)
+            self.return_val = return_val.to_dict()
         else:
             self.return_val = return_val
 

--- a/dbt-bigquery/src/dbt/adapters/bigquery/relation_configs/_materialized_view.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/relation_configs/_materialized_view.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any, Dict, Optional
 
 from dbt.adapters.contracts.relation import (
@@ -43,6 +43,16 @@ class BigQueryMaterializedViewConfig(BigQueryBaseRelationConfig):
     options: BigQueryOptionsConfig
     partition: Optional[PartitionConfig] = None
     cluster: Optional[BigQueryClusterConfig] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "table_id": self.table_id,
+            "dataset_id": self.dataset_id,
+            "project_id": self.project_id,
+            "options": self.options.to_dict(),
+            "partition": asdict(self.partition) if self.partition is not None else None,
+            "cluster": asdict(self.cluster) if self.cluster is not None else None,
+        }
 
     @classmethod
     def from_dict(cls, config_dict: Dict[str, Any]) -> "BigQueryMaterializedViewConfig":

--- a/dbt-bigquery/src/dbt/adapters/bigquery/relation_configs/_options.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/relation_configs/_options.py
@@ -28,6 +28,21 @@ class BigQueryOptionsConfig(BigQueryBaseRelationConfig):
     labels: MappingProxyType = field(default_factory=lambda: MappingProxyType({}))
     tags: MappingProxyType = field(default_factory=lambda: MappingProxyType({}))
 
+    def to_dict(self) -> Dict[str, Any]:
+        expiration = self.expiration_timestamp
+        if isinstance(expiration, datetime):
+            expiration = expiration.isoformat()
+        return {
+            "enable_refresh": self.enable_refresh,
+            "refresh_interval_minutes": self.refresh_interval_minutes,
+            "expiration_timestamp": expiration,
+            "max_staleness": self.max_staleness,
+            "kms_key_name": self.kms_key_name,
+            "description": self.description,
+            "labels": dict(self.labels),
+            "tags": dict(self.tags),
+        }
+
     def __hash__(self) -> int:
         """Custom hash method to handle unhashable dict fields."""
         hashable_fields = []

--- a/dbt-bigquery/src/dbt/adapters/bigquery/relation_configs/_options.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/relation_configs/_options.py
@@ -39,8 +39,8 @@ class BigQueryOptionsConfig(BigQueryBaseRelationConfig):
             "max_staleness": self.max_staleness,
             "kms_key_name": self.kms_key_name,
             "description": self.description,
-            "labels": dict(self.labels),
-            "tags": dict(self.tags),
+            "labels": dict(self.labels) if self.labels is not None else None,
+            "tags": dict(self.tags) if self.tags is not None else None,
         }
 
     def __hash__(self) -> int:

--- a/dbt-bigquery/tests/unit/test_bigquery_relation_configs.py
+++ b/dbt-bigquery/tests/unit/test_bigquery_relation_configs.py
@@ -179,6 +179,39 @@ class TestBigQueryRelationConfigs(unittest.TestCase):
             self.assertIsNotNone(changeset)
             self.assertIsNotNone(changeset.options)
 
+    def test_describe_relation_result_serializes_immutable_maps_and_datetime(self):
+        """Recorded describe_relation result serializes MappingProxyType labels/tags
+        and a datetime expiration to a non-null dict."""
+        from datetime import datetime, timezone
+        from types import MappingProxyType
+
+        from dbt.adapters.bigquery.record.record_types import (
+            BigQueryAdapterDescribeRelationResult,
+        )
+
+        options = BigQueryOptionsConfig(
+            enable_refresh=True,
+            refresh_interval_minutes=30,
+            expiration_timestamp=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            labels=MappingProxyType({"env": "test", "team": "data"}),
+            tags=MappingProxyType({"test-project/team": "data"}),
+        )
+        mv_config = BigQueryMaterializedViewConfig(
+            table_id="test_table",
+            dataset_id="test_dataset",
+            project_id="test_project",
+            options=options,
+        )
+
+        return_val = BigQueryAdapterDescribeRelationResult(mv_config)._to_dict()["return_val"]
+
+        self.assertIsInstance(return_val, dict)
+        self.assertEqual(return_val["options"]["labels"], {"env": "test", "team": "data"})
+        self.assertEqual(return_val["options"]["tags"], {"test-project/team": "data"})
+        self.assertEqual(
+            return_val["options"]["expiration_timestamp"], "2024-01-01T12:00:00+00:00"
+        )
+
 
 class TestClusterConfigComparison(unittest.TestCase):
     def test_same_fields_different_order_no_change(self):


### PR DESCRIPTION
See: https://github.com/dbt-labs/fs/issues/12821
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Every `BigQueryAdapterDescribeRelationRecord` turns up null:
```
  {
    "params": {
      "thread_id": "model.bigquery_materialized_view_remote_state.mat_view",
      "relation": {
        "path": {
          "database": "repro_project",
          "schema": "repro_dataset",
          "identifier": "mat_view"
        },
        "type": "materialized_view",
        "quote_character": "`",
        "include_policy": {"database": true, "schema": true, "identifier": true},
        "quote_policy": {"database": true, "schema": true, "identifier": true},
        "dbt_created": false,
        "require_alias": false,
        "renameable_relations": ["table"],
        "replaceable_relations": ["table", "view"]
      }
    },
    "result": null, <-- this is wrong
    "seq": 3,
    "type": "BigQueryAdapterDescribeRelationRecord"
  }
```

This is because `dataclasses.as_dict` fails here:
https://github.com/dbt-labs/dbt-adapters/blob/38bd0f6a3a39ada5a84d40b93eac1994d1076607/dbt-bigquery/src/dbt/adapters/bigquery/record/record_types.py#L69

due to the `labels` and `tags` fields being `MappingProxyType`.
https://github.com/dbt-labs/dbt-adapters/blob/38bd0f6a3a39ada5a84d40b93eac1994d1076607/dbt-bigquery/src/dbt/adapters/bigquery/relation_configs/_options.py#L28-L29

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Implement a custom `to_dict` method that handles converting `labels` and `tags` to dicts.

### Checklist

- [ X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X ] I have run this code in development and it appears to resolve the stated issue
- [ X] This PR includes tests, or tests are not required/relevant for this PR
- [X ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
