### PR TITLE
ci: make version bump idempotent so failed releases can be retried

### DIFF
--- a/.github/workflows/_bump-version.yml
+++ b/.github/workflows/_bump-version.yml
@@ -83,11 +83,23 @@ jobs:
 
             - name: "Bump version"
               id: version
+              # Skip the bump when the branch is already at the target version, so a
+              # release that failed *after* this step (e.g. in publish) can be retried
+              # with the same version instead of getting stuck. `hatch version X` errors
+              # out with "not higher than the original version" in that case. The steps
+              # below already no-op when final == initial.
               run: |
-                  echo "initial=$(hatch version)" >> $GITHUB_OUTPUT
-                  hatch version ${{ inputs.version }}
+                  initial="$(hatch version)"
+                  echo "initial=$initial" >> $GITHUB_OUTPUT
+                  if [ "$initial" = "$TARGET_VERSION" ]; then
+                      echo "::notice title=Version unchanged::Already at $TARGET_VERSION; skipping bump."
+                  else
+                      hatch version "$TARGET_VERSION"
+                  fi
                   echo "final=$(hatch version)" >> $GITHUB_OUTPUT
               working-directory: ./${{ inputs.package }}
+              env:
+                  TARGET_VERSION: ${{ inputs.version }}
 
             - name: "Update dbt-athena-community version"
               run: sed -i "s/$INITIAL/$FINAL/g" dbt-athena-community/pyproject.toml


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/# N/A

### Problem

A release that fails *after* the version bump cannot be retried with the same version — it gets permanently stuck in `bump-version`.

`_bump-version.yml` runs `hatch version <target>` unconditionally. When the branch is already at the target, hatch refuses:

```
ValueError: Version `1.11.1` is not higher than the original version `1.11.1`
```

The bump is committed *before* publishing, so any later failure leaves the branch at the new version with nothing on PyPI. Every subsequent attempt at that version then dies in `bump-version` rather than reaching the step that actually failed.

This is what happened to the `dbt-redshift` 1.11.1 release:

1. [Run 32431696158](https://github.com/dbt-labs/dbt-adapters/actions/runs/32431696158) committed `20c2ea475` ("Bump version from 1.11.0 to 1.11.1") to `stable` at 00:11:56, then failed at "Publish to PyPI" (separate issue, fixed in #2131).
2. `stable` is now at 1.11.1 while PyPI has no 1.11.1 — 1.11.0 is still latest.
3. The retry, [run 32449811965](https://github.com/dbt-labs/dbt-adapters/actions/runs/32449811965/job/96676081196), failed in `bump-version / main` with the error above — it never got as far as publishing.

The workflow already anticipates a no-op bump: both "Update dbt-athena-community version" and "Commit version bump" are guarded by `if: steps.version.outputs.final != steps.version.outputs.initial`. Only the `hatch version` call itself aborts, so that intent is unreachable.

### Solution

Skip the bump when the branch is already at the target version, and emit a `::notice` instead. `initial` then equals `final`, the two guarded steps no-op as designed, and the release proceeds to publish — making a failed release retryable with the same version.

Also pass the version via `env:` rather than interpolating `${{ inputs.version }}` directly into the `run:` script, consistent with how `INITIAL`/`FINAL` are handled in the next step.

Behavior is unchanged on the normal path: when the target differs from the current version, `hatch version` runs exactly as before.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me.
- [x] I have run this code in development, and it appears to resolve the stated issue.
- [ ] This PR includes tests, or tests are not required/relevant for this PR. — release-workflow change; not reachable by unit or integration tests.
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc.) or this PR has already received feedback and approval from Product or DX.

### Notes

- Independent of #2131. That PR fixes *why* the 1.11.1 publish failed (stale `gh-action-pypi-publish` pin rejecting `Metadata-Version: 2.5`); this one fixes the pipeline getting stuck on retry. The twine mismatch merely exposed this.
- To unblock 1.11.1 without waiting on this, `_publish-pypi.yml` is separately dispatchable and `stable` already carries the bump, so `package=dbt-redshift deploy-to=prod branch=stable` publishes it directly.
- Not addressed here: the bump commits to `stable` before the artifact is known-good, so a failed publish still leaves the branch ahead of PyPI. Making the bump idempotent is the minimal fix; reordering so the version is committed only after a successful upload would be a larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
