### PR TITLE
Fix nested null rendering as Python's None in Snowflake object/array unit test fixtures

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20260829-121000.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260829-121000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: A nested `null` inside a dict or list column in a unit test fixture was rendered
+  as Python's `None` instead of `null`, producing invalid syntax in Snowflake's
+  object/array constructor literals
+time: 2026-08-29T12:10:00.000000-05:00
+custom:
+  Author: afonsojanu
+  Issue: "15530"

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/utils/safe_cast.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/utils/safe_cast.sql
@@ -5,9 +5,43 @@
         try_to_geography({{field}})
     {% elif type|upper != "VARIANT" -%}
         {#-- Snowflake try_cast does not support casting to variant, and expects the field as a string --#}
-        {% set field_as_string =  dbt.string_literal(field) if field is number else field %}
+        {%- if field is mapping or (field is sequence and field is not string) -%}
+            {#-- A dict or list field's default rendering is Python's own str(),
+                 which spells a nested null as None rather than the null Snowflake's
+                 object/array constructor syntax expects, so it needs its own
+                 serialization instead of falling straight into {{field}} below --#}
+            {% set field_as_string = snowflake_composite_literal(field) %}
+        {%- else -%}
+            {% set field_as_string =  dbt.string_literal(field) if field is number else field %}
+        {%- endif -%}
         try_cast({{field_as_string}} as {{type}})
     {% else -%}
         {{ adapter.dispatch('cast', 'dbt')(field, type) }}
     {% endif -%}
 {% endmacro %}
+
+{%- macro snowflake_composite_literal(value) -%}
+    {#-- Renders a dict or list as Snowflake's own object/array constructor
+         syntax, the same shape Python's str() already produces for
+         everything except None, which this corrects to null at any nesting
+         depth. --#}
+    {%- if value is none -%}
+        {{- 'null' -}}
+    {%- elif value is mapping -%}
+        {%- set parts = [] -%}
+        {%- for key, item in value.items() -%}
+            {%- do parts.append(dbt.string_literal(dbt.escape_single_quotes(key)) ~ ': ' ~ snowflake_composite_literal(item)) -%}
+        {%- endfor -%}
+        {{- '{' ~ parts | join(', ') ~ '}' -}}
+    {%- elif value is sequence and value is not string -%}
+        {%- set parts = [] -%}
+        {%- for item in value -%}
+            {%- do parts.append(snowflake_composite_literal(item)) -%}
+        {%- endfor -%}
+        {{- '[' ~ parts | join(', ') ~ ']' -}}
+    {%- elif value is string -%}
+        {{- dbt.string_literal(dbt.escape_single_quotes(value)) -}}
+    {%- else -%}
+        {{- value -}}
+    {%- endif -%}
+{%- endmacro -%}

--- a/dbt-snowflake/tests/unit/test_safe_cast_macro.py
+++ b/dbt-snowflake/tests/unit/test_safe_cast_macro.py
@@ -1,0 +1,76 @@
+import os
+import unittest
+from unittest import mock
+from jinja2 import Environment, FileSystemLoader
+
+MACROS_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "../../src/dbt/include/snowflake/macros")
+)
+
+
+class TestSnowflakeSafeCastMacro(unittest.TestCase):
+    """
+    A dict or list field with a nested None used to render through Python's
+    own str(), which spells null as None, producing invalid syntax inside
+    Snowflake's object/array constructor literals (#15530). These pin the
+    fix at the macro level, without needing a live warehouse.
+    """
+
+    def setUp(self):
+        self.jinja_env = Environment(
+            loader=FileSystemLoader(MACROS_DIR),
+            extensions=[
+                "jinja2.ext.do",
+            ],
+        )
+        self.default_context = {
+            "adapter": mock.Mock(),
+            "dbt": mock.Mock(
+                string_literal=lambda v: f"'{v}'",
+                escape_single_quotes=lambda v: v.replace("'", "''"),
+            ),
+            "return": lambda r: r,
+        }
+
+    def __get_template(self):
+        return self.jinja_env.get_template("utils/safe_cast.sql", globals=self.default_context)
+
+    def __safe_cast(self, template, field, type_):
+        return getattr(template.module, "snowflake__safe_cast")(field, type_).strip()
+
+    def test_nested_null_in_a_dict_field_renders_as_null_not_none(self):
+        template = self.__get_template()
+        field = {
+            "ADEF-DEPT": {"system_attribute_id": "department", "value": "5"},
+            "ADEF-CUSTOM": {"system_attribute_id": None, "value": "99"},
+        }
+
+        sql = self.__safe_cast(template, field, "OBJECT")
+
+        self.assertNotIn("None", sql)
+        self.assertIn("'system_attribute_id': null", sql)
+
+    def test_nested_null_in_a_list_field_renders_as_null_not_none(self):
+        template = self.__get_template()
+        field = [{"a": None}, {"a": "b"}]
+
+        sql = self.__safe_cast(template, field, "ARRAY")
+
+        self.assertNotIn("None", sql)
+        self.assertEqual(sql, "try_cast([{'a': null}, {'a': 'b'}] as ARRAY)")
+
+    def test_a_string_value_in_a_dict_field_keeps_its_quoting(self):
+        template = self.__get_template()
+        field = {"note": "it's fine"}
+
+        sql = self.__safe_cast(template, field, "OBJECT")
+
+        self.assertEqual(sql, "try_cast({'note': 'it''s fine'} as OBJECT)")
+
+    def test_a_plain_scalar_field_is_unaffected(self):
+        template = self.__get_template()
+
+        self.assertEqual(self.__safe_cast(template, 5, "NUMBER"), "try_cast('5' as NUMBER)")
+        self.assertEqual(
+            self.__safe_cast(template, "hello", "VARCHAR"), "try_cast(hello as VARCHAR)"
+        )

--- a/dbt-snowflake/tests/unit/test_safe_cast_macro.py
+++ b/dbt-snowflake/tests/unit/test_safe_cast_macro.py
@@ -27,7 +27,7 @@ class TestSnowflakeSafeCastMacro(unittest.TestCase):
             "adapter": mock.Mock(),
             "dbt": mock.Mock(
                 string_literal=lambda v: f"'{v}'",
-                escape_single_quotes=lambda v: v.replace("'", "''"),
+                escape_single_quotes=lambda v: v.replace("'", "\\'"),
             ),
             "return": lambda r: r,
         }
@@ -65,7 +65,7 @@ class TestSnowflakeSafeCastMacro(unittest.TestCase):
 
         sql = self.__safe_cast(template, field, "OBJECT")
 
-        self.assertEqual(sql, "try_cast({'note': 'it''s fine'} as OBJECT)")
+        self.assertEqual(sql, "try_cast({'note': 'it\\'s fine'} as OBJECT)")
 
     def test_a_plain_scalar_field_is_unaffected(self):
         template = self.__get_template()


### PR DESCRIPTION
resolves dbt-labs/dbt-core#15530
docs N/A

### Problem

A unit test fixture column whose value is a dict or list can silently break at compile time when one of its nested keys is explicitly `null`. On Snowflake, `select ... {{ dbt.string_literal }} ...` type casting for that column reaches an `invalid identifier 'NONE'` error instead of compiling, because the generated SQL literally contains Python's `None` where a JSON-style `null` belongs.

The column's raw dict/list value reaches Snowflake's `safe_cast` macro unchanged and gets interpolated directly into the object/array constructor syntax it builds around it. Python's own string conversion of a dict or list spells a nested `null` as `None`, which isn't valid inside Snowflake's constructor syntax, so an attribute that's present with a value of `null` (as opposed to being omitted entirely) breaks compilation.

### Solution

Added `snowflake_composite_literal`, a small recursive macro that walks a dict or list and renders it in the same shape Python's own conversion already produces for every other value (single-quoted strings, unquoted numbers, nested braces/brackets), just correcting `None` to `null` at any nesting depth. `snowflake__safe_cast` now routes a dict or list field through this instead of interpolating it directly.

Added unit tests covering a nested null in both a dict and a list column, a string value keeping its existing quote-escaping behavior, and confirming a plain scalar field's rendering is unaffected by this change.

### Checklist

- [x] I have read the contributing guide and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests
- [x] This PR has no interface changes
