### PR TITLE
Scope batch source freshness queries to one project at a time

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fixes-20260829-114624.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20260829-114624.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix batch metadata source freshness reporting another project's table when
+    two sources in different projects share a dataset/schema name
+time: 2026-08-29T11:46:24.000000+00:00
+custom:
+    Author: afonsojanu
+    Issue: "2107"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
@@ -1235,31 +1235,45 @@ class BigQueryAdapter(BaseAdapter):
                 freshness_responses[source] = freshness_response
             return adapter_responses, freshness_responses
 
-        # Track schema, identifiers of sources for lookup from batch query
-        schema_identifier_to_source = {
-            (
-                source.path.get_lowered_part(ComponentName.Schema),  # type: ignore
-                source.path.get_lowered_part(ComponentName.Identifier),  # type: ignore
-            ): source
-            for source in sources
-        }
+        # The batch query's information_schema is derived from relations[0], so
+        # one call can only ever reach a single project's TABLE_STORAGE. Batching
+        # sources from different projects together in one call, as before, sent
+        # every one of them at whichever project relations[0] happened to name,
+        # and matched rows back by (schema, identifier) alone, so a source in
+        # one project could silently be answered by a same-named table in
+        # another project's dataset. Grouping by database first keeps every
+        # batch scoped to the one project its own query actually reaches.
+        sources_by_database: Dict[Optional[str], List[BaseRelation]] = {}
+        for source in sources:
+            database = source.path.get_lowered_part(ComponentName.Database)  # type: ignore
+            sources_by_database.setdefault(database, []).append(source)
 
-        result = self.execute_macro(
-            GET_RELATION_LAST_MODIFIED_MACRO_NAME,
-            kwargs={
-                "information_schema": None,
-                "relations": sources,
-            },
-            macro_resolver=macro_resolver,
-            needs_conn=True,
-        )
-        adapter_response, table = result.response, result.table  # type: ignore[attr-defined]
-        adapter_responses.append(adapter_response)
+        for database_sources in sources_by_database.values():
+            # Track schema, identifiers of sources for lookup from batch query
+            schema_identifier_to_source = {
+                (
+                    source.path.get_lowered_part(ComponentName.Schema),  # type: ignore
+                    source.path.get_lowered_part(ComponentName.Identifier),  # type: ignore
+                ): source
+                for source in database_sources
+            }
 
-        for row in table:
-            raw_relation, freshness_response = self._parse_freshness_row(row, table)
-            source_relation_for_result = schema_identifier_to_source[raw_relation]
-            freshness_responses[source_relation_for_result] = freshness_response
+            result = self.execute_macro(
+                GET_RELATION_LAST_MODIFIED_MACRO_NAME,
+                kwargs={
+                    "information_schema": None,
+                    "relations": database_sources,
+                },
+                macro_resolver=macro_resolver,
+                needs_conn=True,
+            )
+            adapter_response, table = result.response, result.table  # type: ignore[attr-defined]
+            adapter_responses.append(adapter_response)
+
+            for row in table:
+                raw_relation, freshness_response = self._parse_freshness_row(row, table)
+                source_relation_for_result = schema_identifier_to_source[raw_relation]
+                freshness_responses[source_relation_for_result] = freshness_response
 
         return adapter_responses, freshness_responses
 

--- a/dbt-bigquery/tests/unit/test_calculate_freshness_from_metadata_batch.py
+++ b/dbt-bigquery/tests/unit/test_calculate_freshness_from_metadata_batch.py
@@ -1,13 +1,22 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from dbt.adapters.bigquery.impl import BigQueryAdapter
+from dbt.adapters.bigquery.relation import BigQueryRelation
+from dbt.adapters.contracts.relation import RelationType
 
 
 @pytest.fixture
 def adapter():
     return BigQueryAdapter(MagicMock(), MagicMock())
+
+
+def _make_relation(database: str, schema: str, identifier: str) -> BigQueryRelation:
+    return BigQueryRelation.create(
+        database=database, schema=schema, identifier=identifier, type=RelationType.Table
+    )
 
 
 class TestCalculateFreshnessFromMetadataBatch:
@@ -21,3 +30,47 @@ class TestCalculateFreshnessFromMetadataBatch:
         assert adapter_responses == []
         assert freshness_responses == {}
         execute_macro.assert_not_called()
+
+    def test_sources_sharing_a_schema_across_databases_query_separately(self, adapter, mocker):
+        """Two sources with the same schema/identifier but different databases must
+        not be batched into the same query (#2107): the query only ever reaches
+        whichever project relations[0] names, so batching them together would let
+        the wrong project's table answer for one of the sources.
+        """
+        mocker.patch.object(
+            adapter, "_behavior", SimpleNamespace(bigquery_use_batch_source_freshness=True)
+        )
+        stale_source = _make_relation("project-a", "stripe", "plans")
+        fresh_source = _make_relation("project-b", "stripe", "plans")
+
+        # Each fake query result's "table" is just the queried database's own
+        # name, standing in for the single row that database's real query
+        # would come back with: both sources share a schema/identifier, so
+        # nothing but which batch a row came from can tell them apart.
+        freshness_by_database = {
+            "project-a": {"max_loaded_at": "stale", "snapshotted_at": "now", "age": 1.0},
+            "project-b": {"max_loaded_at": "fresh", "snapshotted_at": "now", "age": 2.0},
+        }
+
+        def fake_execute_macro(_name, kwargs, **_kw):
+            database = kwargs["relations"][0].database
+            return MagicMock(response=f"adapter-response-{database}", table=[database])
+
+        execute_macro = mocker.patch.object(
+            adapter, "execute_macro", side_effect=fake_execute_macro
+        )
+        mocker.patch.object(
+            adapter,
+            "_parse_freshness_row",
+            side_effect=lambda row, _table: (("stripe", "plans"), freshness_by_database[row]),
+        )
+
+        _adapter_responses, freshness_responses = adapter.calculate_freshness_from_metadata_batch(
+            sources=[stale_source, fresh_source]
+        )
+
+        assert (
+            execute_macro.call_count == 2
+        ), "each database should get its own batch query, not one shared query"
+        assert freshness_responses[stale_source]["max_loaded_at"] == "stale"
+        assert freshness_responses[fresh_source]["max_loaded_at"] == "fresh"


### PR DESCRIPTION
resolves #2107
docs N/A

### Problem

With `bigquery_use_batch_source_freshness` enabled, `dbt source freshness` can report the freshness of a completely different physical table, in a different BigQuery project, for a source. This happens when two sources point at different projects that both use a dataset with the same name.

`calculate_freshness_from_metadata_batch` batches every source into one query regardless of which project it lives in, but the query's `information_schema` is built from `relations[0]`, so it only ever reaches a single project's `TABLE_STORAGE`. Rows that come back are matched to sources by `(schema, identifier)` alone, so a source in one project can be silently answered by a same-named table in whichever project `relations[0]` happened to name. The result is nondeterministic since it depends on iteration order, and there's no error or log line indicating anything went wrong, just a wrong `max_loaded_at`.

### Solution

Group sources by `database` before batching, so each query only ever contains sources from the project it actually reaches. This costs one extra query round trip per distinct project among the sources being checked, which is the correct tradeoff since BigQuery's `INFORMATION_SCHEMA` genuinely is project-scoped and there's no way to query more than one project at once.

Added a unit test with two sources sharing a schema/identifier across two different databases, confirming each triggers its own query and gets matched back to the right result.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests
- [x] This PR has no interface changes
