### PR TITLE
docs: fix typo in test.env.example filename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ This will vary by package; please refer to the package's `CONTRIBUTING.md` for m
 ### Configure environment variables
 
 Each adapter requires certain environment variables to connect to its platform.
-The template is contained in the respective `test.env.exmaple` file.
+The template is contained in the respective `test.env.example` file.
 If you already ran `hatch run setup` you should have a `test.env` file in the package root.
 Update the environment variables in this file with your instance's connection credentials.
 


### PR DESCRIPTION
resolves N/A

### Problem

CONTRIBUTING.md contains a typo `test.env.exmaple` when referencing the environment variable template file. The actual file is named `test.env.example`.

### Solution

Fixed the typo: `test.env.exmaple` → `test.env.example`.

### Checklist
- [x] I have read the contributing guide and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX