### PR TITLE
feat(spark): support three-part identifiers

### DIFF
--- a/dbt-spark/.changes/unreleased/Features-20260824-193243.yaml
+++ b/dbt-spark/.changes/unreleased/Features-20260824-193243.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add catalog-qualified three-part identifiers to dbt-spark while preserving legacy matching database and schema profiles as two-part identifiers.
+time: 2026-08-24T19:32:43.000000+05:30
+custom:
+  Author: Amogh-2404
+  Issue: "495 2129"

--- a/dbt-spark/.changes/unreleased/Features-20260824-193243.yaml
+++ b/dbt-spark/.changes/unreleased/Features-20260824-193243.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Add catalog-qualified three-part identifiers to dbt-spark while preserving legacy matching database and schema profiles as two-part identifiers.
+body: Add catalog-qualified three-part identifiers to dbt-spark. Profile `catalog` maps to dbt's `database`; model and source `database` configurations now select a catalog. Legacy profiles with matching `database` and `schema` remain two-part.
 time: 2026-08-24T19:32:43.000000+05:30
 custom:
   Author: Amogh-2404

--- a/dbt-spark/src/dbt/adapters/spark/connections.py
+++ b/dbt-spark/src/dbt/adapters/spark/connections.py
@@ -51,6 +51,7 @@ import time
 logger = AdapterLogger("Spark")
 
 NUMBERS = DECIMALS + (int, float)
+CATALOG_ALIAS_MARKER = "__dbt_spark_catalog_provided"
 
 # Exception types that indicate a lost connection during query polling
 # Built once at module load time to avoid reconstructing on every poll
@@ -108,11 +109,28 @@ class SparkCredentials(Credentials):
     query_timeout: Optional[int] = None
     poll_interval: int = 5  # Polling interval in seconds for async queries
     query_retries: int = 1  # Number of times to retry on connection loss during query execution
+    _ALIASES = {"catalog": "database"}
+
+    @classmethod
+    def translate_aliases(cls, kwargs: Dict[str, Any], recurse: bool = False) -> Dict[str, Any]:
+        # Profiles translate aliases before Credentials.from_dict runs. Preserve
+        # whether catalog was explicit so the legacy database == schema shape
+        # can remain a two-part identifier.
+        catalog_provided = kwargs.get(CATALOG_ALIAS_MARKER, False) or "catalog" in kwargs
+        translated = super().translate_aliases(kwargs, recurse)
+        if catalog_provided:
+            translated[CATALOG_ALIAS_MARKER] = True
+        return translated
 
     @classmethod
     def __pre_deserialize__(cls, data: Any) -> Any:
         data = super().__pre_deserialize__(data)
+        catalog_provided = data.pop(CATALOG_ALIAS_MARKER, False)
         if "database" not in data:
+            data["database"] = None
+        elif not catalog_provided and data["database"] == data.get("schema"):
+            # Before three-part support, this was the only accepted value for
+            # database and SparkCredentials always discarded it.
             data["database"] = None
         return data
 
@@ -128,15 +146,10 @@ class SparkCredentials(Credentials):
         if self.schema is None:
             raise DbtRuntimeError("Must specify `schema` in profile")
 
-        # spark classifies database and schema as the same thing
-        if self.database is not None and self.database != self.schema:
-            raise DbtRuntimeError(
-                f"    schema: {self.schema} \n"
-                f"    database: {self.database} \n"
-                f"On Spark, database must be omitted or have the same value as"
-                f" schema."
-            )
-        self.database = None
+        if self.database is not None:
+            self.database = self.database.strip()
+            if not self.database:
+                raise DbtConfigError("Catalog cannot be empty")
 
         if self.method == SparkConnectionMethod.ODBC:
             try:
@@ -199,7 +212,7 @@ class SparkCredentials(Credentials):
         return self.host  # type: ignore
 
     def _connection_keys(self) -> Tuple[str, ...]:
-        return "host", "port", "cluster", "endpoint", "schema", "organization"
+        return "host", "port", "cluster", "endpoint", "database", "schema", "organization"
 
 
 class SparkConnectionWrapper(ABC):

--- a/dbt-spark/src/dbt/adapters/spark/impl.py
+++ b/dbt-spark/src/dbt/adapters/spark/impl.py
@@ -129,7 +129,7 @@ class SparkAdapter(SQLAdapter):
     }
 
     Relation: TypeAlias = SparkRelation
-    RelationInfo = Tuple[str, str, str]
+    RelationInfo = Tuple[str, str, bool, str]
     Column: TypeAlias = SparkColumn
     ConnectionManager: TypeAlias = SparkConnectionManager
     AdapterSpecificConfigs: TypeAlias = SparkConfig
@@ -171,30 +171,36 @@ class SparkAdapter(SQLAdapter):
     def _get_relation_information(self, row: "agate.Row") -> RelationInfo:
         """relation info was fetched with SHOW TABLES EXTENDED"""
         try:
-            _schema, name, _, information = row
+            _schema, name, is_temporary, information = row
         except ValueError:
             raise DbtRuntimeError(
                 f'Invalid value from "show tables extended ...", got {len(row)} values, expected 4'
             )
 
-        return _schema, name, information
+        return _schema, name, is_temporary, information
 
-    def _get_relation_information_using_describe(self, row: "agate.Row") -> RelationInfo:
+    def _get_relation_information_using_describe(
+        self, row: "agate.Row", schema_relation: BaseRelation
+    ) -> RelationInfo:
         """Relation info fetched using SHOW TABLES and an auxiliary DESCRIBE statement"""
         try:
-            _schema, name, _ = row
+            _schema, name, is_temporary = row
         except ValueError:
             raise DbtRuntimeError(
                 f'Invalid value from "show tables ...", got {len(row)} values, expected 3'
             )
 
-        table_name = f"{_schema}.{name}"
+        if is_temporary:
+            return _schema, name, is_temporary, ""
+
+        table_relation = schema_relation.replace_path(identifier=name).include(identifier=True)
         try:
             table_results = self.execute_macro(
-                DESCRIBE_TABLE_EXTENDED_MACRO_NAME, kwargs={"table_name": table_name}
+                DESCRIBE_TABLE_EXTENDED_MACRO_NAME,
+                kwargs={"table_name": table_relation},
             )
         except DbtRuntimeError as e:
-            logger.debug(f"Error while retrieving information about {table_name}: {e.msg}")
+            logger.debug(f"Error while retrieving information about {table_relation}: {e.msg}")
             table_results = AttrDict()
 
         information = ""
@@ -203,17 +209,26 @@ class SparkAdapter(SQLAdapter):
             if not info_type.startswith("#"):
                 information += f"{info_type}: {info_value}\n"
 
-        return _schema, name, information
+        return _schema, name, is_temporary, information
 
     def _build_spark_relation_list(
         self,
         row_list: "agate.Table",
         relation_info_func: Callable[["agate.Row"], RelationInfo],
+        schema_relation: BaseRelation,
     ) -> List[BaseRelation]:
         """Aggregate relations with format metadata included."""
         relations = []
         for row in row_list:
-            _schema, name, information = relation_info_func(row)
+            returned_schema, name, is_temporary, information = relation_info_func(row)
+            if is_temporary:
+                continue
+
+            relation_schema = returned_schema or schema_relation.schema
+            if schema_relation.database is None and "." in (schema_relation.schema or ""):
+                # Preserve the legacy catalog.namespace schema workaround. Spark
+                # reports only the final namespace component in SHOW results.
+                relation_schema = schema_relation.schema
 
             rel_type: RelationType = (
                 RelationType.View
@@ -225,7 +240,8 @@ class SparkAdapter(SQLAdapter):
             is_iceberg: bool = "Provider: iceberg" in information
 
             relation: BaseRelation = self.Relation.create(
-                schema=_schema,
+                database=schema_relation.database,
+                schema=relation_schema,
                 identifier=name,
                 type=rel_type,
                 information=information,
@@ -243,12 +259,28 @@ class SparkAdapter(SQLAdapter):
 
         kwargs = {"schema_relation": schema_relation}
 
+        def list_relations_using_show_tables() -> List[BaseRelation]:
+            show_table_rows = self.execute_macro(
+                LIST_RELATIONS_SHOW_TABLES_MACRO_NAME, kwargs=kwargs
+            )
+            return self._build_spark_relation_list(
+                row_list=show_table_rows,
+                relation_info_func=lambda row: self._get_relation_information_using_describe(
+                    row, schema_relation
+                ),
+                schema_relation=schema_relation,
+            )
+
         try:
+            if schema_relation.database:
+                return list_relations_using_show_tables()
+
             # Default compute engine behavior: show tables extended
             show_table_extended_rows = self.execute_macro(LIST_RELATIONS_MACRO_NAME, kwargs=kwargs)
             return self._build_spark_relation_list(
                 row_list=show_table_extended_rows,
                 relation_info_func=self._get_relation_information,
+                schema_relation=schema_relation,
             )
         except DbtRuntimeError as e:
             errmsg = getattr(e, "msg", "")
@@ -260,21 +292,9 @@ class SparkAdapter(SQLAdapter):
             elif "SHOW TABLE EXTENDED is not supported for v2 tables" in errmsg:
                 # this happens with spark-iceberg with v2 iceberg tables
                 # https://issues.apache.org/jira/browse/SPARK-33393
-                show_table_rows = self.execute_macro(
-                    LIST_RELATIONS_SHOW_TABLES_MACRO_NAME, kwargs=kwargs
-                )
-                return self._build_spark_relation_list(
-                    row_list=show_table_rows,
-                    relation_info_func=self._get_relation_information_using_describe,
-                )
+                return list_relations_using_show_tables()
             else:
                 raise
-
-    def get_relation(self, database: str, schema: str, identifier: str) -> Optional[BaseRelation]:
-        if not self.Relation.get_default_include_policy().database:
-            database = None  # type: ignore
-
-        return super().get_relation(database, schema, identifier)
 
     def parse_describe_extended(
         self, relation: BaseRelation, raw_rows: AttrDict
@@ -293,7 +313,7 @@ class SparkAdapter(SQLAdapter):
         table_stats = SparkColumn.convert_table_stats(raw_table_stats)
         return [
             SparkColumn(
-                table_database=None,
+                table_database=relation.database,
                 table_schema=relation.schema,
                 table_name=relation.name,
                 table_type=relation.type,
@@ -351,7 +371,7 @@ class SparkAdapter(SQLAdapter):
         for match_num, match in enumerate(matches):
             column_name, column_type, nullable = match.groups()
             column = SparkColumn(
-                table_database=None,
+                table_database=relation.database,
                 table_schema=relation.schema,
                 table_name=relation.table,
                 table_type=relation.type,
@@ -383,7 +403,7 @@ class SparkAdapter(SQLAdapter):
             as_dict = column.to_column_dict()
             as_dict["column_name"] = as_dict.pop("column", None)
             as_dict["column_type"] = as_dict.pop("dtype")
-            as_dict["table_database"] = None
+            as_dict["table_database"] = relation.database
             yield as_dict
 
     def get_catalog(
@@ -392,23 +412,20 @@ class SparkAdapter(SQLAdapter):
         used_schemas: FrozenSet[Tuple[str, str]],
     ) -> Tuple["agate.Table", List[Exception]]:
         schema_map = self._get_catalog_schemas(relation_configs)
-        if len(schema_map) > 1:
-            raise CompilationError(
-                f"Expected only one database in get_catalog, found " f"{list(schema_map)}"
-            )
 
         with executor(self.config) as tpe:
             futures: List[Future["agate.Table"]] = []
             for info, schemas in schema_map.items():
                 for schema in schemas:
+                    connection_name = f"{info.database}.{schema}" if info.database else schema
                     futures.append(
                         tpe.submit_connected(
                             self,
-                            schema,
+                            connection_name,
                             self._get_one_catalog,
                             info,
                             [schema],
-                            relation_configs,
+                            used_schemas,
                         )
                     )
             catalogs, exceptions = catch_as_completed(futures)

--- a/dbt-spark/src/dbt/adapters/spark/impl.py
+++ b/dbt-spark/src/dbt/adapters/spark/impl.py
@@ -243,6 +243,7 @@ class SparkAdapter(SQLAdapter):
                 database=schema_relation.database,
                 schema=relation_schema,
                 identifier=name,
+                quote_policy=schema_relation.quote_policy,
                 type=rel_type,
                 information=information,
                 is_delta=is_delta,
@@ -456,9 +457,7 @@ class SparkAdapter(SQLAdapter):
 
     def check_schema_exists(self, database: str, schema: str) -> bool:
         results = self.execute_macro(LIST_SCHEMAS_MACRO_NAME, kwargs={"database": database})
-
-        exists = True if schema in [row[0] for row in results] else False
-        return exists
+        return schema.lower() in (str(row[0]).lower() for row in results)
 
     def get_rows_different_sql(
         self,

--- a/dbt-spark/src/dbt/adapters/spark/relation.py
+++ b/dbt-spark/src/dbt/adapters/spark/relation.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 
 from dbt.adapters.base.relation import BaseRelation, Policy
 from dbt.adapters.contracts.relation import ComponentName
+from dbt_common.exceptions import DbtRuntimeError
 
 
 @dataclass
@@ -30,6 +31,10 @@ class SparkRelation(BaseRelation):
     # TODO: make this a dict everywhere
     information: Optional[str] = None
     require_alias: bool = False
+
+    def __post_init__(self) -> None:
+        if self.database is not None and not self.database.strip():
+            raise DbtRuntimeError("Catalog cannot be empty")
 
     def _is_exactish_match(self, field: ComponentName, value: str) -> bool:
         if self.quote_policy.get_part(field) is False:

--- a/dbt-spark/src/dbt/adapters/spark/relation.py
+++ b/dbt-spark/src/dbt/adapters/spark/relation.py
@@ -1,14 +1,8 @@
-from typing import Optional, TypeVar
+from typing import Optional
 from dataclasses import dataclass, field
 
 from dbt.adapters.base.relation import BaseRelation, Policy
-from dbt.adapters.events.logging import AdapterLogger
-
-from dbt_common.exceptions import DbtRuntimeError
-
-logger = AdapterLogger("Spark")
-
-Self = TypeVar("Self", bound="BaseRelation")
+from dbt.adapters.contracts.relation import ComponentName
 
 
 @dataclass
@@ -20,7 +14,7 @@ class SparkQuotePolicy(Policy):
 
 @dataclass
 class SparkIncludePolicy(Policy):
-    database: bool = False
+    database: bool = True
     schema: bool = True
     identifier: bool = True
 
@@ -37,14 +31,7 @@ class SparkRelation(BaseRelation):
     information: Optional[str] = None
     require_alias: bool = False
 
-    def __post_init__(self) -> None:
-        if self.database != self.schema and self.database:
-            raise DbtRuntimeError("Cannot set database in spark!")
-
-    def render(self) -> str:
-        if self.include_policy.database and self.include_policy.schema:
-            raise DbtRuntimeError(
-                "Got a spark relation with schema and database set to "
-                "include, but only one can be set"
-            )
-        return super().render()
+    def _is_exactish_match(self, field: ComponentName, value: str) -> bool:
+        if self.quote_policy.get_part(field) is False:
+            return self.path.get_lowered_part(field) == value.lower()
+        return super()._is_exactish_match(field, value)

--- a/dbt-spark/src/dbt/include/spark/macros/adapters.sql
+++ b/dbt-spark/src/dbt/include/spark/macros/adapters.sql
@@ -293,8 +293,9 @@
 {% endmacro %}
 
 {% macro spark__list_relations_without_caching(relation) %}
+  {% set schema_relation = relation if relation is string else relation.without_identifier() %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
-    show table extended in {{ relation.schema }} like '*'
+    show table extended in {{ schema_relation }} like '*'
   {% endcall %}
 
   {% do return(load_result('list_relations_without_caching').table) %}
@@ -304,8 +305,9 @@
   {#-- Spark with iceberg tables don't work with show table extended for #}
   {#-- V2 iceberg tables #}
   {#-- https://issues.apache.org/jira/browse/SPARK-33393 #}
+  {% set schema_relation = schema_relation if schema_relation is string else schema_relation.without_identifier() %}
   {% call statement('list_relations_without_caching_show_tables', fetch_result=True) -%}
-    show tables in {{ schema_relation.schema }} like '*'
+    show tables in {{ schema_relation }} like '*'
   {% endcall %}
 
   {% do return(load_result('list_relations_without_caching_show_tables').table) %}
@@ -323,7 +325,11 @@
 
 {% macro spark__list_schemas(database) -%}
   {% call statement('list_schemas', fetch_result=True, auto_begin=False) %}
-    show databases
+    {% if database %}
+      show namespaces in {{ adapter.quote(database) }}
+    {% else %}
+      show databases
+    {% endif %}
   {% endcall %}
   {{ return(load_result('list_schemas').table) }}
 {% endmacro %}
@@ -350,7 +356,7 @@
 
 
 {% macro spark__generate_database_name(custom_database_name=none, node=none) -%}
-  {% do return(None) %}
+  {% do return(default__generate_database_name(custom_database_name, node)) %}
 {%- endmacro %}
 
 {% macro spark__persist_docs(relation, model, for_relation, for_columns) -%}

--- a/dbt-spark/src/dbt/include/spark/macros/adapters.sql
+++ b/dbt-spark/src/dbt/include/spark/macros/adapters.sql
@@ -326,7 +326,13 @@
 {% macro spark__list_schemas(database) -%}
   {% call statement('list_schemas', fetch_result=True, auto_begin=False) %}
     {% if database %}
-      show namespaces in {{ adapter.quote(database) }}
+      {# dbt-core's create_schemas passes str(relation), which may already be quoted. #}
+      {% if database.startswith('`') and database.endswith('`') %}
+        {% set quoted_database = database %}
+      {% else %}
+        {% set quoted_database = adapter.quote(database) %}
+      {% endif %}
+      show namespaces in {{ quoted_database }}
     {% else %}
       show databases
     {% endif %}

--- a/dbt-spark/src/dbt/include/spark/macros/materializations/snapshot.sql
+++ b/dbt-spark/src/dbt/include/spark/macros/materializations/snapshot.sql
@@ -53,7 +53,7 @@
     {% else %}
       {%- set tmp_relation = api.Relation.create(identifier=tmp_identifier,
                                                     schema=target_relation.schema,
-                                                    database=none,
+                                                    database=target_relation.database,
                                                     type='view') -%}
     {% endif %}
 
@@ -96,7 +96,7 @@
   {%- set grant_config = config.get('grants') -%}
 
   {% set target_relation_exists, target_relation = get_or_create_relation(
-          database=none,
+          database=model.database,
           schema=model.schema,
           identifier=target_table,
           type='table') -%}
@@ -119,7 +119,7 @@
   {% endif %}
 
   {% if not adapter.check_schema_exists(model.database, model.schema) %}
-    {% do create_schema(model.schema) %}
+    {% do create_schema(target_relation.without_identifier()) %}
   {% endif %}
 
   {%- if not target_relation.is_table -%}

--- a/dbt-spark/src/dbt/include/spark/macros/materializations/snapshot.sql
+++ b/dbt-spark/src/dbt/include/spark/macros/materializations/snapshot.sql
@@ -18,7 +18,7 @@
     merge into {{ target }} as DBT_INTERNAL_DEST
     {% if target.is_iceberg %}
       {# create view only supports a name (no catalog, or schema) #}
-      using {{ source.identifier }} as DBT_INTERNAL_SOURCE
+      using {{ source.include(database=false, schema=false) }} as DBT_INTERNAL_SOURCE
     {% else %}
       using {{ source }} as DBT_INTERNAL_SOURCE
     {% endif %}
@@ -46,15 +46,13 @@
 
     {% if target_relation.is_iceberg %}
       {# iceberg catalog does not support create view, but regular spark does. We removed the catalog and schema #}
-      {%- set tmp_relation = api.Relation.create(identifier=tmp_identifier,
-                                                    schema=none,
-                                                    database=none,
-                                                    type='view') -%}
+      {%- set tmp_relation = target_relation.incorporate(
+            path={'identifier': tmp_identifier, 'schema': none, 'database': none},
+            type='view') -%}
     {% else %}
-      {%- set tmp_relation = api.Relation.create(identifier=tmp_identifier,
-                                                    schema=target_relation.schema,
-                                                    database=target_relation.database,
-                                                    type='view') -%}
+      {%- set tmp_relation = target_relation.incorporate(
+            path={'identifier': tmp_identifier},
+            type='view') -%}
     {% endif %}
 
     {% set select = snapshot_staging_table(strategy, sql, target_relation) %}
@@ -100,6 +98,10 @@
           schema=model.schema,
           identifier=target_table,
           type='table') -%}
+
+  {%- if not target_relation_exists -%}
+    {%- set target_relation = this.incorporate(type='table') -%}
+  {%- endif -%}
 
   {%- if file_format not in ['delta', 'iceberg', 'hudi'] -%}
     {% set invalid_format_msg -%}

--- a/dbt-spark/src/dbt/include/spark/macros/materializations/table.sql
+++ b/dbt-spark/src/dbt/include/spark/macros/materializations/table.sql
@@ -4,10 +4,7 @@
   {%- set grant_config = config.get('grants') -%}
 
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
-  {%- set target_relation = api.Relation.create(identifier=identifier,
-                                                schema=schema,
-                                                database=database,
-                                                type='table') -%}
+  {%- set target_relation = this.incorporate(type='table') -%}
 
   {{ run_hooks(pre_hooks) }}
 

--- a/dbt-spark/src/dbt/include/spark/macros/materializations/view.sql
+++ b/dbt-spark/src/dbt/include/spark/macros/materializations/view.sql
@@ -1,3 +1,30 @@
 {% materialization view, adapter='spark' -%}
-    {{ return(create_or_replace_view()) }}
+    {{ return(spark_create_or_replace_view()) }}
 {%- endmaterialization %}
+
+
+{% macro spark_create_or_replace_view() %}
+  {%- set identifier = model['alias'] -%}
+
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
+  {%- set target_relation = this.incorporate(type='view') -%}
+  {% set grant_config = config.get('grants') %}
+
+  {{ run_hooks(pre_hooks) }}
+
+  {%- if old_relation is not none and old_relation.is_table -%}
+    {{ handle_existing_table(should_full_refresh(), old_relation) }}
+  {%- endif -%}
+
+  {% call statement('main') -%}
+    {{ get_create_view_as_sql(target_relation, sql) }}
+  {%- endcall %}
+
+  {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {{ run_hooks(post_hooks) }}
+
+  {{ return({'relations': [target_relation]}) }}
+{% endmacro %}

--- a/dbt-spark/tests/functional/adapter/test_three_part_identifiers.py
+++ b/dbt-spark/tests/functional/adapter/test_three_part_identifiers.py
@@ -1,0 +1,60 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+from tests.functional.fixtures.profiles import spark_session_target
+
+
+INCREMENTAL_MODEL = """
+{{ config(materialized='incremental', incremental_strategy='append') }}
+
+select 1 as id
+{% if is_incremental() %}
+union all
+select 2 as id
+{% endif %}
+"""
+
+
+@pytest.mark.skip_profile(
+    "apache_spark",
+    "spark_http_odbc",
+    "databricks_cluster",
+    "databricks_http_cluster",
+    "databricks_sql_endpoint",
+)
+class TestThreePartIdentifiers:
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self):
+        target = spark_session_target()
+        target["catalog"] = "spark_catalog"
+        return target
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"events.sql": INCREMENTAL_MODEL}
+
+    def test_catalog_qualified_incremental_and_docs(self, project):
+        assert project.database == "spark_catalog"
+
+        first_run = run_dbt(["run"])
+        second_run = run_dbt(["run"])
+        assert len(first_run) == 1
+        assert len(second_run) == 1
+
+        with project.adapter.connection_named("__test"):
+            relation = project.adapter.get_relation(
+                database=project.database,
+                schema=project.test_schema,
+                identifier="events",
+            )
+            assert relation is not None
+            assert str(relation) == f"spark_catalog.{project.test_schema}.events"
+            assert project.adapter.check_schema_exists(project.database, project.test_schema)
+
+        row_count = project.run_sql(f"select count(*) from {relation}", fetch="one")
+        assert row_count[0] == 3
+
+        catalog = run_dbt(["docs", "generate"])
+        table = catalog.nodes["model.test.events"]
+        assert table.metadata.database == "spark_catalog"
+        assert table.metadata.schema == project.test_schema

--- a/dbt-spark/tests/functional/adapter/test_three_part_identifiers.py
+++ b/dbt-spark/tests/functional/adapter/test_three_part_identifiers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dbt.tests.util import run_dbt
+from dbt.tests.util import run_dbt, run_dbt_and_capture
 from tests.functional.fixtures.profiles import spark_session_target
 
 
@@ -12,6 +12,18 @@ select 1 as id
 union all
 select 2 as id
 {% endif %}
+"""
+
+TABLE_MODEL = """
+{{ config(materialized='table', alias='table_events') }}
+
+select 1 as id
+"""
+
+VIEW_MODEL = """
+{{ config(materialized='view', alias='view_events') }}
+
+select 1 as id
 """
 
 
@@ -30,16 +42,36 @@ class TestThreePartIdentifiers:
         return target
 
     @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "quoting": {
+                "database": True,
+                "schema": True,
+                "identifier": True,
+            }
+        }
+
+    @pytest.fixture(scope="class")
     def models(self):
-        return {"events.sql": INCREMENTAL_MODEL}
+        return {
+            "events.sql": INCREMENTAL_MODEL,
+            "quoted_events.sql": TABLE_MODEL,
+            "quoted_view.sql": VIEW_MODEL,
+        }
 
     def test_catalog_qualified_incremental_and_docs(self, project):
         assert project.database == "spark_catalog"
 
-        first_run = run_dbt(["run"])
+        first_run, first_run_logs = run_dbt_and_capture(["--debug", "run"])
         second_run = run_dbt(["run"])
-        assert len(first_run) == 1
-        assert len(second_run) == 1
+        assert len(first_run) == 3
+        assert len(second_run) == 3
+
+        rendered_logs = " ".join(first_run_logs.split())
+        table_relation = f"`spark_catalog`.`{project.test_schema}`.`table_events`"
+        view_relation = f"`spark_catalog`.`{project.test_schema}`.`view_events`"
+        assert f"create table {table_relation}" in rendered_logs
+        assert f"create or replace view {view_relation}" in rendered_logs
 
         with project.adapter.connection_named("__test"):
             relation = project.adapter.get_relation(
@@ -48,8 +80,24 @@ class TestThreePartIdentifiers:
                 identifier="events",
             )
             assert relation is not None
-            assert str(relation) == f"spark_catalog.{project.test_schema}.events"
-            assert project.adapter.check_schema_exists(project.database, project.test_schema)
+            assert str(relation) == f"`spark_catalog`.`{project.test_schema}`.`events`"
+            quoted_relation = project.adapter.get_relation(
+                database=project.database,
+                schema=project.test_schema,
+                identifier="table_events",
+            )
+            assert quoted_relation is not None
+            assert str(quoted_relation) == table_relation
+            quoted_view = project.adapter.get_relation(
+                database=project.database,
+                schema=project.test_schema,
+                identifier="view_events",
+            )
+            assert quoted_view is not None
+            assert str(quoted_view) == view_relation
+            assert project.adapter.check_schema_exists(
+                project.database.upper(), project.test_schema.upper()
+            )
 
         row_count = project.run_sql(f"select count(*) from {relation}", fetch="one")
         assert row_count[0] == 3
@@ -58,3 +106,9 @@ class TestThreePartIdentifiers:
         table = catalog.nodes["model.test.events"]
         assert table.metadata.database == "spark_catalog"
         assert table.metadata.schema == project.test_schema
+        quoted_table = catalog.nodes["model.test.quoted_events"]
+        assert quoted_table.metadata.database == "spark_catalog"
+        assert quoted_table.metadata.schema == project.test_schema
+        quoted_view = catalog.nodes["model.test.quoted_view"]
+        assert quoted_view.metadata.database == "spark_catalog"
+        assert quoted_view.metadata.schema == project.test_schema

--- a/dbt-spark/tests/unit/test_adapter.py
+++ b/dbt-spark/tests/unit/test_adapter.py
@@ -442,6 +442,15 @@ class TestSparkAdapter(unittest.TestCase):
         )
         self.assertEqual(relation.render(), "catalog.analytics.events")
 
+        for blank_database in ("", "   "):
+            with self.subTest(blank_database=blank_database):
+                with self.assertRaisesRegex(DbtRuntimeError, "Catalog cannot be empty"):
+                    adapter.Relation.create(
+                        database=blank_database,
+                        schema="analytics",
+                        identifier="events",
+                    )
+
     def test_profile_with_database(self):
         profile = {
             "outputs": {
@@ -544,6 +553,15 @@ class TestSparkAdapter(unittest.TestCase):
                     relation = adapter.get_relation(database, requested_schema, "EVENTS")
 
                 self.assertEqual(relation, discovered)
+
+    def test_check_schema_exists_is_case_insensitive(self):
+        adapter = SparkAdapter(self.target_http, get_context("spawn"))
+        with mock.patch.object(
+            adapter,
+            "execute_macro",
+            return_value=[("analytics",), ("staging",)],
+        ):
+            self.assertTrue(adapter.check_schema_exists("MyCatalog", "Analytics"))
 
     def test_profile_with_cluster_and_sql_endpoint(self):
         profile = {
@@ -867,6 +885,29 @@ class TestListRelationsWithoutCaching(unittest.TestCase):
         second = adapter.cache.get_relations("catalog_two", "analytics")
         self.assertEqual([relation.database for relation in first], ["catalog_one"])
         self.assertEqual([relation.database for relation in second], ["catalog_two"])
+
+    def test_discovered_relation_preserves_quote_policy(self):
+        adapter = self._make_adapter()
+        schema_relation = adapter.Relation.create(
+            database="catalog-name",
+            schema="namespace-name",
+            identifier="",
+            quote_policy={"database": True, "schema": True, "identifier": True},
+        ).without_identifier()
+        rows = [("namespace-name", "table-name", False, "Type: MANAGED\n")]
+
+        relations = adapter._build_spark_relation_list(
+            rows,
+            adapter._get_relation_information,
+            schema_relation,
+        )
+
+        self.assertEqual(len(relations), 1)
+        self.assertEqual(relations[0].quote_policy, schema_relation.quote_policy)
+        self.assertEqual(
+            relations[0].render(),
+            "`catalog-name`.`namespace-name`.`table-name`",
+        )
 
     def test_unknown_error_is_raised(self):
         """An unexpected error from the metastore should propagate rather than

--- a/dbt-spark/tests/unit/test_adapter.py
+++ b/dbt-spark/tests/unit/test_adapter.py
@@ -1,6 +1,7 @@
 import unittest
 import pytest
 from multiprocessing import get_context
+from types import SimpleNamespace
 from unittest import mock
 
 from dbt_common.exceptions import DbtRuntimeError
@@ -9,7 +10,9 @@ from pyhive import hive
 from dbt.adapters.spark import SparkAdapter, SparkColumn, SparkRelation
 from dbt.adapters.spark.connections import build_ssl_transport
 from dbt.adapters.spark.impl import (
+    DESCRIBE_TABLE_EXTENDED_MACRO_NAME,
     LIST_RELATIONS_MACRO_NAME,
+    LIST_RELATIONS_SHOW_TABLES_MACRO_NAME,
     SCHEMA_NOT_FOUND_MESSAGES,
     TABLE_OR_VIEW_NOT_FOUND_MESSAGES,
 )
@@ -431,11 +434,13 @@ class TestSparkAdapter(unittest.TestCase):
 
     def test_relation_with_database(self):
         adapter = SparkAdapter(self.target_http, get_context("spawn"))
-        # fine
-        adapter.Relation.create(schema="different", identifier="table")
-        with self.assertRaises(DbtRuntimeError):
-            # not fine - database set
-            adapter.Relation.create(database="something", schema="different", identifier="table")
+        relation = adapter.Relation.create(schema="analytics", identifier="events")
+        self.assertEqual(relation.render(), "analytics.events")
+
+        relation = adapter.Relation.create(
+            database="catalog", schema="analytics", identifier="events"
+        )
+        self.assertEqual(relation.render(), "catalog.analytics.events")
 
     def test_profile_with_database(self):
         profile = {
@@ -443,7 +448,6 @@ class TestSparkAdapter(unittest.TestCase):
                 "test": {
                     "type": "spark",
                     "method": "http",
-                    # not allowed
                     "database": "analytics2",
                     "schema": "analytics",
                     "host": "myorg.sparkhost.com",
@@ -455,8 +459,91 @@ class TestSparkAdapter(unittest.TestCase):
             },
             "target": "test",
         }
-        with self.assertRaises(DbtRuntimeError):
-            config_from_parts_or_dicts(self.base_project_cfg, profile)
+        config = config_from_parts_or_dicts(self.base_project_cfg, profile)
+        self.assertEqual(config.credentials.database, "analytics2")
+        self.assertEqual(config.credentials.schema, "analytics")
+
+    def test_profile_with_catalog_alias(self):
+        profile = {
+            "outputs": {
+                "test": {
+                    "type": "spark",
+                    "method": "http",
+                    "catalog": "analytics_catalog",
+                    "schema": "analytics",
+                    "host": "myorg.sparkhost.com",
+                    "port": 443,
+                    "token": "abc123",
+                    "organization": "0123456789",
+                    "cluster": "01234-23423-coffeetime",
+                }
+            },
+            "target": "test",
+        }
+        config = config_from_parts_or_dicts(self.base_project_cfg, profile)
+        self.assertEqual(config.credentials.database, "analytics_catalog")
+        self.assertEqual(config.credentials.schema, "analytics")
+
+    def test_catalog_alias_supports_matching_catalog_and_schema(self):
+        profile = {
+            "outputs": {
+                "test": {
+                    "type": "spark",
+                    "method": "http",
+                    "catalog": "analytics",
+                    "schema": "analytics",
+                    "host": "myorg.sparkhost.com",
+                    "port": 443,
+                    "token": "abc123",
+                    "organization": "0123456789",
+                    "cluster": "01234-23423-coffeetime",
+                }
+            },
+            "target": "test",
+        }
+        config = config_from_parts_or_dicts(self.base_project_cfg, profile)
+        self.assertEqual(config.credentials.database, "analytics")
+        self.assertEqual(config.credentials.schema, "analytics")
+
+    def test_profile_with_matching_database_and_schema(self):
+        profile = {
+            "outputs": {
+                "test": {
+                    "type": "spark",
+                    "method": "http",
+                    "database": "analytics",
+                    "schema": "analytics",
+                    "host": "myorg.sparkhost.com",
+                    "port": 443,
+                    "token": "abc123",
+                    "organization": "0123456789",
+                    "cluster": "01234-23423-coffeetime",
+                }
+            },
+            "target": "test",
+        }
+        config = config_from_parts_or_dicts(self.base_project_cfg, profile)
+        self.assertIsNone(config.credentials.database)
+        self.assertEqual(config.credentials.schema, "analytics")
+
+    def test_get_relation_matches_unquoted_identifiers_case_insensitively(self):
+        adapter = SparkAdapter(self.target_http, get_context("spawn"))
+        cases = [
+            (None, "Analytics", "analytics"),
+            ("MyCatalog", "Analytics", "analytics"),
+        ]
+
+        for database, requested_schema, returned_schema in cases:
+            with self.subTest(database=database):
+                discovered = adapter.Relation.create(
+                    database=database,
+                    schema=returned_schema,
+                    identifier="events",
+                )
+                with mock.patch.object(adapter, "list_relations", return_value=[discovered]):
+                    relation = adapter.get_relation(database, requested_schema, "EVENTS")
+
+                self.assertEqual(relation, discovered)
 
     def test_profile_with_cluster_and_sql_endpoint(self):
         profile = {
@@ -727,8 +814,59 @@ class TestListRelationsWithoutCaching(unittest.TestCase):
     def _make_adapter(self):
         return SparkAdapter(self.target_http, get_context("spawn"))
 
-    def _make_schema_relation(self, adapter, schema="analytics"):
-        return adapter.Relation.create(schema=schema, identifier="").without_identifier()
+    def _make_schema_relation(self, adapter, schema="analytics", database=None):
+        return adapter.Relation.create(
+            database=database, schema=schema, identifier=""
+        ).without_identifier()
+
+    def test_relations_keep_requested_catalog_and_namespace(self):
+        adapter = self._make_adapter()
+        schema_relation = self._make_schema_relation(
+            adapter, database="catalog", schema="analytics"
+        )
+        rows = [
+            ("", "dbt_tmp", True),
+            ("analytics", "events", False),
+        ]
+
+        def execute_macro_side_effect(macro_name, *args, **kwargs):
+            if macro_name == LIST_RELATIONS_SHOW_TABLES_MACRO_NAME:
+                return rows
+            if macro_name == DESCRIBE_TABLE_EXTENDED_MACRO_NAME:
+                return [
+                    ("Type", "MANAGED", None),
+                    ("Provider", "iceberg", None),
+                ]
+            self.fail(f"Unexpected macro: {macro_name}")
+
+        with mock.patch.object(adapter, "execute_macro", side_effect=execute_macro_side_effect):
+            result = adapter.list_relations_without_caching(schema_relation)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].database, "catalog")
+        self.assertEqual(result[0].schema, "analytics")
+        self.assertEqual(result[0].identifier, "events")
+        self.assertTrue(result[0].is_iceberg)
+
+    def test_relations_with_same_name_are_isolated_by_catalog(self):
+        adapter = self._make_adapter()
+        rows = [("analytics", "events", False, "Type: MANAGED\n")]
+
+        for database in ("catalog_one", "catalog_two"):
+            schema_relation = self._make_schema_relation(
+                adapter, database=database, schema="analytics"
+            )
+            relations = adapter._build_spark_relation_list(
+                rows,
+                adapter._get_relation_information,
+                schema_relation,
+            )
+            adapter.cache.add(relations[0])
+
+        first = adapter.cache.get_relations("catalog_one", "analytics")
+        second = adapter.cache.get_relations("catalog_two", "analytics")
+        self.assertEqual([relation.database for relation in first], ["catalog_one"])
+        self.assertEqual([relation.database for relation in second], ["catalog_two"])
 
     def test_unknown_error_is_raised(self):
         """An unexpected error from the metastore should propagate rather than
@@ -749,15 +887,19 @@ class TestListRelationsWithoutCaching(unittest.TestCase):
         """When the schema/database genuinely does not exist (legacy Hive
         'Database not found' message), an empty list should be returned."""
         adapter = self._make_adapter()
-        schema_relation = self._make_schema_relation(adapter, schema="nonexistent")
+        for database in (None, "catalog"):
+            with self.subTest(database=database):
+                schema_relation = self._make_schema_relation(
+                    adapter, database=database, schema="nonexistent"
+                )
 
-        with mock.patch.object(
-            adapter,
-            "execute_macro",
-            side_effect=DbtRuntimeError("Database not found"),
-        ):
-            result = adapter.list_relations_without_caching(schema_relation)
-            self.assertEqual(result, [])
+                with mock.patch.object(
+                    adapter,
+                    "execute_macro",
+                    side_effect=DbtRuntimeError("Database not found"),
+                ):
+                    result = adapter.list_relations_without_caching(schema_relation)
+                    self.assertEqual(result, [])
 
 
 @pytest.mark.parametrize("not_found_msg", SCHEMA_NOT_FOUND_MESSAGES)
@@ -817,8 +959,53 @@ class TestListRelationsIcebergV2Fallback(unittest.TestCase):
     def _make_adapter(self):
         return SparkAdapter(self.target_http, get_context("spawn"))
 
-    def _make_schema_relation(self, adapter, schema="analytics"):
-        return adapter.Relation.create(schema=schema, identifier="").without_identifier()
+    def _make_schema_relation(self, adapter, schema="analytics", database=None):
+        return adapter.Relation.create(
+            database=database, schema=schema, identifier=""
+        ).without_identifier()
+
+    def test_fallback_describes_requested_relation(self):
+        cases = [
+            ("catalog", "analytics", "catalog.analytics.events"),
+            (None, "nessie.analytics", "nessie.analytics.events"),
+        ]
+
+        for database, schema, expected_table_name in cases:
+            with self.subTest(database=database, schema=schema):
+                adapter = self._make_adapter()
+                schema_relation = self._make_schema_relation(
+                    adapter, database=database, schema=schema
+                )
+                described_relations = []
+
+                def execute_macro_side_effect(macro_name, *args, **kwargs):
+                    if macro_name == LIST_RELATIONS_MACRO_NAME:
+                        if database is not None:
+                            self.fail("Catalog-qualified discovery must use SHOW TABLES")
+                        raise DbtRuntimeError(ICEBERG_V2_ERROR)
+                    if macro_name == LIST_RELATIONS_SHOW_TABLES_MACRO_NAME:
+                        return [("analytics", "events", False)]
+                    if macro_name == DESCRIBE_TABLE_EXTENDED_MACRO_NAME:
+                        described_relations.append(kwargs["kwargs"]["table_name"])
+                        return [
+                            ("Type", "MANAGED", None),
+                            ("Provider", "iceberg", None),
+                        ]
+                    self.fail(f"Unexpected macro: {macro_name}")
+
+                with mock.patch.object(
+                    adapter, "execute_macro", side_effect=execute_macro_side_effect
+                ):
+                    result = adapter.list_relations_without_caching(schema_relation)
+
+                self.assertEqual(
+                    [str(relation) for relation in described_relations], [expected_table_name]
+                )
+                self.assertEqual(len(result), 1)
+                self.assertEqual(result[0].database, database)
+                self.assertEqual(result[0].schema, schema)
+                self.assertEqual(result[0].identifier, "events")
+                self.assertTrue(result[0].is_iceberg)
 
     def test_iceberg_v2_fallback_returns_relations(self):
         """When the primary macro raises the v2-table error, the fallback SHOW TABLES
@@ -879,6 +1066,7 @@ class TestGetColumnsForCatalogIcebergFallback(unittest.TestCase):
         # so parse_columns_from_information will return an empty list.
         information = "id: int\n" "name: string\n" "Provider: iceberg\n" "Owner: root\n"
         relation = SparkRelation.create(
+            database="catalog",
             schema="default",
             identifier="orders",
             type=SparkRelation.get_relation_type.Table,
@@ -918,6 +1106,7 @@ class TestGetColumnsForCatalogIcebergFallback(unittest.TestCase):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]["column_name"], "id")
         self.assertEqual(result[0]["column_type"], "int")
+        self.assertEqual(result[0]["table_database"], "catalog")
         self.assertEqual(result[1]["column_name"], "name")
         self.assertEqual(result[1]["column_type"], "string")
 
@@ -968,3 +1157,67 @@ class TestGetColumnsForCatalogIcebergFallback(unittest.TestCase):
             result = list(adapter._get_columns_for_catalog(relation))
 
         self.assertEqual(result, [])
+
+
+def test_get_catalog_supports_multiple_databases(target_http):
+    adapter = SparkAdapter(target_http, get_context("spawn"))
+    relation_configs = [
+        SimpleNamespace(
+            resource_type="model",
+            name=f"events_{database}",
+            description="",
+            database=database,
+            schema="analytics",
+            identifier="events",
+            compiled_code=None,
+            meta={},
+            tags=[],
+            quoting_dict={},
+            config=None,
+            catalog_name=None,
+        )
+        for database in ("catalog_one", "catalog_two")
+    ]
+    thread_pool = mock.MagicMock()
+    executor_context = mock.MagicMock()
+    executor_context.__enter__.return_value = thread_pool
+
+    with mock.patch("dbt.adapters.spark.impl.executor", return_value=executor_context):
+        with mock.patch("dbt.adapters.spark.impl.catch_as_completed", return_value=([], [])):
+            catalogs, exceptions = adapter.get_catalog(relation_configs, frozenset())
+
+    assert catalogs == []
+    assert exceptions == []
+    connection_names = [call.args[1] for call in thread_pool.submit_connected.call_args_list]
+    assert connection_names == ["catalog_one.analytics", "catalog_two.analytics"]
+
+
+@pytest.mark.parametrize("database", ["catalog_one", "catalog_two"])
+def test_get_one_catalog_preserves_database_in_rows(target_http, database):
+    adapter = SparkAdapter(target_http, get_context("spawn"))
+    information_schema = mock.MagicMock(database=database)
+    relation = SparkRelation.create(
+        database=database,
+        schema="analytics",
+        identifier="events",
+        type=SparkRelation.get_relation_type.Table,
+    )
+    column = {
+        "table_database": database,
+        "table_schema": "analytics",
+        "table_name": "events",
+        "column_name": "id",
+        "column_type": "int",
+    }
+
+    with mock.patch.object(adapter, "list_relations", return_value=[relation]) as list_relations:
+        with mock.patch.object(adapter, "_get_columns_for_catalog", return_value=[column]):
+            result = adapter._get_one_catalog(
+                information_schema,
+                {"analytics"},
+                frozenset({(database, "analytics")}),
+            )
+
+    list_relations.assert_called_once_with(database, "analytics")
+    assert len(result.rows) == 1
+    assert result.rows[0]["table_database"] == database

--- a/dbt-spark/tests/unit/test_credentials.py
+++ b/dbt-spark/tests/unit/test_credentials.py
@@ -1,4 +1,8 @@
+import pytest
+
+from dbt.adapters.exceptions import DuplicateAliasError
 from dbt.adapters.spark.connections import SparkConnectionMethod, SparkCredentials
+from dbt_common.exceptions import DbtConfigError
 
 
 def test_credentials_server_side_parameters_keys_and_values_are_strings() -> None:
@@ -31,3 +35,30 @@ def test_credentials_server_side_parameters_ansi_disabled_default() -> None:
         schema="tests",
     )
     assert credentials.server_side_parameters["spark.sql.ansi.enabled"] == "false"
+
+
+def test_credentials_reject_duplicate_catalog_and_database() -> None:
+    with pytest.raises(DuplicateAliasError):
+        SparkCredentials.from_dict(
+            {
+                "host": "localhost",
+                "method": "thrift",
+                "catalog": "catalog",
+                "database": "database",
+                "schema": "analytics",
+            }
+        )
+
+
+@pytest.mark.parametrize("key", ["catalog", "database"])
+@pytest.mark.parametrize("value", ["", "   "])
+def test_credentials_reject_blank_catalog(key: str, value: str) -> None:
+    with pytest.raises(DbtConfigError, match="Catalog cannot be empty"):
+        SparkCredentials.from_dict(
+            {
+                "host": "localhost",
+                "method": "thrift",
+                key: value,
+                "schema": "analytics",
+            }
+        )

--- a/dbt-spark/tests/unit/test_macros.py
+++ b/dbt-spark/tests/unit/test_macros.py
@@ -1,7 +1,10 @@
 import unittest
 from unittest import mock
 import re
+from types import SimpleNamespace
 from jinja2 import Environment, FileSystemLoader
+
+from dbt.adapters.spark import SparkRelation
 
 
 class TestSparkMacros(unittest.TestCase):
@@ -42,6 +45,98 @@ class TestSparkMacros(unittest.TestCase):
 
     def test_macros_load(self):
         self.jinja_env.get_template("adapters.sql")
+
+    def test_list_relations_uses_catalog_qualified_namespace(self):
+        def statement(*args, caller=None, **kwargs):
+            return caller()
+
+        context = {
+            **self.default_context,
+            "statement": statement,
+            "load_result": lambda name: SimpleNamespace(table=""),
+        }
+        template = self.jinja_env.get_template("adapters.sql", globals=context)
+
+        relation = mock.Mock()
+        relation.without_identifier.return_value = "catalog.analytics"
+        sql = template.module.spark__list_relations_without_caching(relation)
+        fallback_sql = template.module.list_relations_show_tables_without_caching(relation)
+
+        self.assertIn("show table extended in catalog.analytics like '*'", sql)
+        self.assertIn("show tables in catalog.analytics like '*'", fallback_sql)
+        self.assertEqual(relation.without_identifier.call_count, 2)
+
+        string_sql = template.module.spark__list_relations_without_caching("catalog.analytics")
+        self.assertIn("show table extended in catalog.analytics like '*'", string_sql)
+
+    def test_list_schemas_uses_quoted_catalog(self):
+        def statement(*args, caller=None, **kwargs):
+            return caller()
+
+        context = {
+            **self.default_context,
+            "statement": statement,
+            "load_result": lambda name: SimpleNamespace(table=""),
+        }
+        context["adapter"].quote.return_value = "`catalog-name`"
+        template = self.jinja_env.get_template("adapters.sql", globals=context)
+
+        sql = template.module.spark__list_schemas("catalog-name")
+        default_sql = template.module.spark__list_schemas(None)
+
+        self.assertIn("show namespaces in `catalog-name`", sql)
+        self.assertIn("show databases", default_sql)
+
+    def test_generate_database_name_uses_default_implementation(self):
+        default_generate_database_name = mock.Mock(return_value="catalog")
+        context = {
+            **self.default_context,
+            "default__generate_database_name": default_generate_database_name,
+        }
+        template = self.jinja_env.get_template("adapters.sql", globals=context)
+        node = mock.Mock()
+
+        template.module.spark__generate_database_name("catalog", node)
+
+        default_generate_database_name.assert_called_once_with("catalog", node)
+
+    def test_snapshot_staging_relation_preserves_catalog(self):
+        captured = {}
+
+        def statement(*args, caller=None, **kwargs):
+            return caller()
+
+        def create_view_as(relation, sql):
+            captured["relation"] = relation
+            return f"create view {relation} as {sql}"
+
+        context = {
+            **self.default_context,
+            "api": SimpleNamespace(Relation=SparkRelation),
+            "statement": statement,
+            "snapshot_staging_table": lambda strategy, sql, target: "select 1",
+            "create_view_as": create_view_as,
+        }
+        source, _, _ = self.jinja_env.loader.get_source(
+            self.jinja_env, "materializations/snapshot.sql"
+        )
+        helper_macros = source.split("{% materialization", maxsplit=1)[0]
+        template = self.jinja_env.from_string(helper_macros, globals=context)
+        target_relation = SparkRelation.create(
+            database="catalog",
+            schema="analytics",
+            identifier="events_snapshot",
+            type="table",
+        )
+
+        template.module.spark_build_snapshot_staging_table(
+            mock.Mock(), "select 1", target_relation
+        )
+
+        self.assertEqual(
+            str(captured["relation"]),
+            "catalog.analytics.events_snapshot__dbt_tmp",
+        )
 
     def test_macros_create_table_as(self):
         template = self.__get_template("adapters.sql")

--- a/dbt-spark/tests/unit/test_macros.py
+++ b/dbt-spark/tests/unit/test_macros.py
@@ -82,9 +82,12 @@ class TestSparkMacros(unittest.TestCase):
         template = self.jinja_env.get_template("adapters.sql", globals=context)
 
         sql = template.module.spark__list_schemas("catalog-name")
+        prequoted_sql = template.module.spark__list_schemas("`catalog-name`")
         default_sql = template.module.spark__list_schemas(None)
 
         self.assertIn("show namespaces in `catalog-name`", sql)
+        self.assertIn("show namespaces in `catalog-name`", prequoted_sql)
+        self.assertNotIn("``catalog-name``", prequoted_sql)
         self.assertIn("show databases", default_sql)
 
     def test_generate_database_name_uses_default_implementation(self):
@@ -123,10 +126,11 @@ class TestSparkMacros(unittest.TestCase):
         helper_macros = source.split("{% materialization", maxsplit=1)[0]
         template = self.jinja_env.from_string(helper_macros, globals=context)
         target_relation = SparkRelation.create(
-            database="catalog",
-            schema="analytics",
-            identifier="events_snapshot",
+            database="catalog-name",
+            schema="analytics-name",
+            identifier="events-snapshot",
             type="table",
+            quote_policy={"database": True, "schema": True, "identifier": True},
         )
 
         template.module.spark_build_snapshot_staging_table(
@@ -135,7 +139,62 @@ class TestSparkMacros(unittest.TestCase):
 
         self.assertEqual(
             str(captured["relation"]),
-            "catalog.analytics.events_snapshot__dbt_tmp",
+            "`catalog-name`.`analytics-name`.`events-snapshot__dbt_tmp`",
+        )
+        self.assertEqual(captured["relation"].quote_policy, target_relation.quote_policy)
+
+    def test_iceberg_snapshot_uses_quoted_unqualified_staging_relation(self):
+        captured = {}
+
+        def statement(*args, caller=None, **kwargs):
+            return caller()
+
+        def create_view_as(relation, sql):
+            captured["relation"] = relation
+            return f"create view {relation} as {sql}"
+
+        context = {
+            **self.default_context,
+            "statement": statement,
+            "snapshot_staging_table": lambda strategy, sql, target: "select 1",
+            "create_view_as": create_view_as,
+        }
+        source, _, _ = self.jinja_env.loader.get_source(
+            self.jinja_env, "materializations/snapshot.sql"
+        )
+        helper_macros = source.split("{% materialization", maxsplit=1)[0]
+        template = self.jinja_env.from_string(helper_macros, globals=context)
+        target_relation = SparkRelation.create(
+            database="catalog-name",
+            schema="analytics-name",
+            identifier="events-snapshot",
+            type="table",
+            is_iceberg=True,
+            quote_policy={"database": True, "schema": True, "identifier": True},
+        )
+
+        template.module.spark_build_snapshot_staging_table(
+            mock.Mock(), "select 1", target_relation
+        )
+
+        staging_relation = captured["relation"]
+        self.assertEqual(str(staging_relation), "`events-snapshot__dbt_tmp`")
+        self.assertIsNone(staging_relation.database)
+        self.assertIsNone(staging_relation.schema)
+        self.assertEqual(staging_relation.quote_policy, target_relation.quote_policy)
+
+        self.config["snapshot_table_column_names"] = SimpleNamespace(
+            dbt_scd_id="dbt_scd_id",
+            dbt_valid_to="dbt_valid_to",
+        )
+        merge_sql = template.module.spark__snapshot_merge_sql(
+            target_relation,
+            staging_relation,
+            ["id"],
+        )
+        self.assertIn(
+            "using `events-snapshot__dbt_tmp` as DBT_INTERNAL_SOURCE",
+            merge_sql,
         )
 
     def test_macros_create_table_as(self):


### PR DESCRIPTION
addresses #495
resolves #2129
related to #480 and #496
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/9867) dbt-labs/docs.getdbt.com/#9867
[design decision](https://github.com/dbt-labs/dbt-spark/issues/281#issuecomment-1026835932)

### Problem

dbt-spark treats relations as two-part `schema.identifier` names and rejects a
distinct profile `database`. Modern Spark supports catalog-qualified
`catalog.namespace.identifier` names.

The existing workaround—placing `catalog.namespace` in `schema`—also fails
during relation discovery because Spark returns only the namespace from `SHOW
TABLES`. This can cause cache misses, incorrect `DESCRIBE` targets, and
incremental models failing to recognise existing relations.

### Solution

- Accept `catalog` as a profile alias for dbt's `database`.
- Use dbt's canonical `database` configuration for per-model and per-source
  catalog selection.
- Render catalog-qualified relations as `database.schema.identifier`.
- Preserve two-part behaviour when no catalog is supplied.
- Preserve legacy profiles where matching `database` and `schema` previously
  collapsed to a two-part identifier.
- Keep discovery, cache keys, column metadata, snapshots, and `docs generate`
  output catalog-aware.
- Preserve database/schema/identifier quote policy through discovery and the
  table, view, and snapshot materializations.
- Reject blank catalog values instead of rendering malformed identifiers.
- Use catalog-aware namespace listing and fully qualified `DESCRIBE`
  statements.
- Preserve the legacy dotted-schema workaround.
- Support documentation generation across multiple databases.

### Compatibility and scope

Restoring the standard `generate_database_name` behaviour means existing
model or source `database` / `+database` values that dbt-spark previously
ignored will now select a Spark catalog. Projects should audit those dormant
values before upgrading. `catalog` is a profile alias only; Spark namespaces
continue to use dbt's `schema` field, and no `namespace` profile alias is added.

The existing relation `information` string remains unchanged; converting it
to a dictionary remains scoped to #496. Catalog-qualified discovery uses the
existing Iceberg-compatible `SHOW TABLES` plus `DESCRIBE` fallback. During docs
generation this can mean two `DESCRIBE` queries per relation because the flat
`information` string does not retain parsed columns. That trade-off was already
accepted in #1870 for Iceberg tables; #496 remains the focused place to improve
the representation and query cost.

This includes the namespace-rendering correction independently proposed by
@dgvj-work in #2117 because full relation rendering is required for
catalog-qualified namespaces. #2117 remains linked as prior overlapping work.

The naming and metadata changes are above connection selection and apply to
`session`, `thrift`, `http`, and `odbc`. The committed functional regression
uses `session`; the external Spark/Iceberg acceptance uses Thrift. HTTP and
ODBC share the same adapter path but still require a server that supports and
configures the named Spark catalog.

### Validation

- `hatch run unit-tests` — 90 passed
- `hatch run code-quality` — passed
- `dagger/run_dbt_spark_tests.py --profile spark_session --test-path tests/functional/adapter/test_three_part_identifiers.py` — 1 passed
- `hatch build` — passed
- `hatch run build:check-all` — passed
- Spark 3.5.8 / Java 17 / Iceberg 1.11.0 named-catalog acceptance — 1 passed

The external Iceberg acceptance used a named `test_catalog` plus a same-name
shadow table in `spark_catalog`. It ran the incremental model twice and the
snapshot twice, then verified qualified queries, relation discovery, schema
lookup, catalog isolation, and model/snapshot docs metadata.

The committed Session regression ran incremental, table, and view models and
asserted the exact quoted three-part `CREATE TABLE` and `CREATE VIEW` SQL.

### Checklist

- [x] I have read the contributing guide and understand what is expected.
- [x] I have run this code in development and it appears to resolve the stated issue.
- [x] This PR includes tests.
- [ ] This interface change has received current Product or DX approval.
