### PR TITLE
Draft: add typed DDL materialization plans

### DIFF
--- a/dbt-adapters/src/dbt/adapters/base/impl.py
+++ b/dbt-adapters/src/dbt/adapters/base/impl.py
@@ -1886,9 +1886,9 @@ class BaseAdapter(metaclass=AdapterMeta):
 
     @available
     def plan_incremental_schema_change(
-        self, requested_strategy: Optional[str]
+        self, requested_strategy: Optional[str], default: str = "ignore"
     ) -> IncrementalSchemaChangePlan:
-        return resolve_incremental_schema_change_plan(requested_strategy)
+        return resolve_incremental_schema_change_plan(requested_strategy, default=default)
 
     @available.parse_none
     def plan_incremental_arguments(

--- a/dbt-adapters/src/dbt/adapters/base/impl.py
+++ b/dbt-adapters/src/dbt/adapters/base/impl.py
@@ -17,6 +17,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -115,10 +116,13 @@ from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.planning import (
     CreateFromQueryPlan,
     DdlAtomicity,
+    IncrementalMutationArguments,
     IncrementalMutationPlan,
     IncrementalMutationStrategy,
+    IncrementalSchemaChangePlan,
     PlanProvenance,
     resolve_incremental_mutation_plan,
+    resolve_incremental_schema_change_plan,
 )
 
 logger = AdapterLogger(__name__)
@@ -1878,6 +1882,30 @@ class BaseAdapter(metaclass=AdapterMeta):
             requested_strategy,
             valid_strategies=self.valid_incremental_strategies(),
             builtin_strategies=self.builtin_incremental_strategies(),
+        )
+
+    @available
+    def plan_incremental_schema_change(
+        self, requested_strategy: Optional[str]
+    ) -> IncrementalSchemaChangePlan:
+        return resolve_incremental_schema_change_plan(requested_strategy)
+
+    @available.parse_none
+    def plan_incremental_arguments(
+        self,
+        *,
+        target_relation: Any,
+        temp_relation: Any,
+        unique_key: Optional[Union[str, Sequence[str]]],
+        dest_columns: Iterable[Any],
+        incremental_predicates: Optional[Sequence[str]],
+    ) -> IncrementalMutationArguments:
+        return IncrementalMutationArguments.from_values(
+            target_relation=target_relation,
+            temp_relation=temp_relation,
+            unique_key=unique_key,
+            dest_columns=dest_columns,
+            incremental_predicates=incremental_predicates,
         )
 
     @available.parse_none

--- a/dbt-adapters/src/dbt/adapters/base/impl.py
+++ b/dbt-adapters/src/dbt/adapters/base/impl.py
@@ -114,13 +114,19 @@ from dbt.adapters.exceptions import (
 from dbt.adapters.protocol import AdapterConfig, MacroContextGeneratorCallable
 from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.planning import (
+    CatalogBindingState,
+    CatalogFacts,
     CreateFromQueryPlan,
+    CreateFromQueryFacts,
     DdlAtomicity,
+    FormatFacts,
     IncrementalMutationArguments,
     IncrementalMutationPlan,
     IncrementalMutationStrategy,
     IncrementalSchemaChangePlan,
     PlanProvenance,
+    RelationFacts,
+    RuntimeFacts,
     resolve_incremental_mutation_plan,
     resolve_incremental_schema_change_plan,
 )
@@ -427,19 +433,115 @@ class BaseAdapter(metaclass=AdapterMeta):
 
     @available
     def plan_create_from_query(
-        self, temporary: bool, relation: BaseRelation
+        self,
+        temporary: bool,
+        relation: BaseRelation,
+        model: Optional[RelationConfig] = None,
     ) -> CreateFromQueryPlan:
         """Resolve how to create ``relation`` from a query before rendering SQL.
 
-        Adapters may override this operation-specific resolver to inspect the
-        resolved relation, catalog binding, format, runtime, or probe results.
-        The renderer must consume the returned plan rather than repeat that
-        inference in Jinja.
+        Adapters may override the fact-building or strategy-resolution hooks.
+        The renderer consumes the returned plan rather than inferring relation,
+        catalog, format, or runtime state in Jinja.
         """
+
+        facts = self.build_create_from_query_facts(temporary, relation, model)
+        return self.resolve_create_from_query_plan(temporary, facts)
+
+    @staticmethod
+    def _create_from_query_fact_value(value: Any, *, canonical: bool = False) -> Optional[str]:
+        if value is None:
+            return None
+        raw_value = getattr(value, "value", value)
+        result = str(raw_value)
+        return result.casefold() if canonical else result
+
+    def get_create_from_query_runtime_facts(
+        self,
+        temporary: bool,
+        relation: BaseRelation,
+        model: Optional[RelationConfig],
+    ) -> RuntimeFacts:
+        """Return execution-runtime facts; adapters may add a resolved version."""
+
+        return RuntimeFacts(engine=self.type())
+
+    def build_create_from_query_facts(
+        self,
+        temporary: bool,
+        relation: BaseRelation,
+        model: Optional[RelationConfig] = None,
+    ) -> CreateFromQueryFacts:
+        """Build immutable resolver inputs from authoritative adapter objects."""
+
+        model_config = getattr(model, "config", None)
+        integration_name = self._create_from_query_fact_value(
+            _config_get(model_config, CATALOG_INTEGRATION_MODEL_CONFIG_NAME)
+            or _config_get(model_config, "catalog")
+            or getattr(relation, "catalog", None)
+        )
+        catalog_relation = self.build_catalog_relation(model) if model is not None else None
+
+        if catalog_relation is not None:
+            catalog_type = self._create_from_query_fact_value(
+                getattr(catalog_relation, "catalog_type", None), canonical=True
+            )
+            catalog_name = self._create_from_query_fact_value(
+                getattr(catalog_relation, "catalog_name", None)
+            )
+            catalog_facts = CatalogFacts(
+                state=CatalogBindingState.RESOLVED,
+                integration_name=integration_name or catalog_name or catalog_type,
+                catalog_type=catalog_type,
+                catalog_name=catalog_name,
+                catalog_database=self._create_from_query_fact_value(
+                    getattr(catalog_relation, "catalog_database", None)
+                ),
+                external_volume=self._create_from_query_fact_value(
+                    getattr(catalog_relation, "external_volume", None)
+                ),
+            )
+        elif integration_name is not None:
+            catalog_facts = CatalogFacts(
+                state=CatalogBindingState.NAMED,
+                integration_name=integration_name,
+            )
+        else:
+            catalog_facts = CatalogFacts(state=CatalogBindingState.UNBOUND)
+
+        format_source = catalog_relation if catalog_relation is not None else relation
+        return CreateFromQueryFacts(
+            relation=RelationFacts(
+                database=self._create_from_query_fact_value(getattr(relation, "database", None)),
+                schema=self._create_from_query_fact_value(getattr(relation, "schema", None)),
+                identifier=self._create_from_query_fact_value(
+                    getattr(relation, "identifier", None)
+                ),
+                relation_type=self._create_from_query_fact_value(
+                    getattr(relation, "type", None), canonical=True
+                ),
+            ),
+            catalog=catalog_facts,
+            format=FormatFacts(
+                table_format=self._create_from_query_fact_value(
+                    getattr(format_source, "table_format", None), canonical=True
+                ),
+                file_format=self._create_from_query_fact_value(
+                    getattr(format_source, "file_format", None), canonical=True
+                ),
+            ),
+            runtime=self.get_create_from_query_runtime_facts(temporary, relation, model),
+        )
+
+    def resolve_create_from_query_plan(
+        self, temporary: bool, facts: CreateFromQueryFacts
+    ) -> CreateFromQueryPlan:
+        """Select a physical strategy from typed, already-resolved facts."""
 
         return CreateFromQueryPlan.ctas(
             temporary=temporary,
             atomicity=DdlAtomicity.UNKNOWN,
+            facts=facts,
             provenance=(
                 PlanProvenance(
                     rule="base.create_from_query.ctas",

--- a/dbt-adapters/src/dbt/adapters/base/impl.py
+++ b/dbt-adapters/src/dbt/adapters/base/impl.py
@@ -112,6 +112,14 @@ from dbt.adapters.exceptions import (
 )
 from dbt.adapters.protocol import AdapterConfig, MacroContextGeneratorCallable
 from dbt.adapters.events.logging import AdapterLogger
+from dbt.adapters.planning import (
+    CreateFromQueryPlan,
+    DdlAtomicity,
+    IncrementalMutationPlan,
+    IncrementalMutationStrategy,
+    PlanProvenance,
+    resolve_incremental_mutation_plan,
+)
 
 logger = AdapterLogger(__name__)
 if TYPE_CHECKING:
@@ -412,6 +420,29 @@ class BaseAdapter(metaclass=AdapterMeta):
             return catalog.build_relation(config)
 
         return None
+
+    @available
+    def plan_create_from_query(
+        self, temporary: bool, relation: BaseRelation
+    ) -> CreateFromQueryPlan:
+        """Resolve how to create ``relation`` from a query before rendering SQL.
+
+        Adapters may override this operation-specific resolver to inspect the
+        resolved relation, catalog binding, format, runtime, or probe results.
+        The renderer must consume the returned plan rather than repeat that
+        inference in Jinja.
+        """
+
+        return CreateFromQueryPlan.ctas(
+            temporary=temporary,
+            atomicity=DdlAtomicity.UNKNOWN,
+            provenance=(
+                PlanProvenance(
+                    rule="base.create_from_query.ctas",
+                    detail="Base adapter create-from-query behavior uses create table as select",
+                ),
+            ),
+        )
 
     ###
     # Methods to set / access a macro resolver
@@ -1839,6 +1870,41 @@ class BaseAdapter(metaclass=AdapterMeta):
 
         return builtin_strategies
 
+    @available
+    def plan_incremental_mutation(
+        self, requested_strategy: Optional[str]
+    ) -> IncrementalMutationPlan:
+        return resolve_incremental_mutation_plan(
+            requested_strategy,
+            valid_strategies=self.valid_incremental_strategies(),
+            builtin_strategies=self.builtin_incremental_strategies(),
+        )
+
+    @available.parse_none
+    def get_incremental_plan_macro(self, model_context, plan: IncrementalMutationPlan):
+        if plan.strategy == IncrementalMutationStrategy.UNSUPPORTED:
+            raise DbtRuntimeError(plan.reason or "Incremental mutation is unsupported")
+
+        if (
+            getattr(type(self), "get_incremental_strategy_macro", None)
+            is BaseAdapter.get_incremental_strategy_macro
+        ):
+            return self._get_incremental_plan_macro(model_context, plan)
+
+        # Preserve adapter overrides of the established public selector.
+        return self.get_incremental_strategy_macro(model_context, plan.requested_strategy)
+
+    def _get_incremental_plan_macro(self, model_context, plan: IncrementalMutationPlan):
+        macro_name = plan.renderer_macro
+        if macro_name not in model_context:
+            raise DbtRuntimeError(
+                'dbt could not find an incremental strategy macro with the name "{}" in {}'.format(
+                    macro_name, self.config.project_name
+                )
+            )
+
+        return model_context[macro_name]
+
     @available.parse_none
     def get_incremental_strategy_macro(self, model_context, strategy: str):
         """Gets the macro for the given incremental strategy.
@@ -1852,31 +1918,10 @@ class BaseAdapter(metaclass=AdapterMeta):
         a "builtin", and nothing will break (and that is desirable).
         """
 
-        # Construct macro_name from strategy name
-        if strategy is None:
-            strategy = "default"
-
-        # validate strategies for this adapter
-        valid_strategies = self.valid_incremental_strategies()
-        valid_strategies.append("default")
-        builtin_strategies = self.builtin_incremental_strategies()
-        if strategy in builtin_strategies and strategy not in valid_strategies:
-            raise DbtRuntimeError(
-                f"The incremental strategy '{strategy}' is not valid for this adapter"
-            )
-
-        strategy = strategy.replace("+", "_")
-        macro_name = f"get_incremental_{strategy}_sql"
-        # The model_context should have callable objects for all macros
-        if macro_name not in model_context:
-            raise DbtRuntimeError(
-                'dbt could not find an incremental strategy macro with the name "{}" in {}'.format(
-                    macro_name, self.config.project_name
-                )
-            )
-
-        # This returns a callable macro
-        return model_context[macro_name]
+        plan = self.plan_incremental_mutation(strategy)
+        if plan.strategy == IncrementalMutationStrategy.UNSUPPORTED:
+            raise DbtRuntimeError(plan.reason or "Incremental mutation is unsupported")
+        return self._get_incremental_plan_macro(model_context, plan)
 
     @classmethod
     def _parse_column_constraint(cls, raw_constraint: Dict[str, Any]) -> ColumnLevelConstraint:

--- a/dbt-adapters/src/dbt/adapters/planning/__init__.py
+++ b/dbt-adapters/src/dbt/adapters/planning/__init__.py
@@ -1,8 +1,14 @@
 from dbt.adapters.planning.create_from_query import (
+    CatalogBindingState,
+    CatalogFacts,
+    CreateFromQueryFacts,
     CreateFromQueryPlan,
     CreateFromQueryStrategy,
     DdlAtomicity,
+    FormatFacts,
     PlanProvenance,
+    RelationFacts,
+    RuntimeFacts,
 )
 from dbt.adapters.planning.incremental import (
     IncrementalMutationArguments,
@@ -15,10 +21,16 @@ from dbt.adapters.planning.incremental import (
 )
 
 __all__ = [
+    "CatalogBindingState",
+    "CatalogFacts",
+    "CreateFromQueryFacts",
     "CreateFromQueryPlan",
     "CreateFromQueryStrategy",
     "DdlAtomicity",
+    "FormatFacts",
     "PlanProvenance",
+    "RelationFacts",
+    "RuntimeFacts",
     "IncrementalMutationArguments",
     "IncrementalMutationPlan",
     "IncrementalMutationStrategy",

--- a/dbt-adapters/src/dbt/adapters/planning/__init__.py
+++ b/dbt-adapters/src/dbt/adapters/planning/__init__.py
@@ -5,9 +5,13 @@ from dbt.adapters.planning.create_from_query import (
     PlanProvenance,
 )
 from dbt.adapters.planning.incremental import (
+    IncrementalMutationArguments,
     IncrementalMutationPlan,
     IncrementalMutationStrategy,
+    IncrementalSchemaChangePlan,
+    IncrementalSchemaChangeStrategy,
     resolve_incremental_mutation_plan,
+    resolve_incremental_schema_change_plan,
 )
 
 __all__ = [
@@ -15,7 +19,11 @@ __all__ = [
     "CreateFromQueryStrategy",
     "DdlAtomicity",
     "PlanProvenance",
+    "IncrementalMutationArguments",
     "IncrementalMutationPlan",
     "IncrementalMutationStrategy",
+    "IncrementalSchemaChangePlan",
+    "IncrementalSchemaChangeStrategy",
     "resolve_incremental_mutation_plan",
+    "resolve_incremental_schema_change_plan",
 ]

--- a/dbt-adapters/src/dbt/adapters/planning/__init__.py
+++ b/dbt-adapters/src/dbt/adapters/planning/__init__.py
@@ -1,0 +1,21 @@
+from dbt.adapters.planning.create_from_query import (
+    CreateFromQueryPlan,
+    CreateFromQueryStrategy,
+    DdlAtomicity,
+    PlanProvenance,
+)
+from dbt.adapters.planning.incremental import (
+    IncrementalMutationPlan,
+    IncrementalMutationStrategy,
+    resolve_incremental_mutation_plan,
+)
+
+__all__ = [
+    "CreateFromQueryPlan",
+    "CreateFromQueryStrategy",
+    "DdlAtomicity",
+    "PlanProvenance",
+    "IncrementalMutationPlan",
+    "IncrementalMutationStrategy",
+    "resolve_incremental_mutation_plan",
+]

--- a/dbt-adapters/src/dbt/adapters/planning/create_from_query.py
+++ b/dbt-adapters/src/dbt/adapters/planning/create_from_query.py
@@ -1,0 +1,139 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Optional, Tuple
+
+
+class CreateFromQueryStrategy(str, Enum):
+    """Closed set of physical strategies for creating a relation from a query."""
+
+    CTAS = "ctas"
+    CREATE_THEN_INSERT = "create_then_insert"
+    UNSUPPORTED = "unsupported"
+
+
+class DdlAtomicity(str, Enum):
+    """Atomicity promised by one physical DDL operation."""
+
+    UNKNOWN = "unknown"
+    STATEMENT = "statement"
+    TRANSACTION = "transaction"
+    BEST_EFFORT = "best_effort"
+    NONE = "none"
+
+
+@dataclass(frozen=True)
+class PlanProvenance:
+    """Rule and evidence that caused a resolver to select a plan."""
+
+    rule: str
+    detail: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.rule, str) or not isinstance(self.detail, str):
+            raise TypeError("Plan provenance rule and detail must be strings")
+        if not self.rule.strip():
+            raise ValueError("Plan provenance rule must not be empty")
+        if not self.detail.strip():
+            raise ValueError("Plan provenance detail must not be empty")
+
+    def to_dict(self) -> Dict[str, str]:
+        return {"rule": self.rule, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class CreateFromQueryPlan:
+    """Validated physical plan consumed by a create-from-query renderer.
+
+    Relation, catalog, format, provider, and runtime facts belong in the
+    resolver that constructs this value. Renderers receive only this resolved
+    decision plus the relation and query they must render.
+    """
+
+    strategy: CreateFromQueryStrategy
+    atomicity: DdlAtomicity
+    temporary: bool
+    provenance: Tuple[PlanProvenance, ...]
+    reason: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.strategy, CreateFromQueryStrategy):
+            raise TypeError("Create-from-query plan strategy must be a CreateFromQueryStrategy")
+        if not isinstance(self.atomicity, DdlAtomicity):
+            raise TypeError("Create-from-query plan atomicity must be a DdlAtomicity")
+        if not isinstance(self.temporary, bool):
+            raise TypeError("Create-from-query plan 'temporary' must be a bool")
+        if not isinstance(self.provenance, tuple):
+            raise TypeError("Create-from-query plan provenance must be an immutable tuple")
+        if not self.provenance:
+            raise ValueError("Create-from-query plan must include provenance")
+        if not all(isinstance(item, PlanProvenance) for item in self.provenance):
+            raise TypeError("Create-from-query plan provenance must contain PlanProvenance")
+        if self.reason is not None and not isinstance(self.reason, str):
+            raise TypeError("Create-from-query plan reason must be a string")
+
+        if self.strategy == CreateFromQueryStrategy.UNSUPPORTED:
+            if not self.reason or not self.reason.strip():
+                raise ValueError("Unsupported create-from-query plan must include a reason")
+            if self.atomicity != DdlAtomicity.NONE:
+                raise ValueError("Unsupported create-from-query plan cannot promise atomicity")
+        elif self.reason is not None:
+            raise ValueError(
+                "Supported create-from-query plan cannot include an unsupported reason"
+            )
+
+    @classmethod
+    def ctas(
+        cls,
+        *,
+        temporary: bool,
+        atomicity: DdlAtomicity,
+        provenance: Tuple[PlanProvenance, ...],
+    ) -> "CreateFromQueryPlan":
+        return cls(
+            strategy=CreateFromQueryStrategy.CTAS,
+            atomicity=atomicity,
+            temporary=temporary,
+            provenance=provenance,
+        )
+
+    @classmethod
+    def create_then_insert(
+        cls,
+        *,
+        temporary: bool,
+        atomicity: DdlAtomicity,
+        provenance: Tuple[PlanProvenance, ...],
+    ) -> "CreateFromQueryPlan":
+        return cls(
+            strategy=CreateFromQueryStrategy.CREATE_THEN_INSERT,
+            atomicity=atomicity,
+            temporary=temporary,
+            provenance=provenance,
+        )
+
+    @classmethod
+    def unsupported(
+        cls,
+        *,
+        temporary: bool,
+        reason: str,
+        provenance: Tuple[PlanProvenance, ...],
+    ) -> "CreateFromQueryPlan":
+        return cls(
+            strategy=CreateFromQueryStrategy.UNSUPPORTED,
+            atomicity=DdlAtomicity.NONE,
+            temporary=temporary,
+            provenance=provenance,
+            reason=reason,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return stable primitive data suitable for fixtures and cross-runtime exchange."""
+
+        return {
+            "strategy": self.strategy.value,
+            "atomicity": self.atomicity.value,
+            "temporary": self.temporary,
+            "provenance": [item.to_dict() for item in self.provenance],
+            "reason": self.reason,
+        }

--- a/dbt-adapters/src/dbt/adapters/planning/create_from_query.py
+++ b/dbt-adapters/src/dbt/adapters/planning/create_from_query.py
@@ -21,6 +21,14 @@ class DdlAtomicity(str, Enum):
     NONE = "none"
 
 
+class CatalogBindingState(str, Enum):
+    """How completely a logical catalog binding has been resolved."""
+
+    UNBOUND = "unbound"
+    NAMED = "named"
+    RESOLVED = "resolved"
+
+
 @dataclass(frozen=True)
 class PlanProvenance:
     """Rule and evidence that caused a resolver to select a plan."""
@@ -40,6 +48,163 @@ class PlanProvenance:
         return {"rule": self.rule, "detail": self.detail}
 
 
+def _validate_optional_string(value: Optional[str], field_name: str) -> None:
+    if value is not None and not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string when provided")
+    if isinstance(value, str) and not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string when provided")
+
+
+@dataclass(frozen=True)
+class RelationFacts:
+    """Resolved logical and physical address facts for a relation."""
+
+    database: Optional[str]
+    schema: Optional[str]
+    identifier: Optional[str]
+    relation_type: Optional[str]
+
+    def __post_init__(self) -> None:
+        _validate_optional_string(self.database, "Relation database")
+        _validate_optional_string(self.schema, "Relation schema")
+        _validate_optional_string(self.identifier, "Relation identifier")
+        _validate_optional_string(self.relation_type, "Relation type")
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        return {
+            "database": self.database,
+            "schema": self.schema,
+            "identifier": self.identifier,
+            "relation_type": self.relation_type,
+        }
+
+
+@dataclass(frozen=True)
+class CatalogFacts:
+    """Resolved catalog identity and storage binding facts."""
+
+    state: CatalogBindingState
+    integration_name: Optional[str] = None
+    catalog_type: Optional[str] = None
+    catalog_name: Optional[str] = None
+    catalog_database: Optional[str] = None
+    external_volume: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.state, CatalogBindingState):
+            raise TypeError("Catalog binding state must be a CatalogBindingState")
+        for value, field_name in (
+            (self.integration_name, "Catalog integration name"),
+            (self.catalog_type, "Catalog type"),
+            (self.catalog_name, "Platform catalog name"),
+            (self.catalog_database, "Catalog database"),
+            (self.external_volume, "External volume"),
+        ):
+            _validate_optional_string(value, field_name)
+
+        if self.state == CatalogBindingState.UNBOUND:
+            if any(
+                value is not None
+                for value in (
+                    self.integration_name,
+                    self.catalog_type,
+                    self.catalog_name,
+                    self.catalog_database,
+                    self.external_volume,
+                )
+            ):
+                raise ValueError("Unbound catalog facts cannot include catalog values")
+        elif self.state == CatalogBindingState.NAMED:
+            if self.integration_name is None:
+                raise ValueError("Named catalog facts require an integration name")
+            if any(
+                value is not None
+                for value in (
+                    self.catalog_type,
+                    self.catalog_name,
+                    self.catalog_database,
+                    self.external_volume,
+                )
+            ):
+                raise ValueError("Named catalog facts cannot include resolved catalog values")
+        elif self.catalog_type is None:
+            raise ValueError("Resolved catalog facts require a catalog type")
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        return {
+            "state": self.state.value,
+            "integration_name": self.integration_name,
+            "catalog_type": self.catalog_type,
+            "catalog_name": self.catalog_name,
+            "catalog_database": self.catalog_database,
+            "external_volume": self.external_volume,
+        }
+
+
+@dataclass(frozen=True)
+class FormatFacts:
+    """Resolved table and file format facts."""
+
+    table_format: Optional[str] = None
+    file_format: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        _validate_optional_string(self.table_format, "Table format")
+        _validate_optional_string(self.file_format, "File format")
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        return {
+            "table_format": self.table_format,
+            "file_format": self.file_format,
+        }
+
+
+@dataclass(frozen=True)
+class RuntimeFacts:
+    """Resolved execution runtime identity available to a strategy resolver."""
+
+    engine: str
+    version: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.engine, str):
+            raise TypeError("Runtime engine must be a string")
+        if not self.engine.strip():
+            raise ValueError("Runtime engine must be a non-empty string")
+        _validate_optional_string(self.version, "Runtime version")
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        return {"engine": self.engine, "version": self.version}
+
+
+@dataclass(frozen=True)
+class CreateFromQueryFacts:
+    """Typed resolver inputs assembled before strategy selection."""
+
+    relation: RelationFacts
+    catalog: CatalogFacts
+    format: FormatFacts
+    runtime: RuntimeFacts
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.relation, RelationFacts):
+            raise TypeError("Create-from-query relation facts must be RelationFacts")
+        if not isinstance(self.catalog, CatalogFacts):
+            raise TypeError("Create-from-query catalog facts must be CatalogFacts")
+        if not isinstance(self.format, FormatFacts):
+            raise TypeError("Create-from-query format facts must be FormatFacts")
+        if not isinstance(self.runtime, RuntimeFacts):
+            raise TypeError("Create-from-query runtime facts must be RuntimeFacts")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "relation": self.relation.to_dict(),
+            "catalog": self.catalog.to_dict(),
+            "format": self.format.to_dict(),
+            "runtime": self.runtime.to_dict(),
+        }
+
+
 @dataclass(frozen=True)
 class CreateFromQueryPlan:
     """Validated physical plan consumed by a create-from-query renderer.
@@ -52,6 +217,7 @@ class CreateFromQueryPlan:
     strategy: CreateFromQueryStrategy
     atomicity: DdlAtomicity
     temporary: bool
+    facts: CreateFromQueryFacts
     provenance: Tuple[PlanProvenance, ...]
     reason: Optional[str] = None
 
@@ -62,6 +228,8 @@ class CreateFromQueryPlan:
             raise TypeError("Create-from-query plan atomicity must be a DdlAtomicity")
         if not isinstance(self.temporary, bool):
             raise TypeError("Create-from-query plan 'temporary' must be a bool")
+        if not isinstance(self.facts, CreateFromQueryFacts):
+            raise TypeError("Create-from-query plan facts must be CreateFromQueryFacts")
         if not isinstance(self.provenance, tuple):
             raise TypeError("Create-from-query plan provenance must be an immutable tuple")
         if not self.provenance:
@@ -87,12 +255,14 @@ class CreateFromQueryPlan:
         *,
         temporary: bool,
         atomicity: DdlAtomicity,
+        facts: CreateFromQueryFacts,
         provenance: Tuple[PlanProvenance, ...],
     ) -> "CreateFromQueryPlan":
         return cls(
             strategy=CreateFromQueryStrategy.CTAS,
             atomicity=atomicity,
             temporary=temporary,
+            facts=facts,
             provenance=provenance,
         )
 
@@ -102,12 +272,14 @@ class CreateFromQueryPlan:
         *,
         temporary: bool,
         atomicity: DdlAtomicity,
+        facts: CreateFromQueryFacts,
         provenance: Tuple[PlanProvenance, ...],
     ) -> "CreateFromQueryPlan":
         return cls(
             strategy=CreateFromQueryStrategy.CREATE_THEN_INSERT,
             atomicity=atomicity,
             temporary=temporary,
+            facts=facts,
             provenance=provenance,
         )
 
@@ -117,12 +289,14 @@ class CreateFromQueryPlan:
         *,
         temporary: bool,
         reason: str,
+        facts: CreateFromQueryFacts,
         provenance: Tuple[PlanProvenance, ...],
     ) -> "CreateFromQueryPlan":
         return cls(
             strategy=CreateFromQueryStrategy.UNSUPPORTED,
             atomicity=DdlAtomicity.NONE,
             temporary=temporary,
+            facts=facts,
             provenance=provenance,
             reason=reason,
         )
@@ -134,6 +308,7 @@ class CreateFromQueryPlan:
             "strategy": self.strategy.value,
             "atomicity": self.atomicity.value,
             "temporary": self.temporary,
+            "facts": self.facts.to_dict(),
             "provenance": [item.to_dict() for item in self.provenance],
             "reason": self.reason,
         }

--- a/dbt-adapters/src/dbt/adapters/planning/incremental.py
+++ b/dbt-adapters/src/dbt/adapters/planning/incremental.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Iterable, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 from dbt.adapters.planning.create_from_query import DdlAtomicity, PlanProvenance
 
@@ -16,6 +16,135 @@ class IncrementalMutationStrategy(str, Enum):
     MICROBATCH = "microbatch"
     CUSTOM = "custom"
     UNSUPPORTED = "unsupported"
+
+
+class IncrementalSchemaChangeStrategy(str, Enum):
+    """Closed schema reconciliation policies understood by the materialization."""
+
+    IGNORE = "ignore"
+    APPEND_NEW_COLUMNS = "append_new_columns"
+    SYNC_ALL_COLUMNS = "sync_all_columns"
+    FAIL = "fail"
+
+
+@dataclass(frozen=True)
+class IncrementalSchemaChangePlan:
+    """Validated schema reconciliation intent, resolved before macro execution."""
+
+    requested_strategy: str
+    strategy: IncrementalSchemaChangeStrategy
+    provenance: Tuple[PlanProvenance, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.requested_strategy, str) or not self.requested_strategy.strip():
+            raise ValueError("Schema change plan requested strategy must be a non-empty string")
+        if not isinstance(self.strategy, IncrementalSchemaChangeStrategy):
+            raise TypeError(
+                "Schema change plan strategy must be an IncrementalSchemaChangeStrategy"
+            )
+        if not isinstance(self.provenance, tuple):
+            raise TypeError("Schema change plan provenance must be an immutable tuple")
+        if not self.provenance:
+            raise ValueError("Schema change plan must include provenance")
+        if not all(isinstance(item, PlanProvenance) for item in self.provenance):
+            raise TypeError("Schema change plan provenance must contain PlanProvenance")
+
+    @property
+    def was_coerced(self) -> bool:
+        return self.requested_strategy != self.strategy.value
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "requested_strategy": self.requested_strategy,
+            "strategy": self.strategy.value,
+            "provenance": [item.to_dict() for item in self.provenance],
+        }
+
+
+UniqueKey = Optional[Union[str, Tuple[str, ...]]]
+
+
+@dataclass(frozen=True)
+class IncrementalMutationArguments:
+    """Typed late-bound inputs for an incremental strategy renderer."""
+
+    target_relation: Any
+    temp_relation: Any
+    unique_key: UniqueKey
+    dest_columns: Tuple[Any, ...]
+    incremental_predicates: Optional[Tuple[str, ...]]
+
+    def __post_init__(self) -> None:
+        if self.target_relation is None:
+            raise ValueError("Incremental arguments require a target relation")
+        if self.temp_relation is None:
+            raise ValueError("Incremental arguments require a temporary relation")
+        if not isinstance(self.dest_columns, tuple):
+            raise TypeError("Incremental destination columns must be an immutable tuple")
+        if isinstance(self.unique_key, str):
+            if not self.unique_key.strip():
+                raise ValueError("Incremental unique key cannot be empty")
+        elif self.unique_key is not None:
+            if not isinstance(self.unique_key, tuple):
+                raise TypeError("Incremental unique key columns must be an immutable tuple")
+            if not self.unique_key or not all(
+                isinstance(key, str) and key.strip() for key in self.unique_key
+            ):
+                raise ValueError("Incremental unique key columns must be non-empty strings")
+        if self.incremental_predicates is not None:
+            if not isinstance(self.incremental_predicates, tuple):
+                raise TypeError("Incremental predicates must be an immutable tuple")
+            if not all(
+                isinstance(predicate, str) and predicate.strip()
+                for predicate in self.incremental_predicates
+            ):
+                raise ValueError("Incremental predicates must be non-empty strings")
+
+    @classmethod
+    def from_values(
+        cls,
+        *,
+        target_relation: Any,
+        temp_relation: Any,
+        unique_key: Optional[Union[str, Sequence[str]]],
+        dest_columns: Iterable[Any],
+        incremental_predicates: Optional[Sequence[str]],
+    ) -> "IncrementalMutationArguments":
+        normalized_unique_key: UniqueKey
+        if unique_key is None or isinstance(unique_key, str):
+            normalized_unique_key = unique_key
+        else:
+            normalized_unique_key = tuple(unique_key)
+
+        if isinstance(incremental_predicates, str):
+            raise TypeError("Incremental predicates must be a sequence, not a string")
+        normalized_predicates = None
+        if incremental_predicates is not None:
+            normalized_predicates = tuple(incremental_predicates)
+        return cls(
+            target_relation=target_relation,
+            temp_relation=temp_relation,
+            unique_key=normalized_unique_key,
+            dest_columns=tuple(dest_columns),
+            incremental_predicates=normalized_predicates,
+        )
+
+    def to_macro_dict(self) -> Dict[str, Any]:
+        unique_key: Optional[Union[str, List[str]]]
+        if isinstance(self.unique_key, tuple):
+            unique_key = list(self.unique_key)
+        else:
+            unique_key = self.unique_key
+
+        return {
+            "target_relation": self.target_relation,
+            "temp_relation": self.temp_relation,
+            "unique_key": unique_key,
+            "dest_columns": list(self.dest_columns),
+            "incremental_predicates": (
+                None if self.incremental_predicates is None else list(self.incremental_predicates)
+            ),
+        }
 
 
 @dataclass(frozen=True)
@@ -79,6 +208,50 @@ _BUILTIN_STRATEGIES = {
     "insert_overwrite": IncrementalMutationStrategy.INSERT_OVERWRITE,
     "microbatch": IncrementalMutationStrategy.MICROBATCH,
 }
+
+_SCHEMA_CHANGE_STRATEGIES = {
+    strategy.value: strategy for strategy in IncrementalSchemaChangeStrategy
+}
+
+
+def resolve_incremental_schema_change_plan(
+    requested_strategy: Optional[str],
+    *,
+    default: str = IncrementalSchemaChangeStrategy.IGNORE.value,
+) -> IncrementalSchemaChangePlan:
+    """Resolve schema reconciliation config into a closed, validated policy."""
+
+    if default not in _SCHEMA_CHANGE_STRATEGIES:
+        raise ValueError(f"Unknown default incremental schema change strategy '{default}'")
+
+    requested = requested_strategy or default
+    strategy = _SCHEMA_CHANGE_STRATEGIES.get(requested)
+    if strategy is not None:
+        return IncrementalSchemaChangePlan(
+            requested_strategy=requested,
+            strategy=strategy,
+            provenance=(
+                PlanProvenance(
+                    rule=f"incremental.schema_change.{strategy.value}",
+                    detail=f"Requested schema change strategy '{requested}' is valid",
+                ),
+            ),
+        )
+
+    resolved = _SCHEMA_CHANGE_STRATEGIES[default]
+    return IncrementalSchemaChangePlan(
+        requested_strategy=requested,
+        strategy=resolved,
+        provenance=(
+            PlanProvenance(
+                rule="incremental.schema_change.invalid_default",
+                detail=(
+                    f"Invalid value for on_schema_change ({requested}) specified. "
+                    f"Setting default value of {default}."
+                ),
+            ),
+        ),
+    )
 
 
 def resolve_incremental_mutation_plan(

--- a/dbt-adapters/src/dbt/adapters/planning/incremental.py
+++ b/dbt-adapters/src/dbt/adapters/planning/incremental.py
@@ -1,0 +1,125 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+from dbt.adapters.planning.create_from_query import DdlAtomicity, PlanProvenance
+
+
+class IncrementalMutationStrategy(str, Enum):
+    """Closed physical strategies understood by the built-in incremental renderer."""
+
+    ADAPTER_DEFAULT = "adapter_default"
+    APPEND = "append"
+    DELETE_INSERT = "delete_insert"
+    MERGE = "merge"
+    INSERT_OVERWRITE = "insert_overwrite"
+    MICROBATCH = "microbatch"
+    CUSTOM = "custom"
+    UNSUPPORTED = "unsupported"
+
+
+@dataclass(frozen=True)
+class IncrementalMutationPlan:
+    """Validated selection of one incremental mutation renderer."""
+
+    requested_strategy: str
+    strategy: IncrementalMutationStrategy
+    renderer_macro: Optional[str]
+    atomicity: DdlAtomicity
+    provenance: Tuple[PlanProvenance, ...]
+    reason: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.requested_strategy, str) or not self.requested_strategy.strip():
+            raise ValueError("Incremental plan requested strategy must be a non-empty string")
+        if not isinstance(self.strategy, IncrementalMutationStrategy):
+            raise TypeError("Incremental plan strategy must be an IncrementalMutationStrategy")
+        if self.renderer_macro is not None and not isinstance(self.renderer_macro, str):
+            raise TypeError("Incremental plan renderer macro must be a string")
+        if not isinstance(self.atomicity, DdlAtomicity):
+            raise TypeError("Incremental plan atomicity must be a DdlAtomicity")
+        if not isinstance(self.provenance, tuple):
+            raise TypeError("Incremental plan provenance must be an immutable tuple")
+        if not self.provenance:
+            raise ValueError("Incremental plan must include provenance")
+        if not all(isinstance(item, PlanProvenance) for item in self.provenance):
+            raise TypeError("Incremental plan provenance must contain PlanProvenance")
+        if self.reason is not None and not isinstance(self.reason, str):
+            raise TypeError("Incremental plan reason must be a string")
+
+        if self.strategy == IncrementalMutationStrategy.UNSUPPORTED:
+            if self.renderer_macro is not None:
+                raise ValueError("Unsupported incremental plan cannot select a renderer macro")
+            if self.atomicity != DdlAtomicity.NONE:
+                raise ValueError("Unsupported incremental plan cannot promise atomicity")
+            if not self.reason or not self.reason.strip():
+                raise ValueError("Unsupported incremental plan must include a reason")
+        else:
+            if not self.renderer_macro or not self.renderer_macro.strip():
+                raise ValueError("Supported incremental plan must select a renderer macro")
+            if self.reason is not None:
+                raise ValueError("Supported incremental plan cannot include an unsupported reason")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "requested_strategy": self.requested_strategy,
+            "strategy": self.strategy.value,
+            "renderer_macro": self.renderer_macro,
+            "atomicity": self.atomicity.value,
+            "provenance": [item.to_dict() for item in self.provenance],
+            "reason": self.reason,
+        }
+
+
+_BUILTIN_STRATEGIES = {
+    "default": IncrementalMutationStrategy.ADAPTER_DEFAULT,
+    "append": IncrementalMutationStrategy.APPEND,
+    "delete+insert": IncrementalMutationStrategy.DELETE_INSERT,
+    "merge": IncrementalMutationStrategy.MERGE,
+    "insert_overwrite": IncrementalMutationStrategy.INSERT_OVERWRITE,
+    "microbatch": IncrementalMutationStrategy.MICROBATCH,
+}
+
+
+def resolve_incremental_mutation_plan(
+    requested_strategy: Optional[str],
+    *,
+    valid_strategies: Iterable[str],
+    builtin_strategies: Iterable[str],
+) -> IncrementalMutationPlan:
+    """Resolve user intent and adapter support into one renderer selection."""
+
+    requested = requested_strategy or "default"
+    valid = frozenset(valid_strategies) | {"default"}
+    builtin = frozenset(builtin_strategies)
+
+    if requested in builtin and requested not in valid:
+        reason = f"The incremental strategy '{requested}' is not valid for this adapter"
+        return IncrementalMutationPlan(
+            requested_strategy=requested,
+            strategy=IncrementalMutationStrategy.UNSUPPORTED,
+            renderer_macro=None,
+            atomicity=DdlAtomicity.NONE,
+            provenance=(
+                PlanProvenance(
+                    rule="incremental.requested_strategy.unsupported",
+                    detail=reason,
+                ),
+            ),
+            reason=reason,
+        )
+
+    strategy = _BUILTIN_STRATEGIES.get(requested, IncrementalMutationStrategy.CUSTOM)
+    renderer_macro = f"get_incremental_{requested.replace('+', '_')}_sql"
+    return IncrementalMutationPlan(
+        requested_strategy=requested,
+        strategy=strategy,
+        renderer_macro=renderer_macro,
+        atomicity=DdlAtomicity.UNKNOWN,
+        provenance=(
+            PlanProvenance(
+                rule=f"incremental.requested_strategy.{strategy.value}",
+                detail=f"Requested strategy '{requested}' resolved to '{renderer_macro}'",
+            ),
+        ),
+    )

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/incremental.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/incremental.sql
@@ -12,7 +12,11 @@
   -- configs
   {%- set unique_key = config.get('unique_key') -%}
   {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}
-  {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
+  {%- set schema_change_plan = adapter.plan_incremental_schema_change(config.get('on_schema_change')) -%}
+  {%- set on_schema_change = schema_change_plan.strategy.value -%}
+  {%- if schema_change_plan.was_coerced -%}
+    {% do log(schema_change_plan.provenance[-1].detail) %}
+  {%- endif -%}
 
   -- the temp_ and backup_ relations should not already exist in the database; get_relation
   -- will return None in that case. Otherwise, we get a relation that we can drop
@@ -60,8 +64,14 @@
 
     {#-- Get the incremental_strategy, the macro to use for the strategy, and build the sql --#}
     {% set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) %}
-    {% set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': temp_relation, 'unique_key': unique_key, 'dest_columns': dest_columns, 'incremental_predicates': incremental_predicates }) %}
-    {% set build_sql = strategy_sql_macro_func(strategy_arg_dict) %}
+    {% set strategy_args = adapter.plan_incremental_arguments(
+        target_relation=target_relation,
+        temp_relation=temp_relation,
+        unique_key=unique_key,
+        dest_columns=dest_columns,
+        incremental_predicates=incremental_predicates
+    ) %}
+    {% set build_sql = strategy_sql_macro_func(strategy_args.to_macro_dict()) %}
 
   {% endif %}
 

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/incremental.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/incremental.sql
@@ -33,7 +33,8 @@
   {% set to_drop = [] %}
 
   {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}
-  {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(context, incremental_strategy) %}
+  {% set incremental_plan = adapter.plan_incremental_mutation(incremental_strategy) %}
+  {% set strategy_sql_macro_func = adapter.get_incremental_plan_macro(context, incremental_plan) %}
 
   {% if existing_relation is none %}
       {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/incremental.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/incremental.sql
@@ -12,11 +12,7 @@
   -- configs
   {%- set unique_key = config.get('unique_key') -%}
   {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}
-  {%- set schema_change_plan = adapter.plan_incremental_schema_change(config.get('on_schema_change')) -%}
-  {%- set on_schema_change = schema_change_plan.strategy.value -%}
-  {%- if schema_change_plan.was_coerced -%}
-    {% do log(schema_change_plan.provenance[-1].detail) %}
-  {%- endif -%}
+  {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
 
   -- the temp_ and backup_ relations should not already exist in the database; get_relation
   -- will return None in that case. Otherwise, we get a relation that we can drop

--- a/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/on_schema_change.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/materializations/models/incremental/on_schema_change.sql
@@ -1,18 +1,9 @@
 {% macro incremental_validate_on_schema_change(on_schema_change, default='ignore') %}
-
-   {% if on_schema_change not in ['sync_all_columns', 'append_new_columns', 'fail', 'ignore'] %}
-
-     {% set log_message = 'Invalid value for on_schema_change (%s) specified. Setting default value of %s.' % (on_schema_change, default) %}
-     {% do log(log_message) %}
-
-     {{ return(default) }}
-
-   {% else %}
-
-     {{ return(on_schema_change) }}
-
-   {% endif %}
-
+  {% set schema_change_plan = adapter.plan_incremental_schema_change(on_schema_change, default) %}
+  {% if schema_change_plan.was_coerced %}
+    {% do log(schema_change_plan.provenance[-1].detail) %}
+  {% endif %}
+  {{ return(schema_change_plan.strategy.value) }}
 {% endmacro %}
 
 

--- a/dbt-adapters/src/dbt/include/global_project/macros/relations/table/create.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/relations/table/create.sql
@@ -3,7 +3,26 @@
 {%- endmacro %}
 
 {% macro default__get_create_table_as_sql(temporary, relation, sql) -%}
-  {{ return(create_table_as(temporary, relation, sql)) }}
+  {% set plan = adapter.plan_create_from_query(temporary, relation) %}
+  {{ return(render_create_from_query_plan(plan, relation, sql)) }}
+{% endmacro %}
+
+
+{% macro render_create_from_query_plan(plan, relation, sql) -%}
+  {{ return(adapter.dispatch('render_create_from_query_plan', 'dbt')(plan, relation, sql)) }}
+{% endmacro %}
+
+
+{% macro default__render_create_from_query_plan(plan, relation, sql) -%}
+  {% if plan.strategy == 'ctas' %}
+    {{ return(create_table_as(plan.temporary, relation, sql)) }}
+  {% elif plan.strategy == 'unsupported' %}
+    {{ exceptions.raise_compiler_error(plan.reason) }}
+  {% else %}
+    {{ exceptions.raise_compiler_error(
+      "Create-from-query strategy '" ~ plan.strategy ~ "' requires an adapter-specific renderer"
+    ) }}
+  {% endif %}
 {% endmacro %}
 
 

--- a/dbt-adapters/src/dbt/include/global_project/macros/relations/table/create.sql
+++ b/dbt-adapters/src/dbt/include/global_project/macros/relations/table/create.sql
@@ -3,7 +3,7 @@
 {%- endmacro %}
 
 {% macro default__get_create_table_as_sql(temporary, relation, sql) -%}
-  {% set plan = adapter.plan_create_from_query(temporary, relation) %}
+  {% set plan = adapter.plan_create_from_query(temporary, relation, config.model) %}
   {{ return(render_create_from_query_plan(plan, relation, sql)) }}
 {% endmacro %}
 

--- a/dbt-adapters/tests/unit/test_create_from_query_planning.py
+++ b/dbt-adapters/tests/unit/test_create_from_query_planning.py
@@ -1,0 +1,123 @@
+import pytest
+
+from dbt.adapters.base.impl import BaseAdapter
+from dbt.adapters.planning import (
+    CreateFromQueryPlan,
+    CreateFromQueryStrategy,
+    DdlAtomicity,
+    PlanProvenance,
+)
+
+
+PROVENANCE = (
+    PlanProvenance(
+        rule="test.create_from_query",
+        detail="Test operation capability selected this strategy",
+    ),
+)
+
+
+def test_base_adapter_resolves_portable_ctas_plan():
+    plan = BaseAdapter.plan_create_from_query(None, temporary=False, relation=None)
+
+    assert plan == CreateFromQueryPlan.ctas(
+        temporary=False,
+        atomicity=DdlAtomicity.UNKNOWN,
+        provenance=(
+            PlanProvenance(
+                rule="base.create_from_query.ctas",
+                detail="Base adapter create-from-query behavior uses create table as select",
+            ),
+        ),
+    )
+    assert "plan_create_from_query" in BaseAdapter._available_
+
+
+def test_plan_serializes_to_stable_primitives():
+    plan = CreateFromQueryPlan.create_then_insert(
+        temporary=True,
+        atomicity=DdlAtomicity.TRANSACTION,
+        provenance=PROVENANCE,
+    )
+
+    assert plan.to_dict() == {
+        "strategy": "create_then_insert",
+        "atomicity": "transaction",
+        "temporary": True,
+        "provenance": [
+            {
+                "rule": "test.create_from_query",
+                "detail": "Test operation capability selected this strategy",
+            }
+        ],
+        "reason": None,
+    }
+
+
+def test_unsupported_plan_requires_reason_and_cannot_promise_atomicity():
+    with pytest.raises(ValueError, match="must include a reason"):
+        CreateFromQueryPlan(
+            strategy=CreateFromQueryStrategy.UNSUPPORTED,
+            atomicity=DdlAtomicity.NONE,
+            temporary=False,
+            provenance=PROVENANCE,
+        )
+
+    with pytest.raises(ValueError, match="cannot promise atomicity"):
+        CreateFromQueryPlan(
+            strategy=CreateFromQueryStrategy.UNSUPPORTED,
+            atomicity=DdlAtomicity.STATEMENT,
+            temporary=False,
+            provenance=PROVENANCE,
+            reason="CTAS and create-then-insert are unavailable",
+        )
+
+
+def test_supported_plan_cannot_include_unsupported_reason():
+    with pytest.raises(ValueError, match="cannot include an unsupported reason"):
+        CreateFromQueryPlan(
+            strategy=CreateFromQueryStrategy.CTAS,
+            atomicity=DdlAtomicity.STATEMENT,
+            temporary=False,
+            provenance=PROVENANCE,
+            reason="This state is contradictory",
+        )
+
+
+@pytest.mark.parametrize("provenance", [(), ("not provenance",), [PROVENANCE[0]]])
+def test_plan_requires_typed_provenance(provenance):
+    error = ValueError if provenance == () else TypeError
+
+    with pytest.raises(error):
+        CreateFromQueryPlan.ctas(
+            temporary=False,
+            atomicity=DdlAtomicity.STATEMENT,
+            provenance=provenance,
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value,error",
+    [
+        ("strategy", "ctas", "strategy"),
+        ("atomicity", "statement", "atomicity"),
+        ("temporary", 1, "temporary"),
+        ("reason", 1, "reason"),
+    ],
+)
+def test_plan_rejects_untyped_fields(field, value, error):
+    kwargs = {
+        "strategy": CreateFromQueryStrategy.CTAS,
+        "atomicity": DdlAtomicity.STATEMENT,
+        "temporary": False,
+        "provenance": PROVENANCE,
+    }
+    kwargs[field] = value
+
+    with pytest.raises(TypeError, match=error):
+        CreateFromQueryPlan(**kwargs)
+
+
+def test_provenance_requires_string_fields():
+    with pytest.raises(TypeError, match="must be strings"):
+        PlanProvenance(rule=1, detail="Invalid rule type")

--- a/dbt-adapters/tests/unit/test_create_from_query_planning.py
+++ b/dbt-adapters/tests/unit/test_create_from_query_planning.py
@@ -1,11 +1,19 @@
+from types import SimpleNamespace
+
 import pytest
 
 from dbt.adapters.base.impl import BaseAdapter
 from dbt.adapters.planning import (
+    CatalogBindingState,
+    CatalogFacts,
+    CreateFromQueryFacts,
     CreateFromQueryPlan,
     CreateFromQueryStrategy,
     DdlAtomicity,
+    FormatFacts,
     PlanProvenance,
+    RelationFacts,
+    RuntimeFacts,
 )
 
 
@@ -16,13 +24,59 @@ PROVENANCE = (
     ),
 )
 
+FACTS = CreateFromQueryFacts(
+    relation=RelationFacts(
+        database="analytics",
+        schema="mart",
+        identifier="orders",
+        relation_type="table",
+    ),
+    catalog=CatalogFacts(state=CatalogBindingState.UNBOUND),
+    format=FormatFacts(),
+    runtime=RuntimeFacts(engine="test"),
+)
+
+
+class PlanningAdapter:
+    _create_from_query_fact_value = staticmethod(BaseAdapter._create_from_query_fact_value)
+    get_create_from_query_runtime_facts = BaseAdapter.get_create_from_query_runtime_facts
+    build_create_from_query_facts = BaseAdapter.build_create_from_query_facts
+    resolve_create_from_query_plan = BaseAdapter.resolve_create_from_query_plan
+
+    catalog_relation = None
+
+    @classmethod
+    def type(cls):
+        return "test"
+
+    def build_catalog_relation(self, model):
+        return self.catalog_relation
+
+
+class TemporaryAwarePlanningAdapter(PlanningAdapter):
+    def get_create_from_query_runtime_facts(self, temporary, relation, model):
+        engine = "temporary-runtime" if temporary else "permanent-runtime"
+        return RuntimeFacts(engine=engine, version="1.0")
+
 
 def test_base_adapter_resolves_portable_ctas_plan():
-    plan = BaseAdapter.plan_create_from_query(None, temporary=False, relation=None)
+    relation = SimpleNamespace(
+        database="analytics",
+        schema="mart",
+        identifier="orders",
+        type="table",
+        catalog=None,
+    )
+    adapter = PlanningAdapter()
+
+    plan = BaseAdapter.plan_create_from_query(
+        adapter, temporary=False, relation=relation, model=None
+    )
 
     assert plan == CreateFromQueryPlan.ctas(
         temporary=False,
         atomicity=DdlAtomicity.UNKNOWN,
+        facts=FACTS,
         provenance=(
             PlanProvenance(
                 rule="base.create_from_query.ctas",
@@ -37,6 +91,7 @@ def test_plan_serializes_to_stable_primitives():
     plan = CreateFromQueryPlan.create_then_insert(
         temporary=True,
         atomicity=DdlAtomicity.TRANSACTION,
+        facts=FACTS,
         provenance=PROVENANCE,
     )
 
@@ -44,6 +99,24 @@ def test_plan_serializes_to_stable_primitives():
         "strategy": "create_then_insert",
         "atomicity": "transaction",
         "temporary": True,
+        "facts": {
+            "relation": {
+                "database": "analytics",
+                "schema": "mart",
+                "identifier": "orders",
+                "relation_type": "table",
+            },
+            "catalog": {
+                "state": "unbound",
+                "integration_name": None,
+                "catalog_type": None,
+                "catalog_name": None,
+                "catalog_database": None,
+                "external_volume": None,
+            },
+            "format": {"table_format": None, "file_format": None},
+            "runtime": {"engine": "test", "version": None},
+        },
         "provenance": [
             {
                 "rule": "test.create_from_query",
@@ -60,6 +133,7 @@ def test_unsupported_plan_requires_reason_and_cannot_promise_atomicity():
             strategy=CreateFromQueryStrategy.UNSUPPORTED,
             atomicity=DdlAtomicity.NONE,
             temporary=False,
+            facts=FACTS,
             provenance=PROVENANCE,
         )
 
@@ -68,6 +142,7 @@ def test_unsupported_plan_requires_reason_and_cannot_promise_atomicity():
             strategy=CreateFromQueryStrategy.UNSUPPORTED,
             atomicity=DdlAtomicity.STATEMENT,
             temporary=False,
+            facts=FACTS,
             provenance=PROVENANCE,
             reason="CTAS and create-then-insert are unavailable",
         )
@@ -79,6 +154,7 @@ def test_supported_plan_cannot_include_unsupported_reason():
             strategy=CreateFromQueryStrategy.CTAS,
             atomicity=DdlAtomicity.STATEMENT,
             temporary=False,
+            facts=FACTS,
             provenance=PROVENANCE,
             reason="This state is contradictory",
         )
@@ -92,6 +168,7 @@ def test_plan_requires_typed_provenance(provenance):
         CreateFromQueryPlan.ctas(
             temporary=False,
             atomicity=DdlAtomicity.STATEMENT,
+            facts=FACTS,
             provenance=provenance,
         )
 
@@ -102,6 +179,7 @@ def test_plan_requires_typed_provenance(provenance):
         ("strategy", "ctas", "strategy"),
         ("atomicity", "statement", "atomicity"),
         ("temporary", 1, "temporary"),
+        ("facts", {}, "facts"),
         ("reason", 1, "reason"),
     ],
 )
@@ -110,6 +188,7 @@ def test_plan_rejects_untyped_fields(field, value, error):
         "strategy": CreateFromQueryStrategy.CTAS,
         "atomicity": DdlAtomicity.STATEMENT,
         "temporary": False,
+        "facts": FACTS,
         "provenance": PROVENANCE,
     }
     kwargs[field] = value
@@ -121,3 +200,132 @@ def test_plan_rejects_untyped_fields(field, value, error):
 def test_provenance_requires_string_fields():
     with pytest.raises(TypeError, match="must be strings"):
         PlanProvenance(rule=1, detail="Invalid rule type")
+
+
+def test_builds_canonical_facts_from_resolved_adapter_objects():
+    adapter = PlanningAdapter()
+    adapter.catalog_relation = SimpleNamespace(
+        catalog_type="ICEBERG_REST",
+        catalog_name="platform_catalog",
+        catalog_database="catalog_db",
+        external_volume="analytics_volume",
+        table_format="ICEBERG",
+        file_format="PARQUET",
+    )
+    relation = SimpleNamespace(
+        database="analytics",
+        schema="mart",
+        identifier="orders",
+        type=SimpleNamespace(value="TABLE"),
+        catalog=None,
+    )
+    model = SimpleNamespace(config={"catalog_name": "analytics_catalog"})
+
+    facts = adapter.build_create_from_query_facts(False, relation, model)
+
+    assert facts.to_dict() == {
+        "relation": {
+            "database": "analytics",
+            "schema": "mart",
+            "identifier": "orders",
+            "relation_type": "table",
+        },
+        "catalog": {
+            "state": "resolved",
+            "integration_name": "analytics_catalog",
+            "catalog_type": "iceberg_rest",
+            "catalog_name": "platform_catalog",
+            "catalog_database": "catalog_db",
+            "external_volume": "analytics_volume",
+        },
+        "format": {"table_format": "iceberg", "file_format": "parquet"},
+        "runtime": {"engine": "test", "version": None},
+    }
+
+
+def test_builds_named_catalog_facts_without_model_resolution():
+    adapter = PlanningAdapter()
+    relation = SimpleNamespace(
+        database="analytics",
+        schema="mart",
+        identifier="orders",
+        type="table",
+        catalog="analytics_catalog",
+    )
+
+    facts = adapter.build_create_from_query_facts(False, relation)
+
+    assert facts.catalog == CatalogFacts(
+        state=CatalogBindingState.NAMED,
+        integration_name="analytics_catalog",
+    )
+
+
+def test_fact_hooks_receive_temporary_operation_context():
+    adapter = TemporaryAwarePlanningAdapter()
+    relation = SimpleNamespace(
+        database="analytics",
+        schema="mart",
+        identifier="orders",
+        type="table",
+        catalog=None,
+    )
+
+    facts = adapter.build_create_from_query_facts(True, relation)
+
+    assert facts.runtime == RuntimeFacts(engine="temporary-runtime", version="1.0")
+
+
+@pytest.mark.parametrize(
+    "factory,error_type,error",
+    [
+        (lambda: RuntimeFacts(engine=1), TypeError, "engine"),  # type: ignore[arg-type]
+        (lambda: RuntimeFacts(engine=""), ValueError, "non-empty"),
+        (
+            lambda: RelationFacts(
+                database=1,  # type: ignore[arg-type]
+                schema="mart",
+                identifier="orders",
+                relation_type="table",
+            ),
+            TypeError,
+            "database",
+        ),
+    ],
+)
+def test_fact_records_reject_invalid_string_fields(factory, error_type, error):
+    with pytest.raises(error_type, match=error):
+        factory()
+
+
+@pytest.mark.parametrize(
+    "kwargs,error",
+    [
+        (
+            {
+                "state": CatalogBindingState.UNBOUND,
+                "integration_name": "analytics_catalog",
+            },
+            "Unbound",
+        ),
+        (
+            {"state": CatalogBindingState.NAMED},
+            "require an integration name",
+        ),
+        (
+            {
+                "state": CatalogBindingState.NAMED,
+                "integration_name": "analytics_catalog",
+                "catalog_type": "iceberg_rest",
+            },
+            "cannot include resolved",
+        ),
+        (
+            {"state": CatalogBindingState.RESOLVED},
+            "require a catalog type",
+        ),
+    ],
+)
+def test_catalog_facts_reject_contradictory_states(kwargs, error):
+    with pytest.raises(ValueError, match=error):
+        CatalogFacts(**kwargs)

--- a/dbt-adapters/tests/unit/test_incremental_planning.py
+++ b/dbt-adapters/tests/unit/test_incremental_planning.py
@@ -5,8 +5,11 @@ import pytest
 from dbt.adapters.base.impl import BaseAdapter
 from dbt.adapters.planning import (
     DdlAtomicity,
+    IncrementalMutationArguments,
     IncrementalMutationStrategy,
+    IncrementalSchemaChangeStrategy,
     resolve_incremental_mutation_plan,
+    resolve_incremental_schema_change_plan,
 )
 from dbt_common.exceptions import DbtRuntimeError
 
@@ -140,3 +143,89 @@ def test_plan_macro_selection_preserves_legacy_adapter_override():
     )
 
     assert BaseAdapter.get_incremental_plan_macro(adapter, {}, plan) is selected_macro
+
+
+@pytest.mark.parametrize(
+    "requested,expected",
+    [
+        (None, IncrementalSchemaChangeStrategy.IGNORE),
+        ("ignore", IncrementalSchemaChangeStrategy.IGNORE),
+        ("append_new_columns", IncrementalSchemaChangeStrategy.APPEND_NEW_COLUMNS),
+        ("sync_all_columns", IncrementalSchemaChangeStrategy.SYNC_ALL_COLUMNS),
+        ("fail", IncrementalSchemaChangeStrategy.FAIL),
+    ],
+)
+def test_resolves_incremental_schema_change_strategy(requested, expected):
+    plan = resolve_incremental_schema_change_plan(requested)
+
+    assert plan.strategy == expected
+    assert plan.was_coerced is False
+
+
+def test_invalid_incremental_schema_change_strategy_uses_default_with_provenance():
+    plan = resolve_incremental_schema_change_plan("replace_everything")
+
+    assert plan.to_dict() == {
+        "requested_strategy": "replace_everything",
+        "strategy": "ignore",
+        "provenance": [
+            {
+                "rule": "incremental.schema_change.invalid_default",
+                "detail": (
+                    "Invalid value for on_schema_change (replace_everything) specified. "
+                    "Setting default value of ignore."
+                ),
+            }
+        ],
+    }
+    assert plan.was_coerced is True
+
+
+def test_incremental_arguments_normalize_at_the_legacy_macro_boundary():
+    target_relation = object()
+    temp_relation = object()
+    dest_columns = [object(), object()]
+
+    arguments = IncrementalMutationArguments.from_values(
+        target_relation=target_relation,
+        temp_relation=temp_relation,
+        unique_key=["account_id", "event_id"],
+        dest_columns=dest_columns,
+        incremental_predicates=["DBT_INTERNAL_DEST.event_at > date '2026-01-01'"],
+    )
+
+    assert arguments.unique_key == ("account_id", "event_id")
+    assert arguments.dest_columns == tuple(dest_columns)
+    assert arguments.incremental_predicates == ("DBT_INTERNAL_DEST.event_at > date '2026-01-01'",)
+    assert arguments.to_macro_dict() == {
+        "target_relation": target_relation,
+        "temp_relation": temp_relation,
+        "unique_key": ["account_id", "event_id"],
+        "dest_columns": dest_columns,
+        "incremental_predicates": ["DBT_INTERNAL_DEST.event_at > date '2026-01-01'"],
+    }
+
+
+@pytest.mark.parametrize(
+    "kwargs,exception,error",
+    [
+        ({"target_relation": None}, ValueError, "target relation"),
+        ({"temp_relation": None}, ValueError, "temporary relation"),
+        ({"unique_key": ""}, ValueError, "unique key"),
+        ({"unique_key": []}, ValueError, "unique key columns"),
+        ({"incremental_predicates": [""]}, ValueError, "predicates"),
+        ({"incremental_predicates": "id > 1"}, TypeError, "sequence"),
+    ],
+)
+def test_incremental_arguments_reject_invalid_inputs(kwargs, exception, error):
+    values = {
+        "target_relation": object(),
+        "temp_relation": object(),
+        "unique_key": None,
+        "dest_columns": [],
+        "incremental_predicates": None,
+    }
+    values.update(kwargs)
+
+    with pytest.raises(exception, match=error):
+        IncrementalMutationArguments.from_values(**values)

--- a/dbt-adapters/tests/unit/test_incremental_planning.py
+++ b/dbt-adapters/tests/unit/test_incremental_planning.py
@@ -1,0 +1,142 @@
+from types import SimpleNamespace
+
+import pytest
+
+from dbt.adapters.base.impl import BaseAdapter
+from dbt.adapters.planning import (
+    DdlAtomicity,
+    IncrementalMutationStrategy,
+    resolve_incremental_mutation_plan,
+)
+from dbt_common.exceptions import DbtRuntimeError
+
+
+BUILTIN_STRATEGIES = ["append", "delete+insert", "merge", "insert_overwrite", "microbatch"]
+
+
+@pytest.mark.parametrize(
+    "requested,expected_strategy,expected_macro",
+    [
+        (None, IncrementalMutationStrategy.ADAPTER_DEFAULT, "get_incremental_default_sql"),
+        ("append", IncrementalMutationStrategy.APPEND, "get_incremental_append_sql"),
+        (
+            "delete+insert",
+            IncrementalMutationStrategy.DELETE_INSERT,
+            "get_incremental_delete_insert_sql",
+        ),
+        ("merge", IncrementalMutationStrategy.MERGE, "get_incremental_merge_sql"),
+        (
+            "insert_overwrite",
+            IncrementalMutationStrategy.INSERT_OVERWRITE,
+            "get_incremental_insert_overwrite_sql",
+        ),
+        (
+            "microbatch",
+            IncrementalMutationStrategy.MICROBATCH,
+            "get_incremental_microbatch_sql",
+        ),
+        (
+            "my_strategy",
+            IncrementalMutationStrategy.CUSTOM,
+            "get_incremental_my_strategy_sql",
+        ),
+    ],
+)
+def test_resolves_incremental_strategy_to_renderer(requested, expected_strategy, expected_macro):
+    plan = resolve_incremental_mutation_plan(
+        requested,
+        valid_strategies=BUILTIN_STRATEGIES,
+        builtin_strategies=BUILTIN_STRATEGIES,
+    )
+
+    assert plan.strategy == expected_strategy
+    assert plan.renderer_macro == expected_macro
+    assert plan.atomicity == DdlAtomicity.UNKNOWN
+    assert plan.reason is None
+
+
+def test_unsupported_builtin_strategy_is_an_explicit_plan():
+    plan = resolve_incremental_mutation_plan(
+        "merge",
+        valid_strategies=["append"],
+        builtin_strategies=BUILTIN_STRATEGIES,
+    )
+
+    assert plan.to_dict() == {
+        "requested_strategy": "merge",
+        "strategy": "unsupported",
+        "renderer_macro": None,
+        "atomicity": "none",
+        "provenance": [
+            {
+                "rule": "incremental.requested_strategy.unsupported",
+                "detail": "The incremental strategy 'merge' is not valid for this adapter",
+            }
+        ],
+        "reason": "The incremental strategy 'merge' is not valid for this adapter",
+    }
+
+
+def test_base_adapter_resolver_uses_adapter_strategy_support():
+    adapter = SimpleNamespace(
+        valid_incremental_strategies=lambda: ["append"],
+        builtin_incremental_strategies=lambda: BUILTIN_STRATEGIES,
+    )
+
+    plan = BaseAdapter.plan_incremental_mutation(adapter, "merge")
+
+    assert plan.strategy == IncrementalMutationStrategy.UNSUPPORTED
+
+
+def test_plan_macro_selection_preserves_missing_macro_error():
+    adapter = SimpleNamespace(
+        config=SimpleNamespace(project_name="test_project"),
+        get_incremental_strategy_macro=lambda context, strategy: BaseAdapter.get_incremental_strategy_macro(
+            adapter, context, strategy
+        ),
+        plan_incremental_mutation=lambda strategy: resolve_incremental_mutation_plan(
+            strategy,
+            valid_strategies=["append"],
+            builtin_strategies=BUILTIN_STRATEGIES,
+        ),
+        _get_incremental_plan_macro=lambda context, plan: BaseAdapter._get_incremental_plan_macro(
+            adapter, context, plan
+        ),
+    )
+    plan = resolve_incremental_mutation_plan(
+        "my_strategy",
+        valid_strategies=["append"],
+        builtin_strategies=BUILTIN_STRATEGIES,
+    )
+
+    with pytest.raises(DbtRuntimeError, match="get_incremental_my_strategy_sql"):
+        BaseAdapter.get_incremental_plan_macro(adapter, {}, plan)
+
+
+def test_plan_macro_selection_rejects_unsupported_plan():
+    adapter = SimpleNamespace(
+        config=SimpleNamespace(project_name="test_project"),
+        get_incremental_strategy_macro=lambda context, strategy: None,
+    )
+    plan = resolve_incremental_mutation_plan(
+        "merge",
+        valid_strategies=["append"],
+        builtin_strategies=BUILTIN_STRATEGIES,
+    )
+
+    with pytest.raises(DbtRuntimeError, match="not valid for this adapter"):
+        BaseAdapter.get_incremental_plan_macro(adapter, {}, plan)
+
+
+def test_plan_macro_selection_preserves_legacy_adapter_override():
+    selected_macro = object()
+    adapter = SimpleNamespace(
+        get_incremental_strategy_macro=lambda context, strategy: selected_macro,
+    )
+    plan = resolve_incremental_mutation_plan(
+        "my_strategy",
+        valid_strategies=["append"],
+        builtin_strategies=BUILTIN_STRATEGIES,
+    )
+
+    assert BaseAdapter.get_incremental_plan_macro(adapter, {}, plan) is selected_macro

--- a/dbt-adapters/tests/unit/test_incremental_planning.py
+++ b/dbt-adapters/tests/unit/test_incremental_planning.py
@@ -181,6 +181,13 @@ def test_invalid_incremental_schema_change_strategy_uses_default_with_provenance
     assert plan.was_coerced is True
 
 
+def test_incremental_schema_change_resolver_honors_compatibility_macro_default():
+    plan = resolve_incremental_schema_change_plan("replace_everything", default="fail")
+
+    assert plan.strategy == IncrementalSchemaChangeStrategy.FAIL
+    assert plan.was_coerced is True
+
+
 def test_incremental_arguments_normalize_at_the_legacy_macro_boundary():
     target_relation = object()
     temp_relation = object()


### PR DESCRIPTION
## Summary

- introduce immutable, validated create-from-query plans with provenance and stable serialization
- resolve default CTAS behavior in Python before Jinja renders SQL
- introduce typed incremental mutation strategy plans for built-in, custom, and unsupported strategies
- preserve existing adapter macro dispatch and legacy incremental selector overrides

This is a proof of concept for capability-driven DDL/materialization planning. It intentionally keeps Jinja as the renderer and compatibility layer while moving strategy inference into Python.

## Validation

- pre-commit: boundary check, Black, Flake8, and MyPy
- 87 focused unit tests passed
- live dbt-duckdb table materialization passed
- live incremental full-refresh and update passed

## Follow-up

- model resolved relation, catalog, format, and runtime facts as planner inputs
- add typed schema-reconciliation and incremental argument plans
- replace the adapter-default compatibility variant with a fully resolved physical strategy where possible
