### PR TITLE
fix(snowflake): add snowflake_catalog_scan_per_schema behavior flag

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20260804-101500.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260804-101500.yaml
@@ -1,0 +1,9 @@
+kind: Fixes
+body: Add the `snowflake_catalog_scan_per_schema` behavior flag, disabled by default.
+  Catalog queries scan one schema at a time and union the results, rather than filtering
+  with an `or` that can make Snowflake materialize the whole database's metadata. Faster
+  where few schemas are in use, slower where many are
+time: 2026-08-04T10:15:00.000000-05:00
+custom:
+  Author: tauhid621
+  Issue: ""

--- a/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
@@ -83,6 +83,17 @@ SNOWFLAKE_MANAGED_ICEBERG_DEFAULT = BehaviorFlag(
     ),
 )
 
+SNOWFLAKE_CATALOG_SCAN_PER_SCHEMA = BehaviorFlag(
+    name="snowflake_catalog_scan_per_schema",
+    default=False,
+    description=(
+        "When enabled, catalog queries scan one schema at a time and union the results, "
+        "rather than filtering with an `or` that can make Snowflake materialize the whole "
+        "database's metadata. Each schema in use adds a scan, so this helps projects using "
+        "few schemas against a metadata-heavy database, and hurts those using many."
+    ),
+)
+
 # Guard against older dbt-adapters that don't have Capability.CatalogsV2 yet.
 # Remove once dbt-adapters lower bound is bumped to the version that adds it.
 _CATALOGS_V2_CAPABILITY = getattr(Capability, "CatalogsV2", None)  # type: ignore[attr-defined]
@@ -168,7 +179,11 @@ class SnowflakeAdapter(SQLAdapter):
 
     @property
     def _behavior_flags(self) -> list[BehaviorFlag]:
-        return [SNOWFLAKE_DEFAULT_TRANSIENT_DYNAMIC_TABLES, SNOWFLAKE_MANAGED_ICEBERG_DEFAULT]
+        return [
+            SNOWFLAKE_DEFAULT_TRANSIENT_DYNAMIC_TABLES,
+            SNOWFLAKE_MANAGED_ICEBERG_DEFAULT,
+            SNOWFLAKE_CATALOG_SCAN_PER_SCHEMA,
+        ]
 
     def __init__(self, config, mp_context) -> None:
         super().__init__(config, mp_context)

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/catalog.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/catalog.sql
@@ -2,12 +2,10 @@
 
     {% set query %}
         with tables as (
-            {{ snowflake__get_catalog_tables_sql(information_schema) }}
-            {{ snowflake__get_catalog_schemas_where_clause_sql(schemas) }}
+            {{ snowflake__catalog_tables_by_schemas_sql(information_schema, schemas) }}
         ),
         columns as (
-            {{ snowflake__get_catalog_columns_sql(information_schema) }}
-            {{ snowflake__get_catalog_schemas_where_clause_sql(schemas) }}
+            {{ snowflake__catalog_columns_by_schemas_sql(information_schema, schemas) }}
         )
         {{ snowflake__get_catalog_results_sql() }}
     {%- endset -%}
@@ -21,12 +19,10 @@
 
     {% set query %}
         with tables as (
-            {{ snowflake__get_catalog_tables_sql(information_schema) }}
-            {{ snowflake__get_catalog_relations_where_clause_sql(relations) }}
+            {{ snowflake__catalog_tables_by_relations_sql(information_schema, relations) }}
         ),
         columns as (
-            {{ snowflake__get_catalog_columns_sql(information_schema) }}
-            {{ snowflake__get_catalog_relations_where_clause_sql(relations) }}
+            {{ snowflake__catalog_columns_by_relations_sql(information_schema, relations) }}
         )
         {{ snowflake__get_catalog_results_sql() }}
     {%- endset -%}
@@ -36,7 +32,7 @@
 {%- endmacro %}
 
 
-{% macro snowflake__get_catalog_tables_sql(information_schema) -%}
+{% macro snowflake__get_catalog_tables_sql(information_schema, source_sql=none) -%}
     select
         table_catalog as "table_database",
         table_schema as "table_schema",
@@ -69,11 +65,11 @@
         to_varchar(convert_timezone('UTC', last_altered), 'yyyy-mm-dd HH24:MI'||'UTC') as "stats:last_modified:value",
         'The timestamp for last update/change' as "stats:last_modified:description",
         (last_altered is not null and table_type='BASE TABLE') as "stats:last_modified:include"
-    from {{ information_schema }}.tables
+    from {{ source_sql if source_sql is not none else information_schema ~ '.tables' }}
 {%- endmacro %}
 
 
-{% macro snowflake__get_catalog_columns_sql(information_schema) -%}
+{% macro snowflake__get_catalog_columns_sql(information_schema, source_sql=none) -%}
     select
         table_catalog as "table_database",
         table_schema as "table_schema",
@@ -83,7 +79,7 @@
         ordinal_position as "column_index",
         data_type as "column_type",
         comment as "column_comment"
-    from {{ information_schema }}.columns
+    from {{ source_sql if source_sql is not none else information_schema ~ '.columns' }}
 {%- endmacro %}
 
 
@@ -95,14 +91,152 @@
 {%- endmacro %}
 
 
-{% macro snowflake__catalog_equals(field, value) %}
-    "{{ field }}" ilike '{{ value }}' and upper("{{ field }}") = upper('{{ value }}')
+{#
+    `quote` picks which spelling of `field` the predicate refers to.
+
+    Quoted is correct on the outer select, where the projection has aliased the column to a
+    quoted lowercase name (`table_schema as "table_schema"`) that Snowflake lets a where clause
+    reference. It is *not* correct directly against an information_schema view, whose real
+    columns are uppercase -- `"table_schema"` raises `invalid identifier` there. Pass
+    `quote=false` whenever the predicate sits on the view rather than on the projection.
+#}
+{% macro snowflake__catalog_equals(field, value, quote=true) %}
+    {%- set column = '"' ~ field ~ '"' if quote else field -%}
+    {{ column }} ilike '{{ value }}' and upper({{ column }}) = upper('{{ value }}')
 {% endmacro %}
 
 
-{% macro snowflake__get_catalog_schemas_where_clause_sql(schemas) -%}
+{% macro snowflake__catalog_tables_by_schemas_sql(information_schema, schemas) -%}
+    {%- if adapter.behavior.snowflake_catalog_scan_per_schema.no_warn -%}
+        {{ snowflake__get_catalog_tables_sql(
+            information_schema,
+            snowflake__pruned_catalog_scan_by_schemas_sql(information_schema, 'tables', schemas)) }}
+    {%- else %}
+        {{ snowflake__get_catalog_tables_sql(information_schema) }}
+        {{ snowflake__get_catalog_schemas_where_clause_sql(schemas) }}
+    {%- endif -%}
+{%- endmacro %}
+
+
+{% macro snowflake__catalog_columns_by_schemas_sql(information_schema, schemas) -%}
+    {%- if adapter.behavior.snowflake_catalog_scan_per_schema.no_warn -%}
+        {{ snowflake__get_catalog_columns_sql(
+            information_schema,
+            snowflake__pruned_catalog_scan_by_schemas_sql(information_schema, 'columns', schemas)) }}
+    {%- else %}
+        {{ snowflake__get_catalog_columns_sql(information_schema) }}
+        {{ snowflake__get_catalog_schemas_where_clause_sql(schemas) }}
+    {%- endif -%}
+{%- endmacro %}
+
+
+{% macro snowflake__catalog_tables_by_relations_sql(information_schema, relations) -%}
+    {%- if adapter.behavior.snowflake_catalog_scan_per_schema.no_warn -%}
+        {{ snowflake__get_catalog_tables_sql(
+            information_schema,
+            snowflake__pruned_catalog_scan_by_relations_sql(information_schema, 'tables', relations)) }}
+    {%- else %}
+        {{ snowflake__get_catalog_tables_sql(information_schema) }}
+        {{ snowflake__get_catalog_relations_where_clause_sql(relations) }}
+    {%- endif -%}
+{%- endmacro %}
+
+
+{% macro snowflake__catalog_columns_by_relations_sql(information_schema, relations) -%}
+    {%- if adapter.behavior.snowflake_catalog_scan_per_schema.no_warn -%}
+        {{ snowflake__get_catalog_columns_sql(
+            information_schema,
+            snowflake__pruned_catalog_scan_by_relations_sql(information_schema, 'columns', relations)) }}
+    {%- else %}
+        {{ snowflake__get_catalog_columns_sql(information_schema) }}
+        {{ snowflake__get_catalog_relations_where_clause_sql(relations) }}
+    {%- endif -%}
+{%- endmacro %}
+
+
+{#
+    Snowflake only takes the fast per-schema metadata path when the schema filter is a
+    single equality. An `or` across schemas drops it back to materializing the whole
+    database's metadata, so scan one schema at a time and union the results instead.
+
+    Only the scan is repeated per schema, never the surrounding projection: the projection
+    for `tables` is ~1.5kB and Snowflake caps a statement at 1MB, so inlining it per schema
+    would fail outright on a database with a few hundred schemas -- exactly the case this
+    flag exists to speed up. The projection is applied once, over the union.
+#}
+{% macro snowflake__pruned_catalog_scan_by_schemas_sql(information_schema, view_name, schemas) -%}
+    (
+        {%- for schema in schemas | map('upper') | unique | sort %}
+        select * from {{ information_schema }}.{{ view_name }}
+        {{ snowflake__get_catalog_schemas_where_clause_sql([schema], quote=false) }}
+        {%- if not loop.last %}
+        union all
+        {%- endif %}
+        {%- endfor %}
+    ) as pruned_{{ view_name }}
+{%- endmacro %}
+
+
+{#
+    As above, but grouping the requested relations by schema so that each scan is still
+    filtered to a single schema.
+#}
+{% macro snowflake__pruned_catalog_scan_by_relations_sql(information_schema, view_name, relations) -%}
+    {%- set schema_groups = {} -%}
+    {%- for relation in relations -%}
+        {%- set schema = (relation.schema or '') | upper -%}
+        {%- if schema not in schema_groups -%}
+            {%- do schema_groups.update({schema: []}) -%}
+        {%- endif -%}
+        {%- do schema_groups[schema].append(relation) -%}
+    {%- endfor -%}
+
+    (
+        {%- for schema, schema_relations in schema_groups | dictsort %}
+        select * from {{ information_schema }}.{{ view_name }}
+        {{ snowflake__pruned_catalog_relations_where_clause_sql(schema_relations) }}
+        {%- if not loop.last %}
+        union all
+        {%- endif %}
+        {%- endfor %}
+    ) as pruned_{{ view_name }}
+{%- endmacro %}
+
+
+{#
+    `relations` must all belong to the same schema -- mixed schemas raise rather than silently
+    reporting on only the first one. The schema match is hoisted out of the identifier
+    disjunction so that it stays a single equality conjunct.
+#}
+{% macro snowflake__pruned_catalog_relations_where_clause_sql(relations) -%}
+    {%- if relations | rejectattr('schema') | list %}
+        {%- do exceptions.raise_compiler_error(
+            '`get_catalog_relations` requires a list of relations, each with a schema'
+        ) %}
+    {%- endif %}
+
+    {%- set schemas = relations | map(attribute='schema') | map('upper') | unique | sort -%}
+    {%- if schemas | length > 1 %}
+        {%- do exceptions.raise_compiler_error(
+            '`snowflake__pruned_catalog_relations_where_clause_sql` requires relations from a'
+            ~ ' single schema, got: ' ~ (schemas | join(', '))
+        ) %}
+    {%- endif %}
+
+    {%- set whole_schema = relations | rejectattr('identifier') | list | length > 0 -%}
+
+    where {{ snowflake__catalog_equals('table_schema', relations[0].schema, quote=false) }}
+    {%- if not whole_schema %}
+        and ({%- for identifier in relations | map(attribute='identifier') | unique | sort -%}
+            ({{ snowflake__catalog_equals('table_name', identifier, quote=false) }}){%- if not loop.last %} or {% endif -%}
+        {%- endfor -%})
+    {%- endif %}
+{%- endmacro %}
+
+
+{% macro snowflake__get_catalog_schemas_where_clause_sql(schemas, quote=true) -%}
     where ({%- for schema in schemas -%}
-        ({{ snowflake__catalog_equals('table_schema', schema) }}){%- if not loop.last %} or {% endif -%}
+        ({{ snowflake__catalog_equals('table_schema', schema, quote) }}){%- if not loop.last %} or {% endif -%}
     {%- endfor -%})
 {%- endmacro %}
 

--- a/dbt-snowflake/tests/functional/adapter/catalog_tests/files.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_tests/files.py
@@ -30,3 +30,21 @@ MY_DYNAMIC_TABLE = """
 ) }}
 select * from {{ ref('my_seed') }}
 """
+
+
+MY_TABLE_IN_ANOTHER_SCHEMA = """
+{{ config(
+    materialized='table',
+    schema='another',
+) }}
+select * from {{ ref('my_seed') }}
+"""
+
+
+MY_VIEW_IN_ANOTHER_SCHEMA = """
+{{ config(
+    materialized='view',
+    schema='another',
+) }}
+select * from {{ ref('my_seed') }}
+"""

--- a/dbt-snowflake/tests/functional/adapter/catalog_tests/test_catalog_scan_per_schema.py
+++ b/dbt-snowflake/tests/functional/adapter/catalog_tests/test_catalog_scan_per_schema.py
@@ -1,0 +1,93 @@
+from dbt.contracts.results import CatalogArtifact
+from dbt.tests.util import run_dbt
+import pytest
+
+from tests.functional.adapter.catalog_tests import files
+
+
+class BaseCatalogScanPerSchema:
+    """
+    Exercises both catalog macros against a database with relations in more than one schema,
+    which is the only shape where `snowflake_catalog_scan_per_schema` changes the generated sql.
+
+    The same assertions run with the flag on and off, so the two code paths are held to
+    identical results.
+    """
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"my_seed.csv": files.MY_SEED}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_table.sql": files.MY_TABLE,
+            "my_view.sql": files.MY_VIEW,
+            "my_other_table.sql": files.MY_TABLE_IN_ANOTHER_SCHEMA,
+            "my_other_view.sql": files.MY_VIEW_IN_ANOTHER_SCHEMA,
+        }
+
+    EXPECTED_TYPES = {
+        "seed.test.my_seed": "BASE TABLE",
+        "model.test.my_table": "BASE TABLE",
+        "model.test.my_view": "VIEW",
+        "model.test.my_other_table": "BASE TABLE",
+        "model.test.my_other_view": "VIEW",
+    }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def build(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+
+    def assert_catalog(self, catalog: CatalogArtifact, node_names):
+        assert catalog.errors is None, catalog.errors
+        assert set(catalog.nodes) == set(node_names)
+
+        for node_name in node_names:
+            node = catalog.nodes[node_name]
+
+            # `table_type` comes out of a case expression over `is_dynamic`, so this also
+            # confirms the pruned scans hand every information_schema column to the projection
+            assert node.metadata.type == self.EXPECTED_TYPES[node_name]
+
+            # unioning per-schema scans must not drop, duplicate, or reorder columns
+            assert [column.name.lower() for column in node.columns.values()] == ["id", "value"]
+
+    def test_get_catalog_spans_every_schema(self, project):
+        """
+        `snowflake__get_catalog`, filtering by schema.
+
+        `--no-compile` is what selects this macro, not the absence of `--select`. `docs generate`
+        compiles by default, which populates the task's job queue, and `GenerateTask` then hands
+        `get_filtered_catalog` the full relation set -- so a project this small would take the
+        by-relations path even with no selection. Skipping the compile leaves the relation set
+        empty and falls back to filtering by schema.
+        """
+        catalog = run_dbt(["docs", "generate", "--no-compile"])
+        self.assert_catalog(catalog, self.EXPECTED_TYPES.keys())
+
+    def test_get_catalog_relations_spans_every_schema(self, project):
+        """
+        A selection smaller than `MAX_SCHEMA_METADATA_RELATIONS` -> `snowflake__get_catalog_relations`,
+        filtering by relation. The selection deliberately straddles both schemas.
+        """
+        catalog = run_dbt(["docs", "generate", "--select", "my_table", "my_other_view"])
+        self.assert_catalog(catalog, ["model.test.my_table", "model.test.my_other_view"])
+
+    def test_get_catalog_relations_for_a_single_schema(self, project):
+        """A selection confined to one schema must not pull in the other."""
+        catalog = run_dbt(["docs", "generate", "--select", "my_other_table", "my_other_view"])
+        self.assert_catalog(catalog, ["model.test.my_other_table", "model.test.my_other_view"])
+
+
+class TestCatalogScanPerSchemaEnabled(BaseCatalogScanPerSchema):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"snowflake_catalog_scan_per_schema": True}}
+
+
+class TestCatalogScanPerSchemaDisabled(BaseCatalogScanPerSchema):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"snowflake_catalog_scan_per_schema": False}}

--- a/dbt-snowflake/tests/unit/test_catalog_macros.py
+++ b/dbt-snowflake/tests/unit/test_catalog_macros.py
@@ -1,0 +1,311 @@
+import os
+import re
+import unittest
+from unittest import mock
+
+from jinja2 import Environment, FileSystemLoader
+
+MACROS_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "../../src/dbt/include/snowflake/macros")
+)
+
+INFORMATION_SCHEMA = '"my_database".information_schema'
+
+# fragments unique to each projection, used to count how many times it was inlined
+TABLES_PROJECTION_MARKER = '"stats:clustering_key:label"'
+COLUMNS_PROJECTION_MARKER = '"column_index"'
+
+
+class MockRelation:
+    def __init__(self, schema, identifier=None):
+        self.schema = schema
+        self.identifier = identifier
+
+
+class MockCompilerError(Exception):
+    """Stands in for dbt's compiler error so that raising actually aborts rendering."""
+
+
+class TestSnowflakeCatalogMacros(unittest.TestCase):
+    def setUp(self):
+        self.jinja_env = Environment(
+            loader=FileSystemLoader(MACROS_DIR),
+            extensions=["jinja2.ext.do"],
+        )
+        exceptions = mock.Mock()
+        exceptions.raise_compiler_error.side_effect = MockCompilerError
+        self.adapter = mock.Mock()
+        self.set_scan_per_schema(True)
+        self.default_context = {
+            "exceptions": exceptions,
+            "adapter": self.adapter,
+            "return": lambda r: r,
+        }
+        self.template = self.jinja_env.get_template("catalog.sql", globals=self.default_context)
+
+    def set_scan_per_schema(self, enabled):
+        self.adapter.behavior.snowflake_catalog_scan_per_schema.no_warn = enabled
+
+    def __run_macro(self, name, *args):
+        value = getattr(self.template.module, name)(*args)
+        return re.sub(r"\s+", " ", value.strip())
+
+    # -- the per-schema scans -------------------------------------------------
+
+    def test_schemas_emit_one_scan_per_schema(self):
+        sql = self.__run_macro(
+            "snowflake__pruned_catalog_scan_by_schemas_sql",
+            INFORMATION_SCHEMA,
+            "tables",
+            {"foo", "bar"},
+        )
+
+        # one pruned scan per schema, unioned -- never a disjunction across schemas.
+        # note the unquoted `table_schema`: see `test_pruned_scans_do_not_quote_columns`
+        assert sql == (
+            '( select * from "my_database".information_schema.tables '
+            "where ((table_schema ilike 'BAR' and upper(table_schema) = upper('BAR') )) "
+            "union all "
+            'select * from "my_database".information_schema.tables '
+            "where ((table_schema ilike 'FOO' and upper(table_schema) = upper('FOO') )) "
+            ") as pruned_tables"
+        )
+
+    def test_single_schema_emits_no_union(self):
+        sql = self.__run_macro(
+            "snowflake__pruned_catalog_scan_by_schemas_sql", INFORMATION_SCHEMA, "tables", {"foo"}
+        )
+        assert "union" not in sql
+
+    def test_schemas_deduplicated_case_insensitively(self):
+        sql = self.__run_macro(
+            "snowflake__pruned_catalog_scan_by_schemas_sql",
+            INFORMATION_SCHEMA,
+            "tables",
+            ["foo", "FOO"],
+        )
+        assert "union" not in sql
+
+    def test_relations_grouped_by_schema(self):
+        relations = [
+            MockRelation("foo", "table_a"),
+            MockRelation("bar", "table_b"),
+            MockRelation("foo", "table_c"),
+        ]
+        sql = self.__run_macro(
+            "snowflake__pruned_catalog_scan_by_relations_sql",
+            INFORMATION_SCHEMA,
+            "columns",
+            relations,
+        )
+
+        # two schemas -> two scans, and the schema match is a top-level conjunct in each
+        assert sql.count("union all") == 1
+        assert sql.count("information_schema.columns") == 2
+        assert sql.count("ilike 'foo'") == 1
+        assert sql.count("ilike 'bar'") == 1
+        assert "table_a" in sql and "table_b" in sql and "table_c" in sql
+
+    def test_relations_sql_does_not_depend_on_input_order(self):
+        # `relations` reaches the macro as a set, so the emitted sql must not depend on ordering
+        a = MockRelation("foo", "table_a")
+        b = MockRelation("bar", "table_b")
+        c = MockRelation("foo", "table_c")
+
+        def render(relations):
+            return self.__run_macro(
+                "snowflake__pruned_catalog_scan_by_relations_sql",
+                INFORMATION_SCHEMA,
+                "tables",
+                relations,
+            )
+
+        assert render([a, b, c]) == render([c, b, a])
+
+    def test_pruned_scans_do_not_quote_columns(self):
+        """
+        The pruned scans filter the information_schema view directly, and that view's real
+        columns are uppercase. `"table_schema"` only resolves on the outer select, where the
+        projection has aliased it -- against the view it is `invalid identifier`, which fails
+        the whole catalog query. So no predicate inside a pruned scan may be quoted.
+        """
+        relations = [MockRelation("foo", "table_a"), MockRelation("bar", "table_b")]
+        rendered = [
+            self.__run_macro(
+                "snowflake__pruned_catalog_scan_by_schemas_sql",
+                INFORMATION_SCHEMA,
+                "tables",
+                {"foo", "bar"},
+            ),
+            self.__run_macro(
+                "snowflake__pruned_catalog_scan_by_relations_sql",
+                INFORMATION_SCHEMA,
+                "columns",
+                relations,
+            ),
+        ]
+
+        for sql in rendered:
+            assert '"table_schema"' not in sql
+            assert '"table_name"' not in sql
+            assert "table_schema ilike" in sql
+
+    # -- the where clause ----------------------------------------------------
+
+    def test_relation_identifiers_share_one_schema_predicate(self):
+        relations = [MockRelation("foo", "table_a"), MockRelation("foo", "table_c")]
+        sql = self.__run_macro("snowflake__pruned_catalog_relations_where_clause_sql", relations)
+
+        assert sql == (
+            "where table_schema ilike 'foo' and upper(table_schema) = upper('foo') "
+            "and ((table_name ilike 'table_a' and upper(table_name) = upper('table_a') ) "
+            "or (table_name ilike 'table_c' and upper(table_name) = upper('table_c') ))"
+        )
+
+    def test_relation_without_identifier_selects_whole_schema(self):
+        relations = [MockRelation("foo", "table_a"), MockRelation("foo")]
+        sql = self.__run_macro("snowflake__pruned_catalog_relations_where_clause_sql", relations)
+
+        assert "table_name" not in sql
+        assert sql == "where table_schema ilike 'foo' and upper(table_schema) = upper('foo')"
+
+    def test_relation_without_schema_raises(self):
+        relations = [MockRelation(None, "table_a")]
+
+        with self.assertRaises(MockCompilerError):
+            self.__run_macro("snowflake__pruned_catalog_relations_where_clause_sql", relations)
+
+        self.default_context["exceptions"].raise_compiler_error.assert_called_once_with(
+            "`get_catalog_relations` requires a list of relations, each with a schema"
+        )
+
+    def test_relations_from_mixed_schemas_raise(self):
+        # the where clause pins a single schema, so mixed input would silently drop the rest
+        relations = [MockRelation("foo", "table_a"), MockRelation("bar", "table_b")]
+
+        with self.assertRaises(MockCompilerError):
+            self.__run_macro("snowflake__pruned_catalog_relations_where_clause_sql", relations)
+
+        self.default_context["exceptions"].raise_compiler_error.assert_called_once_with(
+            "`snowflake__pruned_catalog_relations_where_clause_sql` requires relations from a"
+            " single schema, got: BAR, FOO"
+        )
+
+    # -- statement size ------------------------------------------------------
+
+    def test_projection_is_not_repeated_per_schema(self):
+        """
+        Snowflake caps a statement at 1MB and the `tables` projection is ~1.5kB, so inlining it
+        per schema would blow the limit at a few hundred schemas -- the exact case this flag
+        targets. Only the scan may repeat.
+        """
+        schemas = {f"schema_{i}" for i in range(300)}
+
+        tables = self.__run_macro(
+            "snowflake__catalog_tables_by_schemas_sql", INFORMATION_SCHEMA, schemas
+        )
+        columns = self.__run_macro(
+            "snowflake__catalog_columns_by_schemas_sql", INFORMATION_SCHEMA, schemas
+        )
+
+        assert tables.count(TABLES_PROJECTION_MARKER) == 1
+        assert columns.count(COLUMNS_PROJECTION_MARKER) == 1
+        assert tables.count("union all") == 299
+        assert columns.count("union all") == 299
+
+    def test_projection_is_not_repeated_per_relation_group(self):
+        relations = [MockRelation(f"schema_{i}", f"table_{i}") for i in range(300)]
+
+        tables = self.__run_macro(
+            "snowflake__catalog_tables_by_relations_sql", INFORMATION_SCHEMA, relations
+        )
+        columns = self.__run_macro(
+            "snowflake__catalog_columns_by_relations_sql", INFORMATION_SCHEMA, relations
+        )
+
+        assert tables.count(TABLES_PROJECTION_MARKER) == 1
+        assert columns.count(COLUMNS_PROJECTION_MARKER) == 1
+        assert tables.count("union all") == 299
+        assert columns.count("union all") == 299
+
+    def test_statement_size_stays_well_under_snowflake_limit(self):
+        # 1000 schemas in one database is large but not unheard of; both ctes go in one statement
+        schemas = {f"schema_{i}" for i in range(1000)}
+
+        rendered = getattr(self.template.module, "snowflake__catalog_tables_by_schemas_sql")(
+            INFORMATION_SCHEMA, schemas
+        ) + getattr(self.template.module, "snowflake__catalog_columns_by_schemas_sql")(
+            INFORMATION_SCHEMA, schemas
+        )
+
+        assert len(rendered) < 1_000_000
+
+    # -- the projection macros still default to the information schema -------
+
+    def test_projection_defaults_to_information_schema_view(self):
+        tables = self.__run_macro("snowflake__get_catalog_tables_sql", INFORMATION_SCHEMA)
+        columns = self.__run_macro("snowflake__get_catalog_columns_sql", INFORMATION_SCHEMA)
+
+        assert tables.endswith('from "my_database".information_schema.tables')
+        assert columns.endswith('from "my_database".information_schema.columns')
+
+    def test_flag_does_not_change_the_projection(self):
+        """
+        The two ctes are joined on their projected columns, so the flag must only move the
+        filtering -- never touch the select list.
+        """
+        for macro in (
+            "snowflake__catalog_tables_by_schemas_sql",
+            "snowflake__catalog_columns_by_schemas_sql",
+        ):
+            self.set_scan_per_schema(True)
+            pruned = self.__run_macro(macro, INFORMATION_SCHEMA, {"foo", "bar"})
+            self.set_scan_per_schema(False)
+            legacy = self.__run_macro(macro, INFORMATION_SCHEMA, {"foo", "bar"})
+
+            assert pruned.split(" from ")[0] == legacy.split(" from ")[0]
+
+    # -- flag off: unchanged behaviour --------------------------------------
+
+    def test_flag_disabled_keeps_single_scan_across_schemas(self):
+        self.set_scan_per_schema(False)
+
+        sql = self.__run_macro(
+            "snowflake__catalog_tables_by_schemas_sql", INFORMATION_SCHEMA, ["foo", "bar"]
+        )
+
+        assert "union" not in sql
+        # the legacy predicate stays quoted: it sits on the projection, whose aliases are
+        # quoted lowercase, not on the information_schema view
+        assert sql.endswith(
+            'from "my_database".information_schema.tables '
+            "where ((\"table_schema\" ilike 'foo' and upper(\"table_schema\") = upper('foo') ) "
+            "or (\"table_schema\" ilike 'bar' and upper(\"table_schema\") = upper('bar') ))"
+        )
+
+    def test_flag_disabled_keeps_schema_identifier_pairs(self):
+        self.set_scan_per_schema(False)
+        relations = [MockRelation("foo", "table_a"), MockRelation("bar")]
+
+        sql = self.__run_macro(
+            "snowflake__catalog_columns_by_relations_sql", INFORMATION_SCHEMA, relations
+        )
+
+        # legacy path pairs each schema with its own identifier, so mixed schemas stay correct
+        assert "union" not in sql
+        assert sql.endswith(
+            'from "my_database".information_schema.columns where ( ( '
+            "\"table_schema\" ilike 'foo' and upper(\"table_schema\") = upper('foo') "
+            "and \"table_name\" ilike 'table_a' and upper(\"table_name\") = upper('table_a') "
+            ") or ( \"table_schema\" ilike 'bar' and upper(\"table_schema\") = upper('bar') ) )"
+        )
+
+    def test_flag_disabled_still_requires_a_schema(self):
+        self.set_scan_per_schema(False)
+
+        with self.assertRaises(MockCompilerError):
+            self.__run_macro(
+                "snowflake__catalog_tables_by_relations_sql",
+                INFORMATION_SCHEMA,
+                [MockRelation(None, "table_a")],
+            )

--- a/dbt-snowflake/tests/unit/test_snowflake_adapter.py
+++ b/dbt-snowflake/tests/unit/test_snowflake_adapter.py
@@ -104,6 +104,13 @@ class TestSnowflakeAdapter(unittest.TestCase):
         self.patcher.stop()
         self.load_state_check.stop()
 
+    def test_catalog_scan_per_schema_flag_is_registered_and_off_by_default(self):
+        flags = {flag["name"]: flag for flag in self.adapter._behavior_flags}
+
+        assert "snowflake_catalog_scan_per_schema" in flags
+        assert flags["snowflake_catalog_scan_per_schema"]["default"] is False
+        assert self.adapter.behavior.snowflake_catalog_scan_per_schema.no_warn is False
+
     def test_quoting_on_drop_schema(self):
         relation = SnowflakeAdapter.Relation.create(
             database="test_database",


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!-- Draft: issue number and docs ticket still needed before this can merge. -->

### Problem

`snowflake__get_catalog` filters its per-database query to the schemas in
`manifest.get_used_schemas()` with an `or` across them. Snowflake prunes to a schema's
metadata only when the predicate matches a single schema, so that `or` can fall back to
materializing the whole database's metadata.

On a reported account, two schemas returning the same 386 rows cost ~4s queried
individually and **~275s together, scanning 102MB instead of 16KB** — enough to exceed a
scheduled job's timeout and block a nightly batch. Warehouse size made no difference.

### Solution

Add `snowflake_catalog_scan_per_schema`, **off by default**. When enabled, both catalog
macros scan one schema at a time and union the results, so every scan keeps a single-schema
predicate. Still one statement returning one result set.

Two points for review:

- Only the scan repeats per schema, not the ~1.5kB projection — inlining that per branch
  would exceed Snowflake's 1MB statement limit at a few hundred schemas.
- Predicates inside the pruned scans are unquoted. `"table_schema"` resolves on the outer
  select, where the projection has aliased it, but raises `invalid identifier` against an
  `information_schema` view. The default path is unchanged and still quoted.

### Tradeoff

Each schema in use adds a scan, and the fixed cost of resolving `information_schema` is
paid per union branch. Against a 4,071-schema test database the flag scans ~18x less
metadata but runs **~10x slower** at 25 used schemas (397s vs 39s), and times out past 600s
at 100 where the default takes 45s.

So: large win where few schemas are in use against a metadata-heavy database, significant
loss where many are. Hence opt-in. A schema-count cap falling back to the `or` form would
make it safer to enable broadly — happy to add one if reviewers want it.

### Testing

- Unit tests over the generated SQL for both flag states, including a regression guard on
  the identifier quoting above.
- Functional tests against Snowflake across two schemas, with the same assertions run
  flag-on and flag-off; row counts match at four schema counts.
- `docs generate` compiles by default, which sends even a tiny project down the
  by-relations path, so the by-schemas test passes `--no-compile`.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX

🤖 Generated with [Claude Code](https://claude.com/claude-code)
