### PR TITLE
chore(deps): relax sqlparse ceiling to <0.7.0 for dbt-redshift

### DIFF
--- a/dbt-redshift/.changes/unreleased/Dependencies-20260820-000000.yaml
+++ b/dbt-redshift/.changes/unreleased/Dependencies-20260820-000000.yaml
@@ -1,0 +1,8 @@
+kind: Dependencies
+body: Relax the `sqlparse` upper bound from `<0.6.0` to `<0.7.0` so dbt-redshift can
+  co-install with dbt-core, which now allows `sqlparse` 0.6.0. The floor stays at `0.5.0`
+  so no upgrade is forced.
+time: 2026-08-20T00:00:00.000000+05:30
+custom:
+  Author: ash2shukla
+  PR: "2130"

--- a/dbt-redshift/pyproject.toml
+++ b/dbt-redshift/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
     "dbt-core>=1.8.0b3,<2.0",
     # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
-    "sqlparse>=0.5.0,<0.6.0",
+    "sqlparse>=0.5.0,<0.7.0",
     "agate",
     "requests",
 ]


### PR DESCRIPTION
## Problem

`dbt-redshift` caps `sqlparse` at `<0.6.0`:

```toml
# dbt-redshift/pyproject.toml
"sqlparse>=0.5.0,<0.6.0",
```

dbt-core is moving to `sqlparse>=0.5.5,<0.7.0` in [dbt-core#15989](https://github.com/dbt-labs/dbt-core/pull/15989) to allow 0.6.0, the release carrying the parser denial-of-service fixes (CVE-2026-54284, CVE-2026-59893, CVE-2026-59894, CVE-2026-71491).

Once that lands, an environment installing both dbt-core and dbt-redshift can still resolve (both permit 0.5.5), but **dbt-redshift blocks anyone from actually picking up 0.6.0** — the intersection is pinned below the fixed release. Any environment that upgrades sqlparse to 0.6.0 for the CVE fixes will fail to resolve against dbt-redshift.

## Change

Relax the ceiling only:

```diff
-    "sqlparse>=0.5.0,<0.6.0",
+    "sqlparse>=0.5.0,<0.7.0",
```

The `>=0.5.0` floor is deliberately left alone, so this forces no upgrade — 0.5.x users are unaffected, and 0.6.0 becomes reachable.

## Why this needs care

`sqlparse` is a real functional dependency for this adapter, not an incidental import. Two call sites in `dbt-redshift/src/dbt/adapters/redshift/connections.py`:

- `add_query()` — `queries = sqlparse.split(sql)`, on the hot path for **every** Redshift query
- `_initialize_sqlparse_lexer()` — `Lexer.get_default_instance()`, per [dbt-redshift#710](https://github.com/dbt-labs/dbt-redshift/issues/710) / [dbt-core#8215](https://github.com/dbt-labs/dbt-core/pull/8215)

## Validation

Checked both call sites against sqlparse 0.6.0 in a clean 3.11 venv:

| Check | 0.6.0 result |
|---|---|
| `sqlparse.split('select 1; select 2;\n-- comment\nselect 3;')` | `['select 1;', 'select 2;', '-- comment\nselect 3;']` — unchanged |
| `hasattr(Lexer, 'get_default_instance')` | `True`; `get_default_instance()` succeeds |
| `grouping.MAX_GROUPING_DEPTH` / `MAX_GROUPING_TOKENS` | `100` / `10000` — **identical to 0.5.5**, so no new grouping limits are introduced |

The grouping limits are worth calling out explicitly: they were already present in 0.5.5, so 0.6.0 does not tighten parser limits relative to what dbt-redshift ships against today.

## Note for reviewers

The comment above this pin reads "don't pin to avoid version conflicts with dbt-core" — which is exactly the conflict this PR resolves. I left the comment and the floor untouched to keep the diff minimal, but if the intent was truly to leave `sqlparse` unpinned and inherit it from dbt-core, that is worth a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)