### PR TITLE
fix(bigquery): skip catalog check for regional information schema

### DIFF
--- a/dbt-bigquery/.changes/unreleased/Fixes-20260831-135348.yaml
+++ b/dbt-bigquery/.changes/unreleased/Fixes-20260831-135348.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Skip physical dataset existence checks for region-scoped INFORMATION_SCHEMA sources
+time: 2026-08-31T13:53:48Z
+custom:
+    Author: carleondel
+    Issue: "2152"

--- a/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
+++ b/dbt-bigquery/src/dbt/adapters/bigquery/impl.py
@@ -1140,6 +1140,18 @@ class BigQueryAdapter(BaseAdapter):
         for info_schema, rels in candidates.items():
             database = info_schema.database
             schema = info_schema.schema
+            region, separator, suffix = schema.partition(".")
+            if (
+                separator
+                and region.lower().startswith("region-")
+                and len(region) > len("region-")
+                and suffix.lower() == "information_schema"
+            ):
+                logger.debug(
+                    "Skipping catalog for {}.{} - region-scoped INFORMATION_SCHEMA "
+                    "is not a physical schema".format(database, schema)
+                )
+                continue
             if database not in schema_exists:
                 schema_exists[database] = {}
             if schema not in schema_exists[database]:

--- a/dbt-bigquery/tests/unit/test_bigquery_adapter.py
+++ b/dbt-bigquery/tests/unit/test_bigquery_adapter.py
@@ -1077,6 +1077,29 @@ class TestBigQueryCatalogRelationsByInfoSchema(BaseTestBigQueryAdapter):
             schema="real_dataset",
             identifier="my_table",
         )
+        nonexistent_relation = BigQueryRelation.create(
+            database="test-project",
+            schema="missing_dataset",
+            identifier="missing_table",
+        )
+
+        result = adapter._get_catalog_relations_by_info_schema(
+            [normal_relation, nonexistent_relation]
+        )
+
+        schemas_in_result = {info.schema for info in result.keys()}
+        assert "real_dataset" in schemas_in_result
+        assert "missing_dataset" not in schemas_in_result
+
+    def test_filters_out_region_information_schema_without_existence_check(self):
+        adapter = self.get_adapter("oauth")
+        adapter.check_schema_exists = MagicMock(return_value=True)
+
+        normal_relation = BigQueryRelation.create(
+            database="test-project",
+            schema="real_dataset",
+            identifier="my_table",
+        )
         info_schema_source = BigQueryRelation.create(
             database="test-project",
             schema="region-us.INFORMATION_SCHEMA",
@@ -1090,6 +1113,7 @@ class TestBigQueryCatalogRelationsByInfoSchema(BaseTestBigQueryAdapter):
         schemas_in_result = {info.schema for info in result.keys()}
         assert "real_dataset" in schemas_in_result
         assert "region-us.INFORMATION_SCHEMA" not in schemas_in_result
+        adapter.check_schema_exists.assert_called_once_with("test-project", "real_dataset")
 
 
 class TestBigQueryAdapterConversions(TestAdapterConversions):


### PR DESCRIPTION
resolves #2152

[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) N/A

### Problem

The catalog relation filtering introduced in #1940 calls the BigQuery REST
tables.list endpoint for every source schema to check whether the dataset
exists. Region-scoped INFORMATION_SCHEMA qualifiers such as
`region-eu.INFORMATION_SCHEMA` are query qualifiers, not physical datasets.

When the executing identity does not have BigLake namespace permissions, that
request is authorized as a BigLake namespace operation and raises a 403 for
`biglake.tables.list`. The exception aborts `dbt docs generate` before
`catalog.json` is written.

### Solution

Skip region-scoped INFORMATION_SCHEMA sources before the physical dataset
existence check. Real BigQuery datasets continue through `check_schema_exists`,
preserving the existing behavior for missing datasets and permission errors.

The test added in #1940 already included a region-scoped INFORMATION_SCHEMA
source, but its mock modeled `check_schema_exists` as returning `False`. In the
reported case, the real API raises a 403 before returning a boolean. The new
regression test therefore asserts that `check_schema_exists` is never called
for the regional qualifier, instead of depending on its return value.

This fix intentionally targets region-scoped INFORMATION_SCHEMA qualifiers.
Exceptions raised by `check_schema_exists` for physical datasets still abort
catalog generation because this pre-check runs before the per-schema futures
handled by `catch_as_completed`. Routing pre-check failures through that
exception collection is left as a follow-up to keep this change minimal.

### Testing

- `hatch run unit-tests` — 217 passed
- `hatch run code-quality` — all hooks passed

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
