### PR TITLE
fix(bigquery): keep partition elimination for int64 range insert_overwrite

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fixes-20260821-120000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20260821-120000.yaml
@@ -1,0 +1,9 @@
+kind: Fixes
+body: Restore partition elimination for insert_overwrite on int64 range partitioned
+    tables with an interval of 1. The partition column is no longer wrapped in `MOD()`
+    arithmetic, which BigQuery cannot use as a partition filter and which tables
+    configured with `require_partition_filter=true` reject outright.
+time: 2026-08-21T12:00:00.000000+00:00
+custom:
+    Author: tauhid621
+    Issue: "2121"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/relation_configs/_partition.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/relation_configs/_partition.py
@@ -75,9 +75,16 @@ class PartitionConfig(dbtClassMixin):
         boundary using: value - MOD(value - range_start, range_interval).
         This prevents generating excessively large arrays of distinct values
         when computing partitions for replacement in insert_overwrite.
+
+        An interval of 1 normalizes to a no-op, so the raw column is returned
+        unwrapped to preserve partition elimination.
         """
         # int64 range partitions: normalize to partition start boundary
-        if self.data_type == "int64" and self.range is not None:
+        if (
+            self.data_type == "int64"
+            and self.range is not None
+            and self.range["interval"] not in (1, "1")
+        ):
             column = self.render(alias)
             start = self.range["start"]
             interval = self.range["interval"]

--- a/dbt-bigquery/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
+++ b/dbt-bigquery/tests/functional/adapter/incremental/incremental_strategy_fixtures.py
@@ -460,6 +460,53 @@ where date_int >= _dbt_max_partition
 {% endif %}
 """.lstrip()
 
+overwrite_range_with_require_partition_sql = """
+{{
+    config(
+        materialized="incremental",
+        incremental_strategy='insert_overwrite',
+        cluster_by="id",
+        partition_by={
+            "field": "date_int",
+            "data_type": "int64",
+            "range": {
+                "start": 20200101,
+                "end": 20200110,
+                "interval": 1
+            }
+        },
+        post_hook="
+            create or replace view `{{ schema }}.incremental_overwrite_range_with_require_partition_view`
+            as select * from {{ this }} where date_int is null or date_int is not null
+        ",
+        require_partition_filter=true
+    )
+}}
+
+
+with data as (
+
+    {% if not is_incremental() %}
+
+        select 1 as id, 20200101 as date_int union all
+        select 2 as id, 20200101 as date_int union all
+        select 3 as id, 20200101 as date_int union all
+        select 4 as id, 20200101 as date_int
+
+    {% else %}
+
+        select 10 as id, 20200101 as date_int union all
+        select 20 as id, 20200101 as date_int union all
+        select 30 as id, 20200102 as date_int union all
+        select 40 as id, 20200102 as date_int
+
+    {% endif %}
+
+)
+
+select * from data
+""".lstrip()
+
 overwrite_range_with_interval_sql = """
 {{
     config(

--- a/dbt-bigquery/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/dbt-bigquery/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -26,6 +26,7 @@ from tests.functional.adapter.incremental.incremental_strategy_fixtures import (
     overwrite_copy_partitions_with_partitions_sql,
     overwrite_range_sql,
     overwrite_range_with_interval_sql,
+    overwrite_range_with_require_partition_sql,
     overwrite_time_sql,
     overwrite_day_with_time_ingestion_sql,
     overwrite_day_with_time_partition_datetime_sql,
@@ -51,6 +52,7 @@ class TestBigQueryScripting(SeedConfigBase):
             "incremental_overwrite_copy_partitions_with_partitions.sql": overwrite_copy_partitions_with_partitions_sql,
             "incremental_overwrite_range.sql": overwrite_range_sql,
             "incremental_overwrite_range_with_interval.sql": overwrite_range_with_interval_sql,
+            "incremental_overwrite_range_with_require_partition.sql": overwrite_range_with_require_partition_sql,
             "incremental_overwrite_time.sql": overwrite_time_sql,
             "incremental_overwrite_day_with_time_partition.sql": overwrite_day_with_time_ingestion_sql,
             "incremental_overwrite_day_with_time_partition_datetime.sql": overwrite_day_with_time_partition_datetime_sql,
@@ -73,10 +75,10 @@ class TestBigQueryScripting(SeedConfigBase):
     def test__bigquery_assert_incremental_configurations_apply_the_right_strategy(self, project):
         run_dbt(["seed"])
         results = run_dbt()
-        assert len(results) == 14
+        assert len(results) == 15
 
         results = run_dbt()
-        assert len(results) == 14
+        assert len(results) == 15
 
         incremental_strategies = [
             ("incremental_merge_range", "merge_expected"),
@@ -94,6 +96,10 @@ class TestBigQueryScripting(SeedConfigBase):
             (
                 "incremental_overwrite_range_with_interval",
                 "incremental_overwrite_range_with_interval_expected",
+            ),
+            (
+                "incremental_overwrite_range_with_require_partition_view",
+                "incremental_overwrite_range_expected",
             ),
             (
                 "incremental_overwrite_day_with_time_partition_datetime",

--- a/dbt-bigquery/tests/unit/test_bigquery_adapter.py
+++ b/dbt-bigquery/tests/unit/test_bigquery_adapter.py
@@ -1261,10 +1261,22 @@ def test_sanitize_label_length(label_length):
 class TestPartitionConfigRenderWrappedInt64Range:
     """Tests for render_wrapped() with int64 range partitions.
 
-    For int64 range partitions, render_wrapped normalizes field values
-    to their partition start value, preventing excessively large arrays when
-    computing partitions for replacement in insert_overwrite.
+    For int64 range partitions with an interval greater than 1, render_wrapped
+    normalizes field values to their partition start value, preventing excessively
+    large arrays when computing partitions for replacement in insert_overwrite.
     """
+
+    @pytest.mark.parametrize("interval", [1, "1"])
+    def test_int64_range_with_interval_one_returns_raw_field(self, interval):
+        config = PartitionConfig.parse(
+            {
+                "field": "period",
+                "data_type": "int64",
+                "range": {"start": 201000, "end": 204999, "interval": interval},
+            }
+        )
+        assert config.render_wrapped() == "period"
+        assert config.render_wrapped(alias="DBT_INTERNAL_DEST") == "DBT_INTERNAL_DEST.period"
 
     def test_int64_range_normalizes_to_partition_start(self):
         """Values should be normalized using: value - MOD(value - start, interval)."""


### PR DESCRIPTION
resolves #2121

### What

Skip the `MOD()` partition-boundary normalization for int64 range partitions when the range interval is 1.

### Why

[#1654](https://github.com/dbt-labs/dbt-adapters/pull/1654) made `render_wrapped()` normalize int64 range values to their bucket start. That expression also renders the delete predicate of the insert_overwrite MERGE, and BigQuery won't use a partition column wrapped in arithmetic for partition elimination — so `require_partition_filter=true` tables fail outright, and everyone else silently loses pruning:

```
Query error: Cannot query over table 'my_table' without a filter over column(s) 'period' that can be used for partition elimination
```

At `interval: 1`, `MOD(x, 1)` is always 0 — the wrapping was a no-op that only broke pruning. Affects the 1.12.x line only; 1.11.0–1.11.3 wheels are clean, so 1.12.0 is the first stable release carrying it.

### How

Extend the branch condition so normalization is skipped at interval 1, falling through to the existing raw-column return. The predicate renders `DBT_INTERNAL_DEST.period` again, as in 1.11.x. `interval > 1` is untouched, so #1654's fixes stay in place, and no macros change.

`interval > 1` + `require_partition_filter=true` is still broken — the normalization is load-bearing there, so it needs a different predicate shape. Tracked with [#1823](https://github.com/dbt-labs/dbt-adapters/issues/1823), same failure class.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX

🤖 Generated with [Claude Code](https://claude.com/claude-code)