### PR TITLE
fix(athena): raise on per-partition errors in swap_table HA swap

### DIFF
--- a/dbt-athena/.changes/unreleased/Fixes-20260824-161525.yaml
+++ b/dbt-athena/.changes/unreleased/Fixes-20260824-161525.yaml
@@ -1,0 +1,9 @@
+kind: Fixes
+body: swap_table now inspects the Errors field returned by batch_delete_partition
+    and batch_create_partition during the HA swap and raises a DbtRuntimeError on any
+    per-partition failure, preventing a silent partial swap that leaves Glue partitions
+    pointing at a mix of the old and new S3 paths
+time: 2026-08-24T16:15:25.000000+00:00
+custom:
+    Author: lemon0333
+    Issue: "1842"

--- a/dbt-athena/src/dbt/adapters/athena/impl.py
+++ b/dbt-athena/src/dbt/adapters/athena/impl.py
@@ -1148,7 +1148,7 @@ class AthenaAdapter(SQLAdapter):
             for partition_batch in get_chunks(
                 target_table_partitions, AthenaAdapter.BATCH_DELETE_PARTITION_API_LIMIT
             ):
-                glue_client.batch_delete_partition(
+                response = glue_client.batch_delete_partition(
                     CatalogId=target_catalog_id,
                     DatabaseName=target_relation.schema,
                     TableName=target_relation.identifier,
@@ -1156,12 +1156,24 @@ class AthenaAdapter(SQLAdapter):
                         {"Values": partition["Values"]} for partition in partition_batch
                     ],
                 )
+                if errors := response.get("Errors"):
+                    for err in errors:
+                        LOGGER.error(
+                            f"Failed to delete Glue partition during swap: "
+                            f"Values='{err['PartitionValues']}', "
+                            f"Code='{err['ErrorDetail']['ErrorCode']}', "
+                            f"Message='{err['ErrorDetail']['ErrorMessage']}'"
+                        )
+                    raise DbtRuntimeError(
+                        f"Failed to delete {len(errors)} partition(s) during swap of Glue table "
+                        f"'{target_relation.schema}.{target_relation.identifier}'"
+                    )
 
         if src_table_partitions:
             for partition_batch in get_chunks(
                 src_table_partitions, AthenaAdapter.BATCH_CREATE_PARTITION_API_LIMIT
             ):
-                glue_client.batch_create_partition(
+                response = glue_client.batch_create_partition(
                     CatalogId=target_catalog_id,
                     DatabaseName=target_relation.schema,
                     TableName=target_relation.identifier,
@@ -1174,6 +1186,18 @@ class AthenaAdapter(SQLAdapter):
                         for partition in partition_batch
                     ],
                 )
+                if errors := response.get("Errors"):
+                    for err in errors:
+                        LOGGER.error(
+                            f"Failed to create Glue partition during swap: "
+                            f"Values='{err['PartitionValues']}', "
+                            f"Code='{err['ErrorDetail']['ErrorCode']}', "
+                            f"Message='{err['ErrorDetail']['ErrorMessage']}'"
+                        )
+                    raise DbtRuntimeError(
+                        f"Failed to create {len(errors)} partition(s) during swap of Glue table "
+                        f"'{target_relation.schema}.{target_relation.identifier}'"
+                    )
 
     def _get_glue_table_versions_to_expire(
         self, relation: AthenaRelation, to_keep: int

--- a/dbt-athena/tests/unit/test_adapter.py
+++ b/dbt-athena/tests/unit/test_adapter.py
@@ -1138,6 +1138,116 @@ class TestAthenaAdapter:
         assert len(target_table_partitions_after) == 26
 
     @mock_aws
+    def test_swap_table_batch_delete_partition_errors_are_raised(
+        self, mock_aws_service, dbt_error_caplog
+    ):
+        """batch_delete_partition can return per-partition errors without raising during
+        the HA swap; verify they are surfaced as a DbtRuntimeError."""
+        mock_aws_service.create_data_catalog()
+        mock_aws_service.create_database()
+        self.adapter.acquire_connection("dummy")
+        target_table = "target_table"
+        source_table = "source_table"
+        mock_aws_service.create_table(source_table)
+        mock_aws_service.add_partitions_to_table(DATABASE_NAME, source_table)
+        mock_aws_service.create_table(target_table)
+        mock_aws_service.add_partitions_to_table(DATABASE_NAME, target_table)
+        source_relation = self.adapter.Relation.create(
+            database=DATA_CATALOG_NAME,
+            schema=DATABASE_NAME,
+            identifier=source_table,
+        )
+        target_relation = self.adapter.Relation.create(
+            database=DATA_CATALOG_NAME,
+            schema=DATABASE_NAME,
+            identifier=target_table,
+        )
+
+        batch_delete_error_response = {
+            "Errors": [
+                {
+                    "PartitionValues": ["2022-01-01"],
+                    "ErrorDetail": {
+                        "ErrorCode": "InternalServiceException",
+                        "ErrorMessage": "Rate exceeded",
+                    },
+                }
+            ]
+        }
+
+        original_make_api_call = botocore.client.BaseClient._make_api_call
+
+        def mock_make_api_call(self, operation_name, api_params):
+            if operation_name == "BatchDeletePartition":
+                return batch_delete_error_response
+            return original_make_api_call(self, operation_name, api_params)
+
+        with patch.object(botocore.client.BaseClient, "_make_api_call", mock_make_api_call):
+            with pytest.raises(
+                DbtRuntimeError,
+                match=r"Failed to delete 1 partition\(s\) during swap of Glue table",
+            ):
+                self.adapter.swap_table(source_relation, target_relation)
+
+        assert "InternalServiceException" in dbt_error_caplog.getvalue()
+        assert "Rate exceeded" in dbt_error_caplog.getvalue()
+
+    @mock_aws
+    def test_swap_table_batch_create_partition_errors_are_raised(
+        self, mock_aws_service, dbt_error_caplog
+    ):
+        """batch_create_partition can return per-partition errors without raising during
+        the HA swap; verify they are surfaced as a DbtRuntimeError."""
+        mock_aws_service.create_data_catalog()
+        mock_aws_service.create_database()
+        self.adapter.acquire_connection("dummy")
+        target_table = "target_table"
+        source_table = "source_table"
+        mock_aws_service.create_table(source_table)
+        mock_aws_service.add_partitions_to_table(DATABASE_NAME, source_table)
+        mock_aws_service.create_table(target_table)
+        mock_aws_service.add_partitions_to_table(DATABASE_NAME, target_table)
+        source_relation = self.adapter.Relation.create(
+            database=DATA_CATALOG_NAME,
+            schema=DATABASE_NAME,
+            identifier=source_table,
+        )
+        target_relation = self.adapter.Relation.create(
+            database=DATA_CATALOG_NAME,
+            schema=DATABASE_NAME,
+            identifier=target_table,
+        )
+
+        batch_create_error_response = {
+            "Errors": [
+                {
+                    "PartitionValues": ["2022-01-01"],
+                    "ErrorDetail": {
+                        "ErrorCode": "AlreadyExistsException",
+                        "ErrorMessage": "Partition already exists",
+                    },
+                }
+            ]
+        }
+
+        original_make_api_call = botocore.client.BaseClient._make_api_call
+
+        def mock_make_api_call(self, operation_name, api_params):
+            if operation_name == "BatchCreatePartition":
+                return batch_create_error_response
+            return original_make_api_call(self, operation_name, api_params)
+
+        with patch.object(botocore.client.BaseClient, "_make_api_call", mock_make_api_call):
+            with pytest.raises(
+                DbtRuntimeError,
+                match=r"Failed to create 1 partition\(s\) during swap of Glue table",
+            ):
+                self.adapter.swap_table(source_relation, target_relation)
+
+        assert "AlreadyExistsException" in dbt_error_caplog.getvalue()
+        assert "Partition already exists" in dbt_error_caplog.getvalue()
+
+    @mock_aws
     def test__get_glue_table_versions_to_expire(self, mock_aws_service, dbt_debug_caplog):
         mock_aws_service.create_data_catalog()
         mock_aws_service.create_database()


### PR DESCRIPTION
resolves #1842
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

### Problem

`swap_table()` in `dbt-athena/src/dbt/adapters/athena/impl.py` performs the HA table swap by calling `glue_client.batch_delete_partition` and `glue_client.batch_create_partition`, but it never inspects the `Errors` field of either response. The AWS Glue API returns per-partition failures (transient throttling, consistency issues, `AlreadyExistsException`) in the response **body** rather than raising exceptions, so these failures were silently swallowed.

The result is a **partial swap**: some Glue partitions keep pointing at the previous run's S3 UUID path while others point at the new one. The upstream table's own uniqueness test still passes (single scan, consistent metadata), but a downstream model that scans the same table more than once (e.g. via an inlined CTE) can resolve different partition locations across scans and surface duplicate rows.

### Solution

Capture the response from both `batch_delete_partition` and `batch_create_partition` and, if `response.get("Errors")` is non-empty, log each per-partition error and raise `DbtRuntimeError` — turning a silent partial swap into a loud, retryable failure.

This mirrors the handling already established in the same file:
- `delete_partition_chunk` (~line 588): `if errors := response.get("Errors"): ... raise DbtRuntimeError(...)`
- `delete_from_s3` (~line 760): same pattern for the S3 `delete_objects` response

The change is minimal and additive (no interface change). Added unit tests mock the Glue client to return an `Errors` payload for `BatchDeletePartition` and `BatchCreatePartition` and assert `swap_table` raises `DbtRuntimeError`, following the existing `test_clean_up_partitions_glue_batch_delete_errors_are_raised` test.

Verified locally: `python -m pytest tests/unit/test_adapter.py -k swap_table` (6 passed) and the full `tests/unit` suite (373 passed, 13 xfailed, 2 xpassed) with no regressions. `black` and `flake8` clean on the changed files.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
