### PR TITLE
Fix _dbt_max_partition false-positive detection in BigQuery incremental (rebase of #1908)

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fixes-20260814-120000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20260814-120000.yaml
@@ -1,0 +1,11 @@
+kind: Fixes
+body: Only declare `_dbt_max_partition` when the compiled model actually references
+  it in executable SQL, not when the token merely appears in comments or string
+  literals, and only when the target table already exists. Previously a mention in
+  a comment made incremental (insert_overwrite) models emit the declare block on
+  their first-ever build, which failed with "Table ... was not found" because it
+  selects `max()` from the not-yet-created target.
+time: 2026-08-14T12:00:00.000000+02:00
+custom:
+    Author: vittorfp ElhadiCherifi95
+    Issue: "580 1907"

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/incremental_strategy/common.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/incremental_strategy/common.sql
@@ -13,9 +13,9 @@
   {%- set compiled_code_without_comments = modules.re.sub("(?s)/\\*.*?\\*/|--[^\\n\\r]*|#[^\\n\\r]*", " ", compiled_code) -%}
   {%- set compiled_code_without_comments_or_strings = modules.re.sub("'(?:''|[^'])*'", " ", compiled_code_without_comments) -%}
   {%- set uses_dbt_max_partition = modules.re.search("(^|[^A-Za-z0-9_])_dbt_max_partition([^A-Za-z0-9_]|$)", compiled_code_without_comments_or_strings) is not none -%}
-  {%- set relation_exists = load_relation(relation) is not none -%}
 
-  {%- if uses_dbt_max_partition and relation_exists -%}
+  {#- `and` short-circuits, so the relation lookup only runs when the token is used. -#}
+  {%- if uses_dbt_max_partition and load_relation(relation) is not none -%}
 
     declare _dbt_max_partition {{ partition_by.data_type_for_partition() }} default (
       select max({{ partition_by.field }}) from {{ this }}

--- a/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/incremental_strategy/common.sql
+++ b/dbt-bigquery/src/dbt/include/bigquery/macros/materializations/incremental_strategy/common.sql
@@ -1,7 +1,21 @@
 {% macro declare_dbt_max_partition(relation, partition_by, compiled_code, language='sql') %}
 
   {#-- TODO: revisit partitioning with python models --#}
-  {%- if '_dbt_max_partition' in compiled_code and language == 'sql' -%}
+  {%- if language != 'sql' -%}
+    {{ return('') }}
+  {%- endif -%}
+
+  {#-
+    Ignore mentions in comments/quoted literals when deciding whether to declare
+    _dbt_max_partition. GoogleSQL supports /* */ blocks plus `--` and `#` line
+    comments.
+  -#}
+  {%- set compiled_code_without_comments = modules.re.sub("(?s)/\\*.*?\\*/|--[^\\n\\r]*|#[^\\n\\r]*", " ", compiled_code) -%}
+  {%- set compiled_code_without_comments_or_strings = modules.re.sub("'(?:''|[^'])*'", " ", compiled_code_without_comments) -%}
+  {%- set uses_dbt_max_partition = modules.re.search("(^|[^A-Za-z0-9_])_dbt_max_partition([^A-Za-z0-9_]|$)", compiled_code_without_comments_or_strings) is not none -%}
+  {%- set relation_exists = load_relation(relation) is not none -%}
+
+  {%- if uses_dbt_max_partition and relation_exists -%}
 
     declare _dbt_max_partition {{ partition_by.data_type_for_partition() }} default (
       select max({{ partition_by.field }}) from {{ this }}

--- a/dbt-bigquery/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
+++ b/dbt-bigquery/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
@@ -190,6 +190,29 @@ where date_day >= _dbt_max_partition
 {% endif %}
 """.lstrip()
 
+overwrite_comment_only_max_partition_token_sql = """
+{{
+    config(
+        materialized="incremental",
+        incremental_strategy='insert_overwrite',
+        on_schema_change='append_new_columns',
+        partition_by={
+            "field": "date_day",
+            "data_type": "date"
+        }
+    )
+}}
+
+with data as (
+    select 1 as id, cast('2020-01-01' as date) as date_day
+)
+
+-- _dbt_max_partition appears in a comment and must not trigger declaration.
+/* _dbt_max_partition in block comments should also be ignored. */
+# _dbt_max_partition in GoogleSQL hash comments should also be ignored.
+select * from data
+""".lstrip()
+
 overwrite_day_sql = """
 {{
     config(

--- a/dbt-bigquery/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/dbt-bigquery/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -30,6 +30,7 @@ from tests.functional.adapter.incremental.incremental_strategy_fixtures import (
     overwrite_day_with_time_ingestion_sql,
     overwrite_day_with_time_partition_datetime_sql,
     overwrite_static_day_sql,
+    overwrite_comment_only_max_partition_token_sql,
 )
 
 
@@ -186,3 +187,24 @@ class TestBigQueryMergeNullUniqueKeyTruthyNullsEquals:
 
         rows = [(row[0], row[1]) for row in table.rows]
         assert rows == [(1, "b_updated"), (None, "a_updated")]
+
+
+class TestBigQueryMaxPartitionCommentToken:
+    """Regression for dbt-labs/dbt-adapters#1907 / #580: a `_dbt_max_partition`
+    token appearing only in comments must not trigger the declare block, which
+    fails with table-not-found on a model's first-ever build."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_overwrite_comment_token.sql": (
+                overwrite_comment_only_max_partition_token_sql
+            ),
+        }
+
+    def test_first_run_and_incremental_run_succeed(self, project):
+        first_run = run_dbt(["run"])
+        assert len(first_run) == 1
+
+        second_run = run_dbt(["run"])
+        assert len(second_run) == 1


### PR DESCRIPTION
resolves #580
resolves #1907
supersedes #1908 (conflicting with main since April; branch can't be updated by non-authors — original fix by @ElhadiCherifi95, kept as commit co-author)

### Problem

`declare_dbt_max_partition()` decides whether to emit

```sql
declare _dbt_max_partition <type> default (
  select max(<partition_field>) from <target>
  where <partition_field> is not null
);
```

via a raw substring check (`'_dbt_max_partition' in compiled_code`) over the **entire compiled model, comments included**. A model that merely mentions the token in a SQL comment or string literal emits the declare unconditionally — and on the model's **first-ever build** the declare selects from a target table that doesn't exist yet:

```
Not found: Table <project>:<dataset>.<model> was not found in location EU at [2:41]
```

This took down a production deploy for us at Epidemic Sound yesterday (2026-08-13): a brand-new `insert_overwrite` model's SQL header documented our incremental-window logic in prose and mentioned the variable name. First reported in Feb 2024 (#580).

### Solution

Same approach as #1908:

- strip `/* */` block comments, `--` line comments, and single-quoted string literals from `compiled_code` before detection
- use a word-boundary regex for the token search (so `my_dbt_max_partition_col` doesn't match)
- only emit the declare when `load_relation(relation)` shows the target actually exists

Additions over #1908:

- also strip `#` line comments, which GoogleSQL supports ([lexical docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#comments)) — the original patch missed these
- test fixture extended with a `#`-comment case
- changelog entry (changie)
- rebased onto current `main` (the functional test file had drifted, which is why #1908 shows conflicts)

### Testing

- Regex behavior unit-checked against 11 cases: block/line/hash comment mentions (no declare), string-literal mentions incl. `''`-escaped quotes (no declare), genuine executable references (declare), word-boundary non-matches, and our exact production docstring (no declare).
- Functional regression test `TestBigQueryMaxPartitionCommentToken` runs an `insert_overwrite` model whose only token occurrences are in comments, and asserts both the first run (table doesn't exist yet — the failing case today) and the incremental second run succeed.
- Reproduced the original failure against BigQuery with dbt 1.10 (with and without `--full-refresh`) and confirmed the patched macro no longer emits the declare for comment-only mentions.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required or relevant for this PR.
- [x] This PR has no interface changes (e.g., macros, CLI, logs, JSON artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.
- [x] This PR includes [type annotations](https://docs.python.org/3/library/typing.html) for new or modified functions.