### PR TITLE
fix(snowflake): skip unconditional SHOW USER FUNCTIONS

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20260811-041500.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260811-041500.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Skip unconditional SHOW USER FUNCTIONS during schema listing unless the
+  project has function nodes (or flags.list_function_relations is enabled)
+time: 2026-08-11T04:15:00.000000-05:00
+custom:
+  Author: dgvj-work
+  Issue: "2106"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
@@ -11,10 +11,13 @@ from typing import (
     Dict,
     FrozenSet,
     Tuple,
+    Iterable,
+    Set,
 )
 
 from dbt.adapters.base.impl import AdapterConfig, ConstraintSupport
 from dbt.adapters.base.meta import available
+from dbt.adapters.base.relation import BaseRelation
 from dbt.adapters.capability import CapabilityDict, CapabilitySupport, Support, Capability
 from dbt.adapters.catalogs import (
     CatalogIntegration,
@@ -163,6 +166,9 @@ class SnowflakeAdapter(SQLAdapter):
         super().__init__(config, mp_context)
         self.add_catalog_integration(constants.DEFAULT_INFO_SCHEMA_CATALOG)
         self.add_catalog_integration(constants.DEFAULT_BUILT_IN_CATALOG)
+        # Populated in set_relations_cache when the project contains function nodes.
+        # Avoids unconditional SHOW USER FUNCTIONS on every schema (dbt-adapters#2106).
+        self._list_function_relations: bool = False
 
     def _v2_to_v1_type(self, catalog_type: str) -> str:
         return self._V2_TO_V1_TYPE.get(catalog_type, catalog_type)
@@ -386,15 +392,48 @@ class SnowflakeAdapter(SQLAdapter):
             column_types=column_types,
         )
 
+    def set_relations_cache(
+        self,
+        relation_configs: Iterable[RelationConfig],
+        clear: bool = False,
+        required_schemas: Optional[Set[BaseRelation]] = None,
+    ) -> None:
+        # Materialize once — relation_configs may be a one-shot iterable, and we
+        # need it both to detect function nodes and to populate the cache.
+        configs = list(relation_configs)
+        flag = self.config.flags.get("list_function_relations")
+        if flag is not None:
+            self._list_function_relations = bool(flag)
+        else:
+            self._list_function_relations = any(
+                str(getattr(cfg, "resource_type", "")).lower() == "function" for cfg in configs
+            )
+        super().set_relations_cache(configs, clear=clear, required_schemas=required_schemas)
+
+    def _should_list_function_relations(self) -> bool:
+        """Whether to issue SHOW USER FUNCTIONS while listing schema relations.
+
+        Defaults to skipping the call unless the project has function nodes (or
+        ``flags.list_function_relations`` is set explicitly). Projects without
+        UDFs were paying one SHOW per schema on every invocation after 1.12.0.
+        """
+        flag = self.config.flags.get("list_function_relations")
+        if flag is not None:
+            return bool(flag)
+        return self._list_function_relations
+
     def list_relations_without_caching(
         self, schema_relation: SnowflakeRelation
     ) -> List[SnowflakeRelation]:
         kwargs = {"schema_relation": schema_relation}
+        list_functions = self._should_list_function_relations()
 
         try:
             schema_objects = self.execute_macro(LIST_RELATIONS_MACRO_NAME, kwargs=kwargs)
-            schema_functions = self.execute_macro(
-                LIST_FUNCTION_RELATIONS_MACRO_NAME, kwargs=kwargs
+            schema_functions = (
+                self.execute_macro(LIST_FUNCTION_RELATIONS_MACRO_NAME, kwargs=kwargs)
+                if list_functions
+                else None
             )
         except DbtDatabaseError as exc:
             # if the schema doesn't exist, we just want to return.
@@ -414,17 +453,20 @@ class SnowflakeAdapter(SQLAdapter):
             "is_dynamic",
             "is_iceberg",
         ]
-        function_columns = ["catalog_name", "schema_name", "name", "is_builtin"]
         schema_objects = schema_objects.rename(
             column_names=[col.lower() for col in schema_objects.column_names]
-        )
-        schema_functions = schema_functions.rename(
-            column_names=[col.lower() for col in schema_functions.column_names]
         )
         tabular_relations = [
             self._parse_list_relations_result(obj)
             for obj in schema_objects.select(tabular_columns)
         ]
+        if schema_functions is None:
+            return tabular_relations
+
+        function_columns = ["catalog_name", "schema_name", "name", "is_builtin"]
+        schema_functions = schema_functions.rename(
+            column_names=[col.lower() for col in schema_functions.column_names]
+        )
         function_relations = [
             self._parse_list_function_relations_result(obj)
             for obj in schema_functions.select(function_columns)

--- a/dbt-snowflake/tests/unit/test_list_function_relations_gating.py
+++ b/dbt-snowflake/tests/unit/test_list_function_relations_gating.py
@@ -1,0 +1,128 @@
+"""Regression coverage for dbt-labs/dbt-adapters#2106.
+
+Kept separate from test_snowflake_adapter.py so it does not require dbt-core
+(FileHash / config_from_parts) to exercise the SHOW USER FUNCTIONS gate.
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest import mock
+
+import agate
+
+from dbt.adapters.snowflake import SnowflakeAdapter
+from dbt.adapters.sql.impl import (
+    LIST_FUNCTION_RELATIONS_MACRO_NAME,
+    LIST_RELATIONS_MACRO_NAME,
+)
+
+
+class TestSnowflakeListFunctionRelationsGating(TestCase):
+    def _adapter(self):
+        adapter = SnowflakeAdapter.__new__(SnowflakeAdapter)
+        adapter.config = SimpleNamespace(flags={})
+        adapter._list_function_relations = False
+        adapter.Relation = SnowflakeAdapter.Relation
+        return adapter
+
+    def _objects_table(self):
+        return agate.Table(
+            [("TEST_DATABASE", "PUBLIC", "MY_TABLE", "TABLE", "N", "N")],
+            column_names=[
+                "database_name",
+                "schema_name",
+                "name",
+                "kind",
+                "is_dynamic",
+                "is_iceberg",
+            ],
+        )
+
+    def _functions_table(self):
+        # Keep is_builtin as Text ("N"/"Y") to match SHOW USER FUNCTIONS results.
+        text = agate.Text()
+        return agate.Table(
+            [("TEST_DATABASE", "PUBLIC", "MY_UDF", "N")],
+            column_names=["catalog_name", "schema_name", "name", "is_builtin"],
+            column_types=[text, text, text, text],
+        )
+
+    def _schema_relation(self):
+        return mock.Mock()
+
+    def test_skips_show_user_functions_when_project_has_no_functions(self):
+        adapter = self._adapter()
+        with mock.patch.object(
+            SnowflakeAdapter.__mro__[1], "set_relations_cache", return_value=None
+        ):
+            adapter.set_relations_cache([])
+
+        self.assertFalse(adapter._list_function_relations)
+
+        with mock.patch.object(
+            adapter, "execute_macro", return_value=self._objects_table()
+        ) as execute_macro:
+            relations = adapter.list_relations_without_caching(self._schema_relation())
+
+        self.assertEqual(len(relations), 1)
+        self.assertEqual(relations[0].identifier, "MY_TABLE")
+        self.assertEqual(execute_macro.call_count, 1)
+        self.assertEqual(execute_macro.call_args.args[0], LIST_RELATIONS_MACRO_NAME)
+
+    def test_lists_functions_when_project_has_function_nodes(self):
+        adapter = self._adapter()
+        with mock.patch.object(
+            SnowflakeAdapter.__mro__[1], "set_relations_cache", return_value=None
+        ):
+            adapter.set_relations_cache([SimpleNamespace(resource_type="function")])
+
+        self.assertTrue(adapter._list_function_relations)
+
+        objects = self._objects_table()
+        functions = self._functions_table()
+
+        def _execute_macro(name, kwargs=None):
+            if name == LIST_RELATIONS_MACRO_NAME:
+                return objects
+            if name == LIST_FUNCTION_RELATIONS_MACRO_NAME:
+                return functions
+            raise AssertionError(f"unexpected macro {name}")
+
+        with mock.patch.object(adapter, "execute_macro", side_effect=_execute_macro) as execute_macro:
+            relations = adapter.list_relations_without_caching(self._schema_relation())
+
+        self.assertEqual({r.identifier for r in relations}, {"MY_TABLE", "MY_UDF"})
+        self.assertEqual(execute_macro.call_count, 2)
+        called = [c.args[0] for c in execute_macro.call_args_list]
+        self.assertIn(LIST_FUNCTION_RELATIONS_MACRO_NAME, called)
+
+    def test_flag_can_force_disable_function_listing(self):
+        adapter = self._adapter()
+        adapter.config.flags = {"list_function_relations": False}
+
+        with mock.patch.object(
+            SnowflakeAdapter.__mro__[1], "set_relations_cache", return_value=None
+        ):
+            adapter.set_relations_cache([SimpleNamespace(resource_type="function")])
+
+        self.assertFalse(adapter._list_function_relations)
+
+        with mock.patch.object(
+            adapter, "execute_macro", return_value=self._objects_table()
+        ) as execute_macro:
+            relations = adapter.list_relations_without_caching(self._schema_relation())
+
+        self.assertEqual(len(relations), 1)
+        self.assertEqual(execute_macro.call_count, 1)
+
+    def test_flag_can_force_enable_function_listing(self):
+        adapter = self._adapter()
+        adapter.config.flags = {"list_function_relations": True}
+
+        with mock.patch.object(
+            SnowflakeAdapter.__mro__[1], "set_relations_cache", return_value=None
+        ):
+            adapter.set_relations_cache([SimpleNamespace(resource_type="model")])
+
+        self.assertTrue(adapter._list_function_relations)
+        self.assertTrue(adapter._should_list_function_relations())


### PR DESCRIPTION
## Summary
- Stop issuing `SHOW USER FUNCTIONS` on every schema listing unless the project has function nodes
- Allow override via `flags.list_function_relations: true|false`
- Add unit regression coverage for the gate

resolves #2106

## Test plan
- [x] Unit tests: `tests.unit.test_list_function_relations_gating`
- [ ] CI unit/integration after `ci:approve-public-fork-ci`
- [ ] Confirm projects without UDFs no longer run `SHOW USER FUNCTIONS` during listing
- [ ] Confirm projects with `resource_type: function` still list UDFs
