### PR TITLE
fix: respect an explicitly empty cache_schemas set in relation-cache population

### DIFF
--- a/dbt-adapters/.changes/unreleased/Fixes-20260814-123426.yaml
+++ b/dbt-adapters/.changes/unreleased/Fixes-20260814-123426.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Respect an explicitly empty `cache_schemas` set in `_relations_cache_for_schemas` instead of treating it the same as `None`, so `--cache-selected-only` is honored for `dbt test`
+time: 2026-08-14T12:34:26.793794-04:00
+custom:
+    Author: dataders claude
+    Issue: "2126"

--- a/dbt-adapters/src/dbt/adapters/base/impl.py
+++ b/dbt-adapters/src/dbt/adapters/base/impl.py
@@ -661,7 +661,12 @@ class BaseAdapter(metaclass=AdapterMeta):
         """Populate the relations cache for the given schemas. Returns an
         iterable of the schemas populated, as strings.
         """
-        if not cache_schemas:
+        # `cache_schemas=set()` is a meaningful "nothing to cache" (e.g. a
+        # selection with no relational nodes), distinct from `None` ("no
+        # schemas were specified, compute the default"). Treating both as
+        # falsy silently expands an intentionally empty selection to every
+        # schema in the project.
+        if cache_schemas is None:
             cache_schemas = self._get_cache_schemas(relation_configs)
         with executor(self.config) as tpe:
             futures: List[Future[List[BaseRelation]]] = []

--- a/dbt-adapters/tests/unit/test_base_adapter.py
+++ b/dbt-adapters/tests/unit/test_base_adapter.py
@@ -494,3 +494,85 @@ class TestGrantsMacroQuotesGrantees:
         # Verify the SQL structure is correct
         assert result.startswith("revoke select on")
         assert "from" in result
+
+
+class TestRelationsCacheForSchemas:
+    @pytest.fixture
+    def adapter(self):
+        config = MagicMock()
+
+        class TestAdapter(BaseAdapter):
+            def convert_boolean_type(self, *args, **kwargs):
+                return None
+
+            def convert_date_type(self, *args, **kwargs):
+                return None
+
+            def convert_datetime_type(self, *args, **kwargs):
+                return None
+
+            def convert_number_type(self, *args, **kwargs):
+                return None
+
+            def convert_text_type(self, *args, **kwargs):
+                return None
+
+            def convert_time_type(self, *args, **kwargs):
+                return None
+
+            def create_schema(self, *args, **kwargs):
+                return None
+
+            def date_function(self, *args, **kwargs):
+                return None
+
+            def drop_relation(self, *args, **kwargs):
+                return None
+
+            def drop_schema(self, *args, **kwargs):
+                return None
+
+            def expand_column_types(self, *args, **kwargs):
+                return None
+
+            def get_columns_in_relation(self, *args, **kwargs):
+                return None
+
+            def is_cancelable(self, *args, **kwargs):
+                return False
+
+            def list_relations_without_caching(self, *args, **kwargs):
+                return []
+
+            def list_schemas(self, *args, **kwargs):
+                return []
+
+            def quote(self, *args, **kwargs):
+                return ""
+
+            def rename_relation(self, *args, **kwargs):
+                return None
+
+            def truncate_relation(self, *args, **kwargs):
+                return None
+
+        return TestAdapter(config, MagicMock())
+
+    def test_empty_cache_schemas_is_not_expanded_to_default(self, adapter):
+        """An explicitly empty `cache_schemas` means "nothing to cache" and
+        must not be re-expanded to every schema in the project (the bug
+        behind dbt-labs/dbt-adapters#2126)."""
+        with patch.object(adapter, "_get_cache_schemas") as mock_get_cache_schemas:
+            adapter._relations_cache_for_schemas([], cache_schemas=set())
+
+        mock_get_cache_schemas.assert_not_called()
+
+    def test_none_cache_schemas_falls_back_to_computed_schemas(self, adapter):
+        """`cache_schemas=None` (the default) still computes the project-wide
+        default via `_get_cache_schemas`."""
+        with patch.object(
+            adapter, "_get_cache_schemas", return_value=set()
+        ) as mock_get_cache_schemas:
+            adapter._relations_cache_for_schemas([], cache_schemas=None)
+
+        mock_get_cache_schemas.assert_called_once_with([])


### PR DESCRIPTION
resolves #2126

### Problem

`BaseAdapter._relations_cache_for_schemas` uses `if not cache_schemas:` to decide whether to fall back to computing the default (project-wide) set of schemas to introspect. That treats an explicitly empty `cache_schemas` set the same as `cache_schemas=None`.

For `dbt test` with `--cache-selected-only` on, dbt-core's `get_model_schemas` legitimately returns an *empty set* for the selection, because test nodes aren't `is_relational`. That empty set means "no schemas are needed for this selection" — but the falsy check re-expands it to every schema in the project via `_get_cache_schemas(relation_configs)`, making `--cache-selected-only` a no-op for `dbt test`.

### Fix

Use `cache_schemas is None` instead of `not cache_schemas`, so an explicitly empty set is respected as "nothing to cache," while `None` (the default, when the caller didn't specify anything) still falls back to computing the full set.

### Scope

This is a companion fix to dbt-labs/dbt-core#15915, which covers the same `--cache-selected-only` gap for `compile`/`show`/`docs generate` in `dbt-core`. That fix didn't touch this file because the `dbt test` gap lives here in `dbt-adapters` and changes behavior specifically for `dbt test`, which the original reporter flagged as needing a maintainer's call (see [dbt-labs/dbt-core#12944 (comment)](https://github.com/dbt-labs/dbt-core/issues/12944#issuecomment-5222202417)).

`postgres` and `redshift` override `_relations_cache_for_schemas` but only pass `cache_schemas` through to `super()` unmodified, so they pick up this fix automatically without needing their own change.

### Testing

- Added a changelog entry
- Added `TestRelationsCacheForSchemas` in `tests/unit/test_base_adapter.py` asserting: an empty `cache_schemas` set does *not* trigger `_get_cache_schemas`, and `cache_schemas=None` still does
- Full `tests/unit/` suite: 164 passed
- `black --check --line-length=99 --target-version=py39` on the changed files: clean
