### PR TITLE
fix(bigquery): set WRITE_TRUNCATE on seed load jobs

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fixes-20260825-140000.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20260825-140000.yaml
@@ -1,0 +1,9 @@
+kind: Fixes
+body: Set an explicit WRITE_TRUNCATE disposition on seed load jobs so seeds always
+    replace their contents. Previously the load job relied on BigQuery's default of
+    WRITE_APPEND, so if the pre-load drop was skipped the seed's rows were appended
+    to the existing table instead of replacing it.
+time: 2026-08-25T14:00:00.000000-05:00
+custom:
+    Author: tauhid621
+    Issue: "2144"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/connections.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/connections.py
@@ -21,6 +21,7 @@ from google.cloud.bigquery import (
     SchemaField,
     Table,
     TableReference,
+    WriteDisposition,
 )
 from google.cloud.exceptions import BadRequest, Conflict, Forbidden, NotFound
 
@@ -534,6 +535,9 @@ class BigQueryConnectionManager(BaseConnectionManager):
             skip_leading_rows=1,
             schema=table_schema,
             field_delimiter=field_delimiter,
+            # Seeds always fully replace the target; don't rely on BigQuery's
+            # job-level default (WRITE_APPEND) if the caller's drop was skipped.
+            write_disposition=WriteDisposition.WRITE_TRUNCATE,
         )
         table = self.table_ref(database, schema, identifier)
         self._write_file_to_table(client, file_path, table, load_config, fallback_timeout)


### PR DESCRIPTION
Resolves #2144

`write_dataframe_to_table` built its `LoadJobConfig` without a `write_disposition`, so seed loads fell back to BigQuery's job-level default of `WRITE_APPEND`. When the pre-load drop was skipped, the load appended to the existing table and the seed silently gained duplicate rows.

Seeds always fully replace the target, so this sets the disposition explicitly instead of depending on the relation cache being accurate. Safe unconditionally: core's seed materialization calls `load_csv_rows` once per run and `bigquery__load_csv_rows` issues a single load job for the whole file, so there is no multi-batch case where truncate would discard earlier batches.

Related: #2145 covers one way the drop gets skipped (`list_relations_without_caching` swallowing `Forbidden`), which is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)