### PR TITLE
feat(snowflake): CREATE OR ALTER for dynamic table query evolution

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Features-20260827-174315.yaml
+++ b/dbt-snowflake/.changes/unreleased/Features-20260827-174315.yaml
@@ -1,0 +1,12 @@
+kind: Features
+body: 'Add the `snowflake_dynamic_table_create_or_alter` behavior flag. When enabled,
+    native dynamic tables are synced with CREATE OR ALTER DYNAMIC TABLE on every run,
+    so edits to the model''s SQL deploy without `--full-refresh`. Note: for INCREMENTAL
+    and AUTO refresh modes, a definition edit reinitializes the table (incremental
+    state is discarded). Schema changes that CREATE OR ALTER cannot express (e.g.
+    column reorder, mid-list insert) still require `--full-refresh`. Iceberg dynamic
+    tables are unaffected.'
+time: 2026-08-27T17:43:15.027603+00:00
+custom:
+    Author: HeisenBug-QAQ
+    Issue: "1825"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
@@ -91,6 +91,28 @@ SNOWFLAKE_MANAGED_ICEBERG_DEFAULT = BehaviorFlag(
     ),
 )
 
+SNOWFLAKE_DYNAMIC_TABLE_CREATE_OR_ALTER = BehaviorFlag(
+    name="snowflake_dynamic_table_create_or_alter",
+    default=False,
+    description=(
+        "When enabled, native (info schema) dynamic tables are synced with CREATE OR ALTER "
+        "DYNAMIC TABLE on every run, so edits to the model's SQL are deployed without "
+        "--full-refresh (matching CTAS ergonomics). WARNING: for INCREMENTAL and AUTO refresh "
+        "modes, a definition edit reinitializes the dynamic table (full recompute, incremental "
+        "state discarded) -- this diverges from dbt incremental models, where a logic change "
+        "requires --full-refresh. CREATE OR ALTER does not support every schema change (e.g. "
+        "column reorder, mid-list insert); incompatible edits still require --full-refresh. "
+        "If `transient` is not set explicitly and the effective transient default diverges from "
+        "the live table (the default flag changed, or an explicit `transient` was removed), dbt "
+        "does not detect it and CREATE OR ALTER attempts a transient flip that Snowflake rejects "
+        "-- recover with --full-refresh. "
+        "With on_configuration_change='continue', a run carrying both a config change and a SQL "
+        "edit skips both. Iceberg dynamic tables are unaffected: this adapter does not apply "
+        "CREATE OR ALTER to them yet (they keep create-or-replace behavior). When disabled "
+        "(default), behavior is unchanged."
+    ),
+)
+
 # Guard against older dbt-adapters that don't have Capability.CatalogsV2 yet.
 # Remove once dbt-adapters lower bound is bumped to the version that adds it.
 _CATALOGS_V2_CAPABILITY = getattr(Capability, "CatalogsV2", None)  # type: ignore[attr-defined]
@@ -176,7 +198,11 @@ class SnowflakeAdapter(SQLAdapter):
 
     @property
     def _behavior_flags(self) -> list[BehaviorFlag]:
-        return [SNOWFLAKE_DEFAULT_TRANSIENT_DYNAMIC_TABLES, SNOWFLAKE_MANAGED_ICEBERG_DEFAULT]
+        return [
+            SNOWFLAKE_DEFAULT_TRANSIENT_DYNAMIC_TABLES,
+            SNOWFLAKE_MANAGED_ICEBERG_DEFAULT,
+            SNOWFLAKE_DYNAMIC_TABLE_CREATE_OR_ALTER,
+        ]
 
     def __init__(self, config, mp_context) -> None:
         super().__init__(config, mp_context)
@@ -700,6 +726,36 @@ CALL {proc_name}();
                 )
             return catalog_integration.build_relation(model)
         return None
+
+    @available
+    def dynamic_table_create_or_alter_enabled(self, model: RelationConfig) -> bool:
+        """Whether the opt-in query-evolution (CREATE OR ALTER) path applies to this model.
+
+        True when the behavior flag is on and the model is a native (info schema) dynamic table.
+        Note: for INCREMENTAL/AUTO dynamic tables a definition edit reinitializes the table (full
+        recompute, incremental state discarded), which diverges from dbt incremental models (where
+        a logic change requires --full-refresh).
+
+        The only exclusion is Iceberg (built_in catalog). Snowflake DOES support
+        `CREATE OR ALTER DYNAMIC ICEBERG TABLE` (added 2026-08-13), but this adapter does not
+        implement that path yet -- it is a deliberate scoping decision, not a platform limit -- so
+        Iceberg dynamic tables keep the standard create-or-replace behavior. Supporting them needs a
+        separate Iceberg COA DDL (external_volume/catalog/base_location) and CI coverage; tracked as
+        follow-up. See https://docs.snowflake.com/en/user-guide/dynamic-tables/modify.
+
+        Args:
+            model (RelationConfig): `config.model` from the jinja context
+        """
+        if not self.behavior.snowflake_dynamic_table_create_or_alter.no_warn:
+            return False
+        catalog_relation = self.build_catalog_relation(model)
+        # Native dynamic tables are INFO_SCHEMA. Iceberg (BUILT_IN) and ICEBERG_REST are excluded by
+        # this positive match: Snowflake supports CREATE OR ALTER DYNAMIC ICEBERG TABLE (2026-08-13),
+        # but this adapter has not implemented that DDL path yet (see follow-up).
+        return (
+            getattr(catalog_relation, "catalog_type", None)
+            == constants.DEFAULT_INFO_SCHEMA_CATALOG.catalog_type
+        )
 
     @available
     def describe_dynamic_table(

--- a/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
@@ -97,7 +97,7 @@ SNOWFLAKE_DYNAMIC_TABLE_CREATE_OR_ALTER = BehaviorFlag(
     description=(
         "When enabled, native (info schema) dynamic tables are synced with CREATE OR ALTER "
         "DYNAMIC TABLE on every run, so edits to the model's SQL are deployed without "
-        "--full-refresh (matching CTAS ergonomics). WARNING: for INCREMENTAL and AUTO refresh "
+        "--full-refresh (matching CTAS expirience). WARNING: for INCREMENTAL and AUTO refresh "
         "modes, a definition edit reinitializes the dynamic table (full recompute, incremental "
         "state discarded) -- this diverges from dbt incremental models, where a logic change "
         "requires --full-refresh. CREATE OR ALTER does not support every schema change (e.g. "

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/dynamic_table.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/dynamic_table.sql
@@ -35,32 +35,43 @@
 
     {% set full_refresh_mode = should_full_refresh() %}
 
-    -- determine the scenario we're in: create, full_refresh, alter, refresh data
+    -- determine the scenario we're in: create, full_refresh, create-or-alter, alter, refresh data
     {% if existing_relation is none %}
         {% set build_sql = get_create_sql(target_relation, sql) %}
     {% elif full_refresh_mode or not existing_relation.is_dynamic_table %}
         {% set build_sql = get_replace_sql(existing_relation, target_relation, sql) %}
     {% else %}
 
-        -- get config options
-        {% set on_configuration_change = config.get('on_configuration_change') %}
-        {% set configuration_changes = snowflake__get_dynamic_table_configuration_changes(existing_relation, config) %}
-
-        {% if configuration_changes is none %}
-            {% set build_sql = '' %}
-            {{ exceptions.warn("No configuration changes were identified on: `" ~ target_relation ~ "`. Continuing.") }}
-
-        {% elif on_configuration_change == 'apply' %}
-            {% set build_sql = snowflake__get_alter_dynamic_table_as_sql(existing_relation, configuration_changes, target_relation, sql) %}
-        {% elif on_configuration_change == 'continue' %}
-            {% set build_sql = '' %}
-            {{ exceptions.warn("Configuration changes were identified and `on_configuration_change` was set to `continue` for `" ~ target_relation ~ "`") }}
-        {% elif on_configuration_change == 'fail' %}
-            {{ exceptions.raise_fail_fast_error("Configuration changes were identified and `on_configuration_change` was set to `fail` for `" ~ target_relation ~ "`") }}
+        {#- Opt-in query-evolution path: a native (info schema) dynamic table syncs its definition
+            in place via CREATE OR ALTER, so SQL edits deploy without --full-refresh. When it does
+            not apply, fall through to the standard config-change handling below (unchanged from
+            upstream). -#}
+        {% if adapter.dynamic_table_create_or_alter_enabled(config.model) %}
+            {% set build_sql = snowflake__get_create_or_alter_dynamic_table_sql(existing_relation, target_relation, sql) %}
 
         {% else %}
-            -- this only happens if the user provides a value other than `apply`, 'continue', 'fail'
-            {{ exceptions.raise_compiler_error("Unexpected configuration scenario: `" ~ on_configuration_change ~ "`") }}
+
+            -- get config options
+            {% set on_configuration_change = config.get('on_configuration_change') %}
+            {% set configuration_changes = snowflake__get_dynamic_table_configuration_changes(existing_relation, config) %}
+
+            {% if configuration_changes is none %}
+                {% set build_sql = '' %}
+                {{ exceptions.warn("No configuration changes were identified on: `" ~ target_relation ~ "`. Continuing.") }}
+
+            {% elif on_configuration_change == 'apply' %}
+                {% set build_sql = snowflake__get_alter_dynamic_table_as_sql(existing_relation, configuration_changes, target_relation, sql) %}
+            {% elif on_configuration_change == 'continue' %}
+                {% set build_sql = '' %}
+                {{ exceptions.warn("Configuration changes were identified and `on_configuration_change` was set to `continue` for `" ~ target_relation ~ "`") }}
+            {% elif on_configuration_change == 'fail' %}
+                {{ exceptions.raise_fail_fast_error("Configuration changes were identified and `on_configuration_change` was set to `fail` for `" ~ target_relation ~ "`") }}
+
+            {% else %}
+                -- this only happens if the user provides a value other than `apply`, 'continue', 'fail'
+                {{ exceptions.raise_compiler_error("Unexpected configuration scenario: `" ~ on_configuration_change ~ "`") }}
+
+            {% endif %}
 
         {% endif %}
 

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create_or_alter.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/relations/dynamic_table/create_or_alter.sql
@@ -1,0 +1,118 @@
+{#-
+    The gate for this path -- flag on + native (info schema) catalog -- lives in Python as
+    adapter.dynamic_table_create_or_alter_enabled() (see impl.py), so the decision is unit-testable
+    without a database. The materialization calls it; this file only renders the DDL once that gate
+    has passed.
+-#}
+{% macro snowflake__get_create_or_alter_dynamic_table_sql(existing_relation, target_relation, sql) -%}
+{#-
+    Definition SQL for the query-evolution path (assumes the gate above already passed).
+
+    CREATE OR ALTER expresses the complete desired end state and applies it idempotently,
+    preserving the object -- and its grants / attached policies / tags -- instead of replacing it.
+    This is how a native dynamic table deploys SQL edits without --full-refresh.
+
+    The config changeset does NOT track the query, so a `none` changeset means "query-only edit
+    (or no change)" and must still emit CREATE OR ALTER -- that is the query-evolution fix. We
+    consult the changeset only to:
+      1. route changes dbt flags as requiring a full rebuild (`requires_full_refresh`: transient
+         and refresh_mode) to CREATE OR REPLACE -- transient in particular cannot be converted by
+         CREATE OR ALTER; and
+      2. honor on_configuration_change (continue / fail) for other detected config changes.
+
+    See the DDL macro below for the per-attribute contract. Note CREATE OR ALTER also cannot
+    express every schema change (column reorder, mid-list insert, type narrowing, drop-all); those
+    surface a Snowflake error at run time and the fallback is --full-refresh.
+-#}
+    {%- set configuration_changes = snowflake__get_dynamic_table_configuration_changes(existing_relation, config) -%}
+    {%- set on_configuration_change = config.get('on_configuration_change') -%}
+    {%- set dynamic_table = target_relation.from_config(config.model) -%}
+
+    {%- if configuration_changes is none -%}
+        {#- query-only edit (or no change): sync the definition in place. -#}
+        {{ return(snowflake__create_or_alter_dynamic_table_info_schema_sql(dynamic_table, target_relation, sql)) }}
+
+    {%- elif on_configuration_change == 'apply' -%}
+        {%- if configuration_changes.requires_full_refresh -%}
+            {#- transient / refresh_mode: dbt flags these as requires_full_refresh -> rebuild. -#}
+            {{ return(get_replace_sql(existing_relation, target_relation, sql)) }}
+        {%- else -%}
+            {#- CREATE OR ALTER declares the full end state, applying config changes and query together. -#}
+            {{ return(snowflake__create_or_alter_dynamic_table_info_schema_sql(dynamic_table, target_relation, sql)) }}
+        {%- endif -%}
+
+    {%- elif on_configuration_change == 'continue' -%}
+        {#- Known limitation: a run carrying BOTH a tracked config change and a SQL edit skips both
+            here (the changeset can't see the query, so we can't apply the edit while honoring
+            'continue' for the config change). Documented in the flag description. -#}
+        {{ exceptions.warn("Configuration changes were identified and `on_configuration_change` was set to `continue` for `" ~ target_relation ~ "`") }}
+        {{ return('') }}
+    {%- elif on_configuration_change == 'fail' -%}
+        {{ exceptions.raise_fail_fast_error("Configuration changes were identified and `on_configuration_change` was set to `fail` for `" ~ target_relation ~ "`") }}
+    {%- else -%}
+        {{ exceptions.raise_compiler_error("Unexpected configuration scenario: `" ~ on_configuration_change ~ "`") }}
+    {%- endif -%}
+{%- endmacro %}
+
+
+{% macro snowflake__create_or_alter_dynamic_table_info_schema_sql(dynamic_table, relation, sql) -%}
+{#-
+    Renders the CREATE OR ALTER DDL for a native (info schema) dynamic table.
+
+    Attribute contract -- CREATE OR ALTER is declarative, so every run re-declares the full desired
+    state. What that means per attribute (and why some clauses that CREATE/REPLACE emit are absent):
+
+      Emitted here (dbt config is the source of truth; omitting one resets it to its
+      default/inherited value, exactly as CREATE OR REPLACE would):
+        transient, target_lag, warehouse, initialization_warehouse, refresh_mode,
+        scheduler, cluster_by, immutable_where
+
+      Never emitted, by design:
+        initialize   -- create-time-only; Snowflake prohibits it on an existing table
+        copy grants  -- copies grants from a *replaced* object; CREATE OR ALTER replaces nothing
+                        (existing grants persist across it anyway)
+        row_access_policy, table_tag (and masking / projection / aggregation policies)
+                     -- CREATE OR ALTER rejects policy & tag clauses (Snowflake error 001506).
+                        Snowflake preserves the existing ones across the statement. These are also
+                        untracked in the config changeset (upstream #1864), so a config-side change
+                        to them is not applied on this path -- use --full-refresh to (re)apply.
+
+    transient / refresh_mode: when dbt DETECTS a change to these it flags requires_full_refresh and
+    the caller routes to CREATE OR REPLACE first (transient cannot be converted by CREATE OR ALTER
+    regardless). Known limitation: when `transient` is unset in config, dbt does not compare it, so
+    if the effective transient default diverges from the live table (default flag changed, or an
+    explicit `transient` was removed) this macro re-declares transient and Snowflake rejects the
+    in-place flip (error 001521). The documented recovery is --full-refresh. (A refresh_mode change
+    to AUTO is likewise undetected, but CREATE OR ALTER applies it in place -- AUTO resolves to a
+    concrete mode -- so it is not an error.) See the flag description in impl.py.
+-#}
+
+    {#- Determine transient: explicit config takes precedence, otherwise use behavior flag default -#}
+    {%- if dynamic_table.transient is not none -%}
+        {%- set is_transient = dynamic_table.transient -%}
+    {%- elif adapter.behavior.snowflake_default_transient_dynamic_tables.no_warn -%}
+        {%- set is_transient = true -%}
+    {%- else -%}
+        {%- set is_transient = false -%}
+    {%- endif -%}
+    {%- set transient_keyword = 'transient ' if is_transient else '' -%}
+
+create or alter {{ transient_keyword }}dynamic table {{ relation }}
+    {% if dynamic_table.target_lag is not none %}target_lag = '{{ dynamic_table.target_lag }}'{% endif %}
+    warehouse = {{ dynamic_table.warehouse_parameter }}
+    {{ optional('initialization_warehouse', dynamic_table.snowflake_initialization_warehouse) }}
+    {{ optional('refresh_mode', dynamic_table.refresh_mode) }}
+    {#- initialize is a create-time-only attribute; CREATE OR ALTER always runs on an existing
+        table where it is meaningless and Snowflake prohibits changing it, so we omit it. -#}
+    {% if dynamic_table.scheduler is not none %}
+    scheduler = '{{ dynamic_table.scheduler }}'
+    {% elif dynamic_table.target_lag is none %}
+    scheduler = 'DISABLE'
+    {% endif %}
+    {{ optional('cluster by', dynamic_table.cluster_by, quote_char='(', equals_char='') }}
+    {{ optional('immutable where', dynamic_table.immutable_where, quote_char='(', equals_char='') }}
+    as (
+        {{ sql }}
+    )
+
+{%- endmacro %}

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_create_or_alter.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_create_or_alter.py
@@ -3,7 +3,7 @@ Functional tests for the CREATE OR ALTER dynamic table path (query evolution).
 
 Behavior flag `snowflake_dynamic_table_create_or_alter` makes any native (info schema) dynamic
 table sync its definition in place on every run, so a SQL edit deploys without --full-refresh
-(matching CTAS ergonomics). For INCREMENTAL/AUTO refresh modes a definition edit reinitializes the
+(matching CTAS expirience). For INCREMENTAL/AUTO refresh modes a definition edit reinitializes the
 table (incremental state discarded). Iceberg dynamic tables are excluded (this adapter does not
 apply CREATE OR ALTER to them yet). These require a live Snowflake connection.
 

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_create_or_alter.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_create_or_alter.py
@@ -1,0 +1,594 @@
+"""
+Functional tests for the CREATE OR ALTER dynamic table path (query evolution).
+
+Behavior flag `snowflake_dynamic_table_create_or_alter` makes any native (info schema) dynamic
+table sync its definition in place on every run, so a SQL edit deploys without --full-refresh
+(matching CTAS ergonomics). For INCREMENTAL/AUTO refresh modes a definition edit reinitializes the
+table (incremental state discarded). Iceberg dynamic tables are excluded (this adapter does not
+apply CREATE OR ALTER to them yet). These require a live Snowflake connection.
+
+Test flow (shared by every test in this module):
+  1. ARRANGE -- the `setup` fixture builds a fresh dynamic table (`seed` + `run`); the
+     behavior flag is turned on via `project_config_update` on the test class.
+  2. ACT -- the test edits the model (SQL change, config change, or a refresh-mode/transient
+     variant), then runs `dbt run` WITHOUT --full-refresh -- this is what exercises the
+     COA path. Some tests use `run_dbt_and_capture` to inspect the run log.
+  3. ASSERT -- read the live table back with `describe_dynamic_table` (SHOW output) and
+     assert the definition/attribute changed as expected. A no-op skip is detected by the
+     "No configuration changes were identified" log line (present == skipped).
+  4. TEARDOWN -- the `setup` fixture drops the schema so each test starts clean.
+
+Each class overrides only what differs: its `models` fixture (the starting model) and,
+where relevant, `project_config_update` (flag on/off, on_configuration_change).
+"""
+
+import pytest
+
+from dbt.tests.util import run_dbt, run_dbt_and_capture
+
+from tests.functional.utils import describe_dynamic_table, query_transient_status, update_model
+
+
+SEED = """
+id,value
+1,alice
+2,bob
+3,carol
+""".strip()
+
+# scheduler='disable' + FULL => dbt-managed refresh; the COA path applies here.
+DT_DISABLE = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    refresh_mode='FULL',
+    scheduler='disable',
+) }}
+select id, value from {{ ref('my_seed') }}
+"""
+
+# COA-compatible edit: add a column at the end.
+DT_DISABLE_EVOLVED = """
+{{ config(
+    materialized='dynamic_table',
+    snowflake_warehouse='DBT_TESTING',
+    refresh_mode='FULL',
+    scheduler='disable',
+) }}
+select id, value, id * 10 as id_x10 from {{ ref('my_seed') }}
+"""
+
+
+# Positive deploy matrix -- (refresh_mode, scheduler, target_lag). With the flag on, a native DT
+# deploys a SQL-only edit in place via COA for every combination; scheduler='enable' needs target_lag.
+_DEPLOY_MATRIX = [
+    ("FULL", "disable", None),
+    ("FULL", "enable", "1 hour"),
+    ("INCREMENTAL", "disable", None),
+    ("INCREMENTAL", "enable", "1 hour"),
+    ("AUTO", "disable", None),
+    ("AUTO", "enable", "1 hour"),
+]
+_DEPLOY_IDS = [f"{rm.lower()}-{sched}" for rm, sched, _ in _DEPLOY_MATRIX]
+
+
+def _dt_model(refresh_mode, scheduler, target_lag, evolved=False):
+    """A native dynamic-table model for the deploy matrix; evolved=True adds a trailing column."""
+    cols = "id, value, id * 10 as id_x10" if evolved else "id, value"
+    lag = f", target_lag='{target_lag}'" if target_lag else ""
+    return (
+        "{{ config(materialized='dynamic_table', snowflake_warehouse='DBT_TESTING', "
+        f"refresh_mode='{refresh_mode}', scheduler='{scheduler}'{lag}) }}}}\n"
+        f"select {cols} from {{{{ ref('my_seed') }}}}"
+    )
+
+
+class TestCreateOrAlterDeployMatrix:
+    """Positive matrix: with the flag on, a native DT deploys a SQL-only edit in place via COA for
+    every refresh_mode x scheduler combination -- the surface this feature opens up. created_on
+    stability proves the sync was in place (COA), not a drop/recreate (replace). For
+    scheduler='enable' dbt issues no immediate refresh, so we assert the definition (SHOW text)
+    changed; data lags to the next scheduled refresh. INCREMENTAL/AUTO reinitialize their data on
+    the edit (a documented Snowflake-side effect), but the object -- and its created_on -- persist.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        # placeholder; each parametrized case rebuilds dt_coa for its own refresh_mode/scheduler
+        yield {"dt_coa.sql": DT_DISABLE}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"snowflake_dynamic_table_create_or_alter": True}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.mark.parametrize(
+        "refresh_mode, scheduler, target_lag", _DEPLOY_MATRIX, ids=_DEPLOY_IDS
+    )
+    def test_sql_edit_deploys_in_place(self, project, refresh_mode, scheduler, target_lag):
+        # build a fresh baseline DT for this cell
+        update_model(project, "dt_coa", _dt_model(refresh_mode, scheduler, target_lag))
+        run_dbt(["run", "--full-refresh"])
+        before = describe_dynamic_table(project, "dt_coa")
+        assert "id_x10" not in (before.query or "").lower()
+        before_created = _created_on(project)
+
+        # SQL-only edit + run WITHOUT --full-refresh -> exercises the COA path
+        update_model(
+            project, "dt_coa", _dt_model(refresh_mode, scheduler, target_lag, evolved=True)
+        )
+        _, logs = run_dbt_and_capture(["run"])
+
+        # definition deployed (not a no-op skip), for every refresh_mode x scheduler
+        after = describe_dynamic_table(project, "dt_coa")
+        assert "id_x10" in (after.query or "").lower()
+        assert "No configuration changes were identified" not in logs
+        # synced in place via CREATE OR ALTER, not dropped/recreated (proves COA, not replace)
+        assert _created_on(project) == before_created
+
+
+DT_TRANSIENT = """
+{{ config(materialized='dynamic_table', snowflake_warehouse='DBT_TESTING',
+          refresh_mode='FULL', scheduler='disable', transient=true) }}
+select id, value from {{ ref('my_seed') }}
+"""
+DT_NON_TRANSIENT = """
+{{ config(materialized='dynamic_table', snowflake_warehouse='DBT_TESTING',
+          refresh_mode='FULL', scheduler='disable', transient=false) }}
+select id, value from {{ ref('my_seed') }}
+"""
+
+# COA-incompatible edit: column reorder (Snowflake rejects it in CREATE OR ALTER).
+DT_REORDERED = """
+{{ config(materialized='dynamic_table', snowflake_warehouse='DBT_TESTING',
+          refresh_mode='FULL', scheduler='disable') }}
+select value, id from {{ ref('my_seed') }}
+"""
+
+
+class TestCreateOrAlterTransientFlipRebuilds:
+    """transient can't be changed via COA -> the requires_full_refresh veto routes to CREATE OR
+    REPLACE, so the run succeeds (not a COA error) and the transient status flips."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_coa.sql": DT_TRANSIENT}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"snowflake_dynamic_table_create_or_alter": True}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def test_transient_flip_routes_to_replace(self, project):
+        assert query_transient_status(project, "dt_coa") is True
+        update_model(project, "dt_coa", DT_NON_TRANSIENT)
+        results = run_dbt(["run"])  # must succeed (veto -> CREATE OR REPLACE), not error on COA
+        assert len(results) == 1
+        assert query_transient_status(project, "dt_coa") is False
+
+
+class TestCreateOrAlterOnConfigurationChangeFail:
+    """on_configuration_change='fail' still fails on a detected config change under the COA path."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_coa.sql": DT_DISABLE}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"snowflake_dynamic_table_create_or_alter": True},
+            "models": {"on_configuration_change": "fail"},
+        }
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def test_config_change_fails_fast(self, project):
+        # add a clustering key -> tracked config change -> on_configuration_change='fail' -> error
+        changed = DT_DISABLE.replace(
+            "scheduler='disable',", "scheduler='disable',\n    cluster_by=['id'],"
+        )
+        update_model(project, "dt_coa", changed)
+        _, logs = run_dbt_and_capture(["run"], expect_pass=False)
+        # the failure is the fail-fast config-change path, not some unrelated error
+        assert "Configuration changes were identified" in logs
+        assert "`on_configuration_change` was set to `fail`" in logs
+
+
+class TestCreateOrAlterOnConfigurationChangeContinue:
+    """on_configuration_change='continue' under the COA path: a run carrying a tracked config change
+    warns and no-ops. Known limitation (documented): a coincident SQL edit is skipped along with the
+    config change -- the changeset can't see the query, so 'continue' drops both. This test pins that
+    behavior so a future change that silently starts deploying the edit is caught."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_coa.sql": DT_DISABLE}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"snowflake_dynamic_table_create_or_alter": True},
+            "models": {"on_configuration_change": "continue"},
+        }
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def test_continue_skips_both_config_and_sql_edit(self, project):
+        # add a clustering key (tracked config change) AND edit the SQL in the same run
+        changed = DT_DISABLE_EVOLVED.replace(
+            "scheduler='disable',", "scheduler='disable',\n    cluster_by=['id'],"
+        )
+        update_model(project, "dt_coa", changed)
+        results, logs = run_dbt_and_capture(["run"])  # succeeds (no-op), does not error
+        assert len(results) == 1
+        assert "`on_configuration_change` was set to `continue`" in logs
+        # documented limitation: the SQL edit is dropped along with the config change
+        after = describe_dynamic_table(project, "dt_coa")
+        assert "id_x10" not in (after.query or "").lower()
+
+
+class TestCreateOrAlterIncompatibleSchemaChangeErrors:
+    """A schema change COA cannot express (column reorder) surfaces Snowflake's error, rather than
+    silently producing a wrong result. Manual fallback is --full-refresh."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_coa.sql": DT_DISABLE}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"snowflake_dynamic_table_create_or_alter": True}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def test_reorder_errors_then_full_refresh_recovers(self, project):
+        update_model(project, "dt_coa", DT_REORDERED)
+        run_dbt(["run"], expect_pass=False)  # COA rejects the reorder
+        # the documented workaround rebuilds cleanly
+        results = run_dbt(["run", "--full-refresh"])
+        assert len(results) == 1
+
+
+DT_INCREMENTAL = """
+{{ config(materialized='dynamic_table', snowflake_warehouse='DBT_TESTING',
+          refresh_mode='INCREMENTAL', scheduler='disable') }}
+select id, value from {{ ref('my_seed') }}
+"""
+
+
+class TestCreateOrAlterRefreshModeChangeRebuilds:
+    """A detected refresh_mode change (INCREMENTAL -> FULL) is flagged requires_full_refresh, so the
+    COA entry macro routes it to CREATE OR REPLACE rather than an in-place CREATE OR ALTER. The run
+    succeeds and the object is rebuilt (created_on changes) -- the discriminator proving the replace
+    route, not COA. (Only the refresh_mode differs between the two models.)"""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_coa.sql": DT_INCREMENTAL}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"snowflake_dynamic_table_create_or_alter": True}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def test_refresh_mode_change_routes_to_replace(self, project):
+        before_created = _created_on(project)
+        update_model(project, "dt_coa", DT_DISABLE)  # INCREMENTAL -> FULL, nothing else differs
+        results = run_dbt(["run"])  # must succeed via the requires_full_refresh -> replace route
+        assert len(results) == 1
+        after = describe_dynamic_table(project, "dt_coa")
+        assert "FULL" in str(after.refresh_mode).upper()
+        # rebuilt (new object) -> created_on changed: proves replace, not in-place COA
+        assert _created_on(project) != before_created
+
+
+class TestCreateOrAlterRefreshModeToAutoApplies:
+    """Reviewer question: does an undetected refresh_mode change to AUTO break COA? It does not.
+    dbt's changeset ignores changes *to* AUTO, so the COA path re-declares refresh_mode=AUTO and
+    Snowflake applies it in place (AUTO resolves to a concrete mode, e.g. ADAPTIVE) -- the run
+    succeeds, no error, no --full-refresh needed. (Contrast the transient flip, which Snowflake
+    rejects: TestCreateOrAlterTransientDriftErrors.)"""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_coa.sql": DT_INCREMENTAL}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"snowflake_dynamic_table_create_or_alter": True}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def test_refresh_mode_to_auto_applies_via_coa(self, project):
+        assert "INCREMENTAL" in str(describe_dynamic_table(project, "dt_coa").refresh_mode).upper()
+        # change refresh_mode to AUTO -- undetected by the changeset (guarded on != AUTO), so it
+        # takes the COA path rather than the requires_full_refresh -> replace route
+        update_model(project, "dt_coa", _dt_model("AUTO", "disable", None))
+        results = run_dbt(["run"])  # must succeed in place, no error, no --full-refresh
+        assert len(results) == 1
+        after = describe_dynamic_table(project, "dt_coa")
+        # AUTO resolves to a concrete mode on readback (ADAPTIVE), never left as INCREMENTAL
+        assert str(after.refresh_mode).upper() in ("AUTO", "ADAPTIVE")
+
+
+class TestCreateOrAlterPreservesTransient:
+    """Review comment: a transient=true DT with a SQL-only edit (transient unchanged) deploys via
+    COA and stays transient. The requires_full_refresh veto only fires on a transient *change*, so
+    a query-only edit must NOT route to CREATE OR REPLACE -- the DT keeps transient=YES in place.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_coa.sql": DT_TRANSIENT}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"snowflake_dynamic_table_create_or_alter": True}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def test_transient_preserved_across_coa_edit(self, project):
+        assert query_transient_status(project, "dt_coa") is True
+        before = _created_on(project)
+        # SQL-only edit, transient unchanged: COA syncs in place, no replace, still transient
+        transient_evolved = DT_TRANSIENT.replace(
+            "select id, value", "select id, value, id * 10 as id_x10"
+        )
+        update_model(project, "dt_coa", transient_evolved)
+        _, logs = run_dbt_and_capture(["run"])
+        after = describe_dynamic_table(project, "dt_coa")
+        assert "id_x10" in (after.query or "").lower()
+        assert query_transient_status(project, "dt_coa") is True
+        assert "No configuration changes were identified" not in logs
+        # synced in place, not rebuilt
+        assert _created_on(project) == before
+
+
+class TestCreateOrAlterTransientDriftErrors:
+    """Known limitation (reviewer-requested): when `transient` is unset in config, dbt does not
+    compare it, so a divergence between the effective transient default and the live table goes
+    undetected -- the COA path re-declares transient and Snowflake rejects the in-place flip
+    (error 001521). Here a DT is created transient (explicit `transient=true`), then `transient` is
+    removed from config alongside a SQL edit; with the transient-default flag off, COA tries to make
+    it non-transient and errors. --full-refresh recovers by rebuilding. (Same mechanism as flipping
+    snowflake_default_transient_dynamic_tables between runs -- the case raised in review.)"""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_coa.sql": DT_TRANSIENT}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        # COA on; snowflake_default_transient_dynamic_tables left OFF, so an unset `transient`
+        # resolves to non-transient -- the divergence that triggers the flip.
+        return {"flags": {"snowflake_dynamic_table_create_or_alter": True}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def test_transient_drift_errors_then_full_refresh_recovers(self, project):
+        assert query_transient_status(project, "dt_coa") is True
+        # remove `transient` from config (now unset) + edit the SQL; default flag off -> COA emits
+        # a non-transient CREATE OR ALTER against a transient table -> Snowflake 001521
+        update_model(project, "dt_coa", DT_DISABLE_EVOLVED)
+        run_dbt(["run"], expect_pass=False)
+        # documented recovery: full rebuild lands it as non-transient
+        results = run_dbt(["run", "--full-refresh"])
+        assert len(results) == 1
+        assert query_transient_status(project, "dt_coa") is False
+
+
+# Iceberg dynamic table -- deliberately excluded from the COA path by the gate (INFO_SCHEMA only).
+# Snowflake supports CREATE OR ALTER DYNAMIC ICEBERG TABLE (since 2026-08-13), but this adapter
+# does not implement that DDL path yet (tracked as follow-up), so Iceberg keeps create-or-replace.
+DT_ICEBERG_DISABLE = """
+{{ config(materialized='dynamic_table', snowflake_warehouse='DBT_TESTING',
+          refresh_mode='FULL', scheduler='disable',
+          table_format='iceberg', external_volume='s3_iceberg_snow',
+          base_location_subpath='coa_iceberg_guard') }}
+select id, value from {{ ref('my_seed') }}
+"""
+DT_ICEBERG_DISABLE_EVOLVED = """
+{{ config(materialized='dynamic_table', snowflake_warehouse='DBT_TESTING',
+          refresh_mode='FULL', scheduler='disable',
+          table_format='iceberg', external_volume='s3_iceberg_snow',
+          base_location_subpath='coa_iceberg_guard') }}
+select id, value, id * 10 as id_x10 from {{ ref('my_seed') }}
+"""
+
+
+class TestCreateOrAlterExcludesIceberg:
+    """The COA path is gated to the native (INFO_SCHEMA) catalog, so an Iceberg dynamic table falls
+    through to the legacy path and a SQL-only edit still no-ops. This is a deliberate scoping
+    decision, not a platform limit: Snowflake supports CREATE OR ALTER DYNAMIC ICEBERG TABLE (since
+    2026-08-13), but this adapter does not implement that DDL path yet (tracked as follow-up).
+
+    Requires the CI Iceberg external volume (`s3_iceberg_snow`), like the other TestIceberg* cases.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_coa.sql": DT_ICEBERG_DISABLE}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"snowflake_dynamic_table_create_or_alter": True}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def test_iceberg_sql_edit_is_noop_even_with_flag(self, project):
+        update_model(project, "dt_coa", DT_ICEBERG_DISABLE_EVOLVED)
+        _, logs = run_dbt_and_capture(["run"])
+        after = describe_dynamic_table(project, "dt_coa")
+        # not evolved: Iceberg is excluded from the COA path in this adapter (see class docstring)
+        assert "id_x10" not in (after.query or "").lower()
+        assert "No configuration changes were identified" in logs
+
+
+class TestCreateOrAlterFlagOffIsNoop:
+    """Control: with the flag off, a SQL-only edit still no-ops (documented gap)."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_coa.sql": DT_DISABLE}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def test_sql_only_edit_is_noop_without_flag(self, project):
+        update_model(project, "dt_coa", DT_DISABLE_EVOLVED)
+        _, logs = run_dbt_and_capture(["run"])
+        after = describe_dynamic_table(project, "dt_coa")
+        # unchanged: the old query is still live
+        assert "id_x10" not in (after.query or "").lower()
+
+
+def _created_on(project):
+    """`created_on` changes only if the object is dropped/recreated -- a stable value across a run
+    proves it was synced in place, not rebuilt. `_` is a LIKE wildcard, so the row is matched on
+    the `name` column rather than trusting the pattern to be exact."""
+    rows = project.run_sql(
+        f"show dynamic tables like '%DT_COA%' in schema {project.database}.{project.test_schema}",
+        fetch="all",
+    )
+    for row in rows:
+        if str(row[1]).upper() == "DT_COA":
+            return row[0]
+    return None
+
+
+class TestCreateOrAlterNoChangeIsNoop:
+    """With the flag on, a `dbt run` with NO model change is an idempotent no-op: the dynamic table
+    is synced in place via CREATE OR ALTER, not rebuilt -- so the object is preserved (created_on
+    unchanged) and the run succeeds. Covers the "no-op when nothing changes" behavior in issue #1825.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_coa.sql": DT_DISABLE}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"snowflake_dynamic_table_create_or_alter": True}}
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def test_no_change_run_is_idempotent_noop(self, project):
+        before = _created_on(project)
+        assert before is not None
+        # identical model, no --full-refresh: COA syncs in place -> no rebuild, no error
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        after = _created_on(project)
+        assert (
+            after == before
+        ), f"object was rebuilt (created_on {before} -> {after}), expected no-op"

--- a/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_create_or_alter_attributes.py
+++ b/dbt-snowflake/tests/functional/relation_tests/dynamic_table_tests/test_create_or_alter_attributes.py
@@ -1,0 +1,394 @@
+"""
+Parameterized attribute-behavior tests for the CREATE OR ALTER dynamic table path.
+
+For a FULL + scheduler='disable' native dynamic table with the behavior flag on, a COA
+query edit re-declares the definition. This module pins down how each dynamic-table
+attribute behaves across that COA, per Snowflake's CREATE OR ALTER semantics:
+
+  - governance (masking / row-access policies, tags) is PRESERVED,
+  - operational attributes set out of band (data_retention, comment) RESET to
+    default/inherited -- the same as CREATE OR REPLACE (--full-refresh),
+  - dbt config-surface attributes (cluster_by, warehouse, ...) are APPLIED from config,
+
+and a combined multi-attribute case confirms they behave independently in one COA.
+
+Test flow (shared by every test in this module):
+  1. ARRANGE -- the `fresh_dt` fixture builds a fresh dynamic table per test
+     (`seed` + baseline model + `run --full-refresh`); the flag is on via
+     `project_config_update`. Axis A then sets the attribute out of band with
+     `run_sql` (masking policy, tag, retention, ...) because these have no dbt
+     config surface, and asserts the setup landed (`before == expected`).
+  2. ACT -- edit the model and `dbt run` WITHOUT --full-refresh. Axis A uses a
+     query-only edit (add a column) purely to trigger a COA; Axis B changes a
+     dbt config key (warehouse, cluster_by, ...) to see it applied in place.
+  3. ASSERT -- read the attribute back and check preserved vs. reset (Axis A) or
+     applied (Axis B). Reads go through `describe_dynamic_table` (SHOW output) for
+     dbt-managed attrs, or a catalog query for the rest -- policies/tags via
+     `information_schema.*_references`, retention/comment via `.tables`,
+     parameters via `SHOW PARAMETERS` (see the `_policies`/`_tags`/`_table_field`/
+     `_param` read helpers below).
+  4. TEARDOWN -- `fresh_dt` drops the schema so each parametrized case starts clean.
+
+Axis A is parametrized over `ATTR_SPECS`, Axis B over `CONFIG_SPECS`; each spec is
+one attribute's (how to set / how to read / expected outcome).
+
+Requires a live Snowflake connection.
+"""
+
+import os
+
+import pytest
+
+from dbt.tests.util import run_dbt
+
+from tests.functional.utils import describe_dynamic_table, update_model
+
+
+FLAG = {"flags": {"snowflake_dynamic_table_create_or_alter": True}}
+
+SEED = "id,value\n1,alice\n2,bob\n3,carol\n"
+
+DT_BASE = """
+{{ config(materialized='dynamic_table', snowflake_warehouse='DBT_TESTING',
+          refresh_mode='FULL', scheduler='disable') }}
+select id, value from {{ ref('my_seed') }}
+"""
+
+# A COA-compatible query edit (add a column at the end) that triggers a COA.
+DT_QUERY_EDIT = """
+{{ config(materialized='dynamic_table', snowflake_warehouse='DBT_TESTING',
+          refresh_mode='FULL', scheduler='disable') }}
+select id, value, id * 10 as id_x10 from {{ ref('my_seed') }}
+"""
+
+
+# --------------------------------------------------------------------------- reads
+
+
+def _fqn(project):
+    return f"{project.database}.{project.test_schema}.dt_coa"
+
+
+def _policies(project):
+    rows = project.run_sql(
+        f"select policy_name from table({project.database}.information_schema.policy_references("
+        f"ref_entity_name => '{_fqn(project)}', ref_entity_domain => 'table'))",
+        fetch="all",
+    )
+    return sorted(r[0].upper() for r in rows)
+
+
+def _tags(project):
+    rows = project.run_sql(
+        f"select tag_name from table({project.database}.information_schema.tag_references("
+        f"'{_fqn(project)}', 'table'))",
+        fetch="all",
+    )
+    return sorted(r[0].upper() for r in rows)
+
+
+def _table_field(project, field):
+    rows = project.run_sql(
+        f"select {field} from {project.database}.information_schema.tables "
+        f"where table_schema ilike '{project.test_schema}' and table_name ilike 'dt_coa'",
+        fetch="all",
+    )
+    return rows[0][0] if rows else None
+
+
+def _param(project, name):
+    # SHOW PARAMETERS returns rows directly (key, value, default, level, ...)
+    rows = project.run_sql(f"show parameters like '{name}' in table {_fqn(project)}", fetch="all")
+    return rows[0][1] if rows else None
+
+
+# --------------------------------------------------------------------------- specs
+
+# Each spec: how to set the attribute out of band, how to read it, and the expected
+# behavior after a COA query edit. `read` returns a comparable value.
+PRESERVED = "preserved"
+RESET = "reset"
+
+ATTR_SPECS = [
+    pytest.param(
+        {
+            "apply": [
+                "create masking policy if not exists mp as (v varchar) returns varchar -> '***'",
+                "alter table {fqn} modify column value set masking policy mp",
+            ],
+            "read": lambda p: "MP" in _policies(p),
+            "before": True,
+            "kind": PRESERVED,
+        },
+        id="masking_policy",
+    ),
+    pytest.param(
+        {
+            "apply": [
+                "create row access policy if not exists rap as (i int) returns boolean -> true",
+                "alter dynamic table {fqn} add row access policy rap on (id)",
+            ],
+            "read": lambda p: "RAP" in _policies(p),
+            "before": True,
+            "kind": PRESERVED,
+        },
+        id="row_access_policy",
+    ),
+    pytest.param(
+        {
+            "apply": [
+                "create tag if not exists mytag",
+                "alter dynamic table {fqn} set tag mytag = 'v1'",
+            ],
+            "read": lambda p: "MYTAG" in _tags(p),
+            "before": True,
+            "kind": PRESERVED,
+        },
+        id="tag",
+    ),
+    pytest.param(
+        {
+            "apply": [
+                "create projection policy if not exists pp as () returns projection_constraint "
+                "-> projection_constraint(allow => true)",
+                "alter table {fqn} modify column value set projection policy pp",
+            ],
+            "read": lambda p: "PP" in _policies(p),
+            "before": True,
+            "kind": PRESERVED,
+        },
+        id="projection_policy",
+    ),
+    pytest.param(
+        {
+            "apply": [
+                "create aggregation policy if not exists ap as () returns aggregation_constraint "
+                "-> aggregation_constraint(min_group_size => 2)",
+                "alter dynamic table {fqn} set aggregation policy ap",
+            ],
+            "read": lambda p: "AP" in _policies(p),
+            "before": True,
+            "kind": PRESERVED,
+        },
+        id="aggregation_policy",
+    ),
+    pytest.param(
+        {
+            "apply": ["alter dynamic table {fqn} set max_data_extension_time_in_days = 5"],
+            "read": lambda p: str(_param(p, "MAX_DATA_EXTENSION_TIME_IN_DAYS")),
+            "before": "5",
+            "kind": RESET,
+        },
+        id="max_data_extension",
+    ),
+    pytest.param(
+        {
+            "apply": ["alter dynamic table {fqn} set data_retention_time_in_days = 3"],
+            "read": lambda p: str(_table_field(p, "retention_time")),
+            "before": "3",
+            "kind": RESET,
+        },
+        id="data_retention",
+    ),
+    pytest.param(
+        {
+            "apply": ["alter dynamic table {fqn} set comment = 'keepme'"],
+            "read": lambda p: (_table_field(p, "comment") or ""),
+            "before": "keepme",
+            "kind": RESET,
+        },
+        id="comment",
+    ),
+]
+
+
+class TestCoaAttributeBehavior:
+    """One fresh DT per case: set the attribute out of band, do a COA query edit, assert."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_coa.sql": DT_BASE}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return FLAG
+
+    @pytest.fixture(scope="function", autouse=True)
+    def fresh_dt(self, project):
+        run_dbt(["seed"])
+        update_model(project, "dt_coa", DT_BASE)
+        run_dbt(["run", "--full-refresh"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.mark.parametrize("spec", ATTR_SPECS)
+    def test_attribute_behavior_across_coa(self, project, spec):
+        fqn = _fqn(project)
+        for stmt in spec["apply"]:
+            project.run_sql(stmt.format(fqn=fqn))
+
+        before = spec["read"](project)
+        assert (
+            before == spec["before"]
+        ), f"setup failed: got {before!r}, expected {spec['before']!r}"
+
+        # trigger a COA via a query-only edit
+        update_model(project, "dt_coa", DT_QUERY_EDIT)
+        run_dbt(["run"])
+        assert "id_x10" in (describe_dynamic_table(project, "dt_coa").query or "").lower()
+
+        after = spec["read"](project)
+        if spec["kind"] == PRESERVED:
+            assert after == before, f"expected preserved, got {after!r}"
+        else:
+            assert after != before, f"expected reset, still {after!r}"
+
+
+def _model(cfg):
+    return (
+        "{{ config(materialized='dynamic_table', refresh_mode='FULL', scheduler='disable', "
+        + cfg
+        + ") }}\nselect id, value from {{ ref('my_seed') }}"
+    )
+
+
+# Axis B: dbt config keys our COA emits -> a config change is applied in place via COA.
+DT_CFG_BASE = _model("snowflake_warehouse='DBT_TESTING'")
+
+# A warehouse change can only be observed with two real, distinct warehouses.
+ALT_WAREHOUSE = os.getenv("SNOWFLAKE_TEST_ALT_WAREHOUSE", "DBT_TESTING")
+_alt_warehouse_configured = pytest.mark.skipif(
+    ALT_WAREHOUSE.strip().upper() == "DBT_TESTING",
+    reason="SNOWFLAKE_TEST_ALT_WAREHOUSE not set to a distinct warehouse; "
+    "this case needs two real, different warehouses to observe the change.",
+)
+
+CONFIG_SPECS = [
+    pytest.param(
+        {
+            "v2": _model(f"snowflake_warehouse='{ALT_WAREHOUSE}'"),
+            "check": lambda dt: str(dt.snowflake_warehouse).upper() == ALT_WAREHOUSE.upper(),
+        },
+        id="warehouse",
+        marks=_alt_warehouse_configured,
+    ),
+    pytest.param(
+        {
+            "v2": _model(
+                "snowflake_warehouse='DBT_TESTING', "
+                f"snowflake_initialization_warehouse='{ALT_WAREHOUSE}'"
+            ),
+            "check": lambda dt: str(dt.snowflake_initialization_warehouse).upper()
+            == ALT_WAREHOUSE.upper(),
+        },
+        id="initialization_warehouse",
+        marks=_alt_warehouse_configured,
+    ),
+    pytest.param(
+        {
+            "v2": _model("snowflake_warehouse='DBT_TESTING', cluster_by=['id']"),
+            "check": lambda dt: "ID" in str(dt.cluster_by or "").upper(),
+        },
+        id="cluster_by",
+    ),
+]
+
+
+class TestCoaConfigChangeApplied:
+    """Axis B: changing a dbt-supported config key is applied in place via COA (no --full-refresh)."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {"dt_coa.sql": DT_CFG_BASE}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return FLAG
+
+    @pytest.fixture(scope="function", autouse=True)
+    def fresh_dt(self, project):
+        run_dbt(["seed"])
+        update_model(project, "dt_coa", DT_CFG_BASE)
+        run_dbt(["run", "--full-refresh"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    @pytest.mark.parametrize("spec", CONFIG_SPECS)
+    def test_config_change_applied_via_coa(self, project, spec):
+        update_model(project, "dt_coa", spec["v2"])
+        run_dbt(["run"])  # config-only change -> COA applies it in place
+        dt = describe_dynamic_table(project, "dt_coa")
+        assert spec["check"](dt), f"config change not applied via COA: {dt}"
+
+
+class TestCoaMultipleAttributes:
+    """Governance + operational + config attrs together: one COA query edit, independent outcomes."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seeds(self):
+        yield {"my_seed.csv": SEED}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        # cluster_by is a config-surface attr -> emitted by COA -> should be applied/kept
+        yield {
+            "dt_coa.sql": """
+{{ config(materialized='dynamic_table', snowflake_warehouse='DBT_TESTING',
+          refresh_mode='FULL', scheduler='disable', cluster_by=['id']) }}
+select id, value from {{ ref('my_seed') }}
+"""
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return FLAG
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run", "--full-refresh"])
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
+
+    def test_mixed_attributes_across_one_coa(self, project):
+        fqn = _fqn(project)
+        # governance (should be preserved) + operational (should reset)
+        project.run_sql(
+            "create masking policy if not exists mp as (v varchar) returns varchar -> '***'"
+        )
+        project.run_sql(f"alter table {fqn} modify column value set masking policy mp")
+        project.run_sql("create tag if not exists mytag")
+        project.run_sql(f"alter dynamic table {fqn} set tag mytag = 'v1'")
+        project.run_sql(f"alter dynamic table {fqn} set data_retention_time_in_days = 3")
+
+        assert "MP" in _policies(project)
+        assert "MYTAG" in _tags(project)
+        assert str(_table_field(project, "retention_time")) == "3"
+        cluster_before = describe_dynamic_table(project, "dt_coa").cluster_by
+
+        # one COA query edit
+        update_model(
+            project,
+            "dt_coa",
+            """
+{{ config(materialized='dynamic_table', snowflake_warehouse='DBT_TESTING',
+          refresh_mode='FULL', scheduler='disable', cluster_by=['id']) }}
+select id, value, id * 10 as id_x10 from {{ ref('my_seed') }}
+""",
+        )
+        run_dbt(["run"])
+
+        after = describe_dynamic_table(project, "dt_coa")
+        assert "id_x10" in (after.query or "").lower()  # query evolved
+        assert "MP" in _policies(project)  # governance preserved
+        assert "MYTAG" in _tags(project)  # governance preserved
+        assert after.cluster_by == cluster_before  # config-surface kept
+        assert str(_table_field(project, "retention_time")) != "3"  # operational reset

--- a/dbt-snowflake/tests/unit/test_dynamic_table_config.py
+++ b/dbt-snowflake/tests/unit/test_dynamic_table_config.py
@@ -1,14 +1,33 @@
 """
-Unit tests for SnowflakeDynamicTableConfig, testing:
+Unit tests for SnowflakeDynamicTableConfig / SnowflakeDynamicTableConfigChangeset, covering:
 - snowflake_initialization_warehouse parameter
 - refresh_warehouse parameter and warehouse_parameter property
 - immutable_where parameter
 - transient parameter
-- scheduler parameter
+- scheduler parameter (+ target_lag validation)
+
+No database required -- these are pure Python. There are three test shapes here:
+
+  1. Config parsing -- `SnowflakeDynamicTableConfig.from_dict({...})` then assert an
+     attribute parsed as expected (optional / defaults to None / accepts a value).
+     Classes named Test<Attr>Optional.
+  2. Changeset semantics -- construct a `SnowflakeDynamicTableConfigChangeset(...)`
+     directly and assert `.has_changes` / `.requires_full_refresh`. This pins which
+     attribute changes can be ALTERed in place vs. force a rebuild (the veto the COA
+     path relies on -- transient/refresh_mode -> full refresh; warehouse/scheduler/
+     immutable_where -> alter). Classes named Test<Attr>Changeset.
+  3. Change detection -- build a mock existing table (`_make_relation_results`, a SHOW
+     row as an agate table) and a desired config (`_make_relation_config`, a mock
+     RelationConfig), call `SnowflakeRelation.dynamic_table_config_changeset(...)`, and
+     assert whether a change is detected. Classes named Test<Attr>ChangeDetectionLogic.
 """
 
 import pytest
 
+from dbt.adapters.snowflake.impl import (
+    SNOWFLAKE_DYNAMIC_TABLE_CREATE_OR_ALTER,
+    SnowflakeAdapter,
+)
 from dbt.adapters.relation_configs import RelationConfigChangeAction
 from dbt.adapters.snowflake.relation_configs import (
     SnowflakeDynamicTableConfig,
@@ -1212,3 +1231,23 @@ class TestRefreshWarehouseChangeset:
 
         if changeset is not None:
             assert changeset.snowflake_warehouse is None
+
+
+class TestCreateOrAlterBehaviorFlag:
+    """The CREATE OR ALTER path is opt-in: this locks the default-off safety contract and
+    that the flag stays wired into the adapter, so neither can be changed unnoticed."""
+
+    def test_flag_name_is_stable(self):
+        # the name is the public API users type in dbt_project.yml flags: {...}
+        assert SNOWFLAKE_DYNAMIC_TABLE_CREATE_OR_ALTER["name"] == (
+            "snowflake_dynamic_table_create_or_alter"
+        )
+
+    def test_flag_defaults_off(self):
+        # default MUST be False: enabling it changes query-evolution behavior for every DT
+        assert SNOWFLAKE_DYNAMIC_TABLE_CREATE_OR_ALTER["default"] is False
+
+    def test_flag_is_registered_on_the_adapter(self):
+        # _behavior_flags is an instance property whose body ignores self, so fget(None) is safe
+        flags = SnowflakeAdapter._behavior_flags.fget(None)
+        assert SNOWFLAKE_DYNAMIC_TABLE_CREATE_OR_ALTER in flags

--- a/dbt-snowflake/tests/unit/test_snowflake_adapter.py
+++ b/dbt-snowflake/tests/unit/test_snowflake_adapter.py
@@ -245,6 +245,47 @@ class TestSnowflakeAdapter(unittest.TestCase):
             self.adapter.post_model_hook(config, result)
             self.mock_execute.assert_not_called()
 
+    def _dynamic_table_create_or_alter_enabled(
+        self, flag_on=True, catalog_type="INFO_SCHEMA", catalog_relation_none=False
+    ):
+        """Drive adapter.dynamic_table_create_or_alter_enabled with its two collaborators mocked:
+        the behavior flag and the catalog relation. The gate is flag + native catalog only
+        (refresh_mode and scheduler don't factor in, so they are not mocked). catalog_relation_none
+        makes build_catalog_relation return None (a non-DT / catalog-less model)."""
+        with (
+            mock.patch.object(
+                type(self.adapter), "behavior", new_callable=mock.PropertyMock
+            ) as mock_behavior,
+            mock.patch.object(self.adapter, "build_catalog_relation") as mock_build_catalog,
+        ):
+            mock_behavior.return_value.snowflake_dynamic_table_create_or_alter.no_warn = flag_on
+            mock_build_catalog.return_value = (
+                None if catalog_relation_none else mock.Mock(catalog_type=catalog_type)
+            )
+            return self.adapter.dynamic_table_create_or_alter_enabled(mock.Mock())
+
+    def test_dt_coa_enabled_for_native(self):
+        # The gate checks only the flag and the native (INFO_SCHEMA) catalog, so one case suffices
+        # -- refresh_mode and scheduler do not affect the decision.
+        self.assertTrue(self._dynamic_table_create_or_alter_enabled())
+
+    def test_dt_coa_disabled_for_iceberg(self):
+        # BUILT_IN == Iceberg: deliberately excluded from the COA path for now. Snowflake supports
+        # Iceberg COA (since 2026-08-13); this adapter just hasn't implemented that DDL path yet.
+        self.assertFalse(self._dynamic_table_create_or_alter_enabled(catalog_type="BUILT_IN"))
+
+    def test_dt_coa_disabled_when_flag_off(self):
+        self.assertFalse(self._dynamic_table_create_or_alter_enabled(flag_on=False))
+
+    def test_dt_coa_disabled_when_catalog_relation_none(self):
+        # build_catalog_relation can return None (e.g. a catalog-less model); the getattr fallback
+        # must yield False rather than raise.
+        self.assertFalse(self._dynamic_table_create_or_alter_enabled(catalog_relation_none=True))
+
+    def test_dt_coa_disabled_when_catalog_type_missing(self):
+        # A catalog relation whose catalog_type is None must not match INFO_SCHEMA.
+        self.assertFalse(self._dynamic_table_create_or_alter_enabled(catalog_type=None))
+
     def test_cancel_open_connections_empty(self):
         self.assertEqual(len(list(self.adapter.cancel_open_connections())), 0)
 


### PR DESCRIPTION
Addresses #1825

### Problem

For a dynamic table, `dbt run` compares only config — not the model's SQL. A SQL-only edit
therefore produces no changeset and no-ops, leaving the old query live, so users must remember
`--full-refresh` (unlike table/view/incremental models, which apply SQL changes automatically).

### Solution

Add the `snowflake_dynamic_table_create_or_alter` behavior flag (default off). When enabled,
native dynamic tables sync their definition in place via `CREATE OR ALTER DYNAMIC TABLE` on every
run — so a SQL edit deploys without `--full-refresh`. Change detection is delegated to Snowflake
rather than comparing SQL text. Applies to any `refresh_mode` and any `scheduler` setting: opting
in means accepting `CREATE OR ALTER` semantics wherever they are expressible.

- **INCREMENTAL / AUTO:** a definition edit reinitializes the table (full recompute, incremental
  state discarded) — a documented divergence from dbt incremental models, where a logic change
  requires `--full-refresh`. Called out loudly in the flag description.
- `transient` / `refresh_mode` changes route to `CREATE OR REPLACE` (dbt treats them as full rebuilds).
- Schema changes `CREATE OR ALTER` can't express (column reorder, mid-list insert, type narrowing,
  drop-all) surface Snowflake's error; the fallback is `--full-refresh` (no automatic fallback).
- A no-change run is an idempotent no-op (synced in place, not rebuilt).
- **Iceberg is out of scope for this PR** — the gate is native (`INFO_SCHEMA`) only. Snowflake added
  `CREATE OR ALTER DYNAMIC ICEBERG TABLE` on 2026-08-13; wiring that Iceberg DDL path is a planned
  follow-up, so for now Iceberg dynamic tables keep the standard create-or-replace behavior.

This adds a behavior flag, one `@available` adapter method, and new dynamic-table macros — all
additive and opt-in (default off).

**Tests:** unit tests for the gate + flag, and a functional matrix across `refresh_mode` ×
`scheduler` (FULL / INCREMENTAL / AUTO × disable / enable), plus the routing/veto (transient,
refresh_mode), `on_configuration_change` (fail / continue), incompatible-edit (errors +
`--full-refresh` recovers), transient-drift (errors + recovers), refresh_mode→AUTO (applies in
place), and no-op / idempotency cases.

Supersedes #1851 (deprecated by its author).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
