### PR TITLE
fix(snowflake): resolve catalog-linked relation identifier casing

### DIFF
--- a/dbt-snowflake/.changes/unreleased/Fixes-20260826-101500.yaml
+++ b/dbt-snowflake/.changes/unreleased/Fixes-20260826-101500.yaml
@@ -1,0 +1,10 @@
+kind: Fixes
+body: Resolve relations in catalog-linked databases whose stored relation identifier
+  differs in case from the name dbt emits, on both `CASE_SENSITIVE` and
+  `CASE_INSENSITIVE` catalogs. Where two relations' identifiers differ only by case,
+  dbt now errors instead of silently binding to one of them. Regular Snowflake
+  databases and Snowflake-managed Iceberg are unaffected.
+time: 2026-08-26T10:15:00.000000-05:00
+custom:
+  Author: ppruett
+  Issue: "0"

--- a/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
@@ -228,6 +228,41 @@ class SnowflakeAdapter(SQLAdapter):
             return False
         return self._strip_quotes(database).upper() in self._catalog_linked_databases
 
+    def _make_match(self, relations_list, database, schema, identifier):
+        """Refuse to resolve a relation identifier that another relation matches apart from case.
+
+        When the catalog holds two relations whose identifiers differ only by case, neither is a safe
+        answer: the other is equally plausible as the model's target, so binding to either silently
+        can read or overwrite the wrong object. Stock dbt picks whichever one its folded name matches
+        and ignores the twin; here we stop instead. That costs a case which "works" today, and the
+        trade is deliberate -- silently operating on the wrong table is worse than stopping.
+
+        The cache cannot show the collision: it keys on lowercased names, so the pair collapsed to
+        one entry before arriving here. It is recorded during the schema listing, while the catalog's
+        own listing is still un-deduped.
+
+        Everything else defers to default matching, unchanged.
+        """
+        if not self._is_catalog_linked_database(database):
+            return super()._make_match(relations_list, database, schema, identifier)
+
+        if identifier is not None and self._has_case_variants(database, schema, identifier):
+            raise DbtRuntimeError(
+                f"Cannot resolve '{self._strip_quotes(str(identifier))}' in catalog-linked database "
+                f"'{self._strip_quotes(str(database))}': the catalog holds more than one relation "
+                "whose identifier differs only by case. dbt cannot tell which one you mean, and "
+                "choosing either could read or overwrite the wrong object. Rename or remove one of "
+                "them, or set an explicit `alias` and enable `quoting` for the identifier."
+            )
+
+        return super()._make_match(relations_list, database, schema, identifier)
+
+    def _has_case_variants(self, database, schema, identifier) -> bool:
+        def norm(value) -> str:
+            return self._strip_quotes(str(value)).casefold() if value is not None else ""
+
+        return (norm(database), norm(schema), norm(identifier)) in self._case_variant_relations
+
     def _make_match_kwargs(self, database, schema, identifier):
         # if any path part is already quoted then consider same casing but without quotes
         quoting = self.config.quoting

--- a/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
@@ -10,6 +10,7 @@ from typing import (
     Union,
     Dict,
     FrozenSet,
+    Set,
     Tuple,
 )
 
@@ -172,6 +173,11 @@ class SnowflakeAdapter(SQLAdapter):
 
     def __init__(self, config, mp_context) -> None:
         super().__init__(config, mp_context)
+        # Names of databases backed by an external catalog, collected as integrations register.
+        self._catalog_linked_databases: Set[str] = set()
+        # (database, schema, casefolded relation identifier) triples where the catalog holds two or
+        # more relations whose identifiers differ only by case. See _record_case_variant_relations.
+        self._case_variant_relations: Set[Tuple[str, str, str]] = set()
         self.add_catalog_integration(constants.DEFAULT_INFO_SCHEMA_CATALOG)
         self.add_catalog_integration(constants.DEFAULT_BUILT_IN_CATALOG)
 
@@ -195,7 +201,10 @@ class SnowflakeAdapter(SQLAdapter):
         # don't mutate the object that dbt-core passes in
         catalog_integration = deepcopy(catalog_integration)
         catalog_integration.name = catalog_integration.name.upper()
-        return super().add_catalog_integration(catalog_integration)
+        integration = super().add_catalog_integration(catalog_integration)
+        if linked_database := getattr(integration, "catalog_linked_database", None):
+            self._catalog_linked_databases.add(linked_database.upper())
+        return integration
 
     def get_catalog_integration(self, name: str) -> CatalogIntegration:
         # Snowflake uppercases everything in their metadata tables
@@ -213,6 +222,11 @@ class SnowflakeAdapter(SQLAdapter):
         # the column names to their lowercased forms.
         lowered = table.rename(column_names=[c.lower() for c in table.column_names])
         return super()._catalog_filter_table(lowered, used_schemas)
+
+    def _is_catalog_linked_database(self, database) -> bool:
+        if not database:
+            return False
+        return self._strip_quotes(database).upper() in self._catalog_linked_databases
 
     def _make_match_kwargs(self, database, schema, identifier):
         # if any path part is already quoted then consider same casing but without quotes
@@ -441,7 +455,38 @@ class SnowflakeAdapter(SQLAdapter):
             for obj in schema_functions.select(function_columns)
             if obj["is_builtin"] == "N"
         ]
-        return tabular_relations + function_relations
+        relations = tabular_relations + function_relations
+        self._record_case_variant_relations(schema_relation, relations)
+        return relations
+
+    def _record_case_variant_relations(self, schema_relation, relations) -> None:
+        """Note the case each relation identifier is stored under in a catalog-linked database.
+
+        This is the only place that information is visible: the relation cache keys on lowercased
+        names (see reference_keys._make_ref_key), so `t_orders` and `T_ORDERS` collapse into a single
+        cache entry and a later lookup can neither tell that two objects exist nor recover the case
+        of the one it has. Recording it here costs no extra query -- this list is already fetched
+        once per schema per run.
+
+        Recording only. Nothing reads either collection yet.
+        """
+        if not self._is_catalog_linked_database(schema_relation.database):
+            return
+        self.Relation.record_stored_case(relations)
+        seen: Dict[str, str] = {}
+        for relation in relations:
+            if relation.identifier is None:
+                continue
+            key = self._strip_quotes(str(relation.identifier)).casefold()
+            if key in seen and seen[key] != relation.identifier:
+                self._case_variant_relations.add(
+                    (
+                        self._strip_quotes(str(schema_relation.database)).casefold(),
+                        self._strip_quotes(str(schema_relation.schema)).casefold(),
+                        key,
+                    )
+                )
+            seen[key] = relation.identifier
 
     def _parse_list_relations_result(self, result: "agate.Row") -> SnowflakeRelation:
         database, schema, identifier, relation_type, is_dynamic, is_iceberg = result

--- a/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/impl.py
@@ -16,6 +16,7 @@ from typing import (
 
 from dbt.adapters.base.impl import AdapterConfig, ConstraintSupport
 from dbt.adapters.base.meta import available
+from dbt.adapters.base.relation import ApproximateMatchError
 from dbt.adapters.capability import CapabilityDict, CapabilitySupport, Support, Capability
 from dbt.adapters.catalogs import (
     CatalogIntegration,
@@ -25,7 +26,7 @@ from dbt.adapters.catalogs import (
 
 from dbt.adapters.contracts.relation import RelationConfig
 from dbt.adapters.sql import SQLAdapter
-from dbt.adapters.events.types import ColTypeChange
+from dbt.adapters.events.types import AdapterEventWarning, ColTypeChange
 from dbt.adapters.cache import _make_ref_key_dict
 from dbt.adapters.sql.impl import (
     LIST_SCHEMAS_MACRO_NAME,
@@ -41,7 +42,7 @@ from dbt_common.contracts.metadata import (
     ColumnMetadata,
 )
 from dbt_common.behavior_flags import BehaviorFlag
-from dbt_common.events.functions import fire_event
+from dbt_common.events.functions import fire_event, warn_or_error
 from dbt_common.exceptions import CompilationError, DbtDatabaseError, DbtRuntimeError
 from dbt_common.utils import filter_null_values
 
@@ -178,6 +179,8 @@ class SnowflakeAdapter(SQLAdapter):
         # (database, schema, casefolded relation identifier) triples where the catalog holds two or
         # more relations whose identifiers differ only by case. See _record_case_variant_relations.
         self._case_variant_relations: Set[Tuple[str, str, str]] = set()
+        # Relations already warned about, so the case-variant notice fires once each.
+        self._warned_case_variants: Set[str] = set()
         self.add_catalog_integration(constants.DEFAULT_INFO_SCHEMA_CATALOG)
         self.add_catalog_integration(constants.DEFAULT_BUILT_IN_CATALOG)
 
@@ -229,23 +232,27 @@ class SnowflakeAdapter(SQLAdapter):
         return self._strip_quotes(database).upper() in self._catalog_linked_databases
 
     def _make_match(self, relations_list, database, schema, identifier):
-        """Refuse to resolve a relation identifier that another relation matches apart from case.
+        """Resolve a relation in a catalog-linked database whose stored case differs from dbt's.
 
-        When the catalog holds two relations whose identifiers differ only by case, neither is a safe
-        answer: the other is equally plausible as the model's target, so binding to either silently
-        can read or overwrite the wrong object. Stock dbt picks whichever one its folded name matches
-        and ignores the twin; here we stop instead. That costs a case which "works" today, and the
-        trade is deliberate -- silently operating on the wrong table is worse than stopping.
+        An external catalog stores relation identifiers in its own case -- lowercase for Glue and
+        Unity, and lowercase for any catalog that normalizes. dbt folds its search to uppercase (each
+        part behind its own `quoting` flag, see _make_match_kwargs) and BaseRelation.matches()
+        compares byte-exact, so the lookup raises ApproximateMatchError. All three parts are
+        affected: a schema-only difference fails a lookup whose table name matches exactly.
 
-        The cache cannot show the collision: it keys on lowercased names, so the pair collapsed to
-        one entry before arriving here. It is recorded during the schema listing, while the catalog's
-        own listing is still un-deduped.
-
-        Everything else defers to default matching, unchanged.
+        Ambiguity is still settled first, before any matching is attempted -- see below. Otherwise
+        default matching runs first and its result is returned untouched, so anything that resolves
+        today keeps resolving identically. Only when default matching finds nothing and would have
+        raised do we fall back to comparing case-insensitively.
         """
         if not self._is_catalog_linked_database(database):
             return super()._make_match(relations_list, database, schema, identifier)
 
+        # When two relations' identifiers differ only by case, neither is a safe answer: the other is
+        # equally plausible as the model's target, so binding to either silently can read or overwrite
+        # the wrong object. The cache cannot show the collision -- it keys on lowercased names, so the
+        # pair collapsed to one entry before arriving here; it is recorded during the schema listing,
+        # while the catalog's own listing is still un-deduped.
         if identifier is not None and self._has_case_variants(database, schema, identifier):
             raise DbtRuntimeError(
                 f"Cannot resolve '{self._strip_quotes(str(identifier))}' in catalog-linked database "
@@ -255,7 +262,61 @@ class SnowflakeAdapter(SQLAdapter):
                 "them, or set an explicit `alias` and enable `quoting` for the identifier."
             )
 
-        return super()._make_match(relations_list, database, schema, identifier)
+        try:
+            exact = super()._make_match(relations_list, database, schema, identifier)
+        except ApproximateMatchError:
+            # A relation matches apart from case. Fall through and resolve it below rather than
+            # refusing: on a catalog-linked database that is the interop case dbt exists to serve.
+            exact = []
+        if exact:
+            return exact
+
+        matches = [
+            relation
+            for relation in relations_list
+            if self._matches_ignoring_case(relation, database, schema, identifier)
+        ]
+        for match in matches:
+            self._warn_case_variant_adopted(match, identifier)
+        return matches
+
+    def _warn_case_variant_adopted(self, relation, identifier) -> None:
+        """Note that dbt bound to a relation stored under a different case than it emits.
+
+        Stock dbt refuses this outright, so surface it once per relation: the object may have been
+        created by another engine, and dbt is now managing it.
+        """
+        key = str(relation)
+        if key in self._warned_case_variants:
+            return
+        self._warned_case_variants.add(key)
+        warn_or_error(
+            AdapterEventWarning(
+                base_msg=(
+                    f"dbt resolved '{self._strip_quotes(str(identifier))}' to {relation}, which is "
+                    "stored under a different case in the catalog-linked database. dbt will manage "
+                    "that object. If it is not meant to be managed by dbt, rename one of them or "
+                    "set an explicit `alias` on the model."
+                )
+            )
+        )
+
+    def _matches_ignoring_case(self, relation, database, schema, identifier) -> bool:
+        def part_matches(part, search) -> bool:
+            if search is None:
+                return True
+            if part is None:
+                return False
+            return (
+                self._strip_quotes(str(part)).casefold()
+                == self._strip_quotes(str(search)).casefold()
+            )
+
+        return (
+            part_matches(relation.database, database)
+            and part_matches(relation.schema, schema)
+            and part_matches(relation.identifier, identifier)
+        )
 
     def _has_case_variants(self, database, schema, identifier) -> bool:
         def norm(value) -> str:
@@ -503,7 +564,8 @@ class SnowflakeAdapter(SQLAdapter):
         of the one it has. Recording it here costs no extra query -- this list is already fetched
         once per schema per run.
 
-        Recording only. Nothing reads either collection yet.
+        Two consumers: SnowflakeRelation.create_from applies the stored case to relations built
+        from configuration, and _make_match refuses to resolve an identifier that collides by case.
         """
         if not self._is_catalog_linked_database(schema_relation.database):
             return

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
@@ -1,6 +1,6 @@
 import textwrap
 from dataclasses import dataclass, field
-from typing import FrozenSet, Optional, Type, Iterator, Tuple
+from typing import ClassVar, Dict, FrozenSet, Optional, Set, Type, Iterator, Tuple
 
 
 from dbt.adapters.base.relation import BaseRelation, EventTimeFilter
@@ -42,6 +42,15 @@ class SnowflakeRelation(BaseRelation):
     relation_configs = {
         SnowflakeRelationType.DynamicTable: SnowflakeDynamicTableConfig,
     }
+
+    # Stored relation-identifier casing for relations in catalog-linked databases, keyed by the
+    # casefolded (database, schema, relation identifier). Populated by SnowflakeAdapter as it lists
+    # a schema. Only catalog-linked databases are recorded, so membership doubles as the signal
+    # that a relation needs its stored case applied.
+    _stored_case: ClassVar[Dict[Tuple[str, str, str], Tuple[str, str]]] = {}
+    # Keys where the catalog holds two or more relations whose identifiers differ only by case, so
+    # no single stored form can be chosen.
+    _ambiguous_case: ClassVar[Set[Tuple[str, str, str]]] = set()
     renameable_relations: FrozenSet[SnowflakeRelationType] = field(
         default_factory=lambda: frozenset(
             {
@@ -81,6 +90,38 @@ class SnowflakeRelation(BaseRelation):
     @classproperty
     def get_relation_type(cls) -> Type[SnowflakeRelationType]:
         return SnowflakeRelationType
+
+    @classmethod
+    def _stored_case_key(cls, relation) -> Optional[Tuple[str, str, str]]:
+        parts = (relation.database, relation.schema, relation.identifier)
+        if any(part is None for part in parts):
+            return None
+        return tuple(str(part).strip('"').casefold() for part in parts)  # type: ignore[return-value]
+
+    @classmethod
+    def record_stored_case(cls, relations) -> None:
+        """Record the case each relation identifier is stored under, and which collide by case.
+
+        Called by the adapter while listing a catalog-linked schema, where the catalog's own listing
+        is still un-deduped -- the relation cache keys on lowercased names, so two relations whose
+        identifiers differ only by case collapse to one entry and become invisible later.
+
+        Both parts come from the listed relation itself, never from the schema that was searched for:
+        the search carries the case written in the project, while the listing carries the case the
+        catalog actually holds. Recording the searched schema would store a name that does not exist.
+        """
+        for relation in relations:
+            if relation.database is None or relation.schema is None or relation.identifier is None:
+                continue
+            key = (
+                str(relation.database).strip('"').casefold(),
+                str(relation.schema).strip('"').casefold(),
+                str(relation.identifier).strip('"').casefold(),
+            )
+            previous = cls._stored_case.get(key)
+            if previous is not None and previous[1] != relation.identifier:
+                cls._ambiguous_case.add(key)
+            cls._stored_case[key] = (relation.schema, relation.identifier)
 
     @classmethod
     def from_config(cls, config: RelationConfig) -> RelationConfigBase:

--- a/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
+++ b/dbt-snowflake/src/dbt/adapters/snowflake/relation.py
@@ -1,6 +1,6 @@
 import textwrap
 from dataclasses import dataclass, field
-from typing import ClassVar, Dict, FrozenSet, Optional, Set, Type, Iterator, Tuple
+from typing import ClassVar, Dict, FrozenSet, Iterator, Optional, Set, Tuple, Type
 
 
 from dbt.adapters.base.relation import BaseRelation, EventTimeFilter
@@ -45,11 +45,11 @@ class SnowflakeRelation(BaseRelation):
 
     # Stored relation-identifier casing for relations in catalog-linked databases, keyed by the
     # casefolded (database, schema, relation identifier). Populated by SnowflakeAdapter as it lists
-    # a schema. Only catalog-linked databases are recorded, so membership doubles as the signal
-    # that a relation needs its stored case applied.
+    # a schema; read by create_from below. Only catalog-linked databases are recorded, so membership
+    # doubles as the signal that a relation needs its stored case applied.
     _stored_case: ClassVar[Dict[Tuple[str, str, str], Tuple[str, str]]] = {}
     # Keys where the catalog holds two or more relations whose identifiers differ only by case, so
-    # no single stored form can be chosen.
+    # no single stored form can be chosen. Left alone here; the adapter's relation lookup raises.
     _ambiguous_case: ClassVar[Set[Tuple[str, str, str]]] = set()
     renameable_relations: FrozenSet[SnowflakeRelationType] = field(
         default_factory=lambda: frozenset(
@@ -90,6 +90,37 @@ class SnowflakeRelation(BaseRelation):
     @classproperty
     def get_relation_type(cls) -> Type[SnowflakeRelationType]:
         return SnowflakeRelationType
+
+    @classmethod
+    def create_from(cls, quoting, relation_config, **kwargs) -> "SnowflakeRelation":
+        """Build a relation, applying the stored relation-identifier case for catalog-linked databases.
+
+        A catalog-linked database stores relation identifiers in the external catalog's case.
+        Relations built from configuration -- `this`, `ref()`, `source()` -- carry the name as written
+        in the project and render it unquoted, so Snowflake folds it. When the stored name is not
+        that folded form the reference fails with 002003, which surfaces inside the model's own SQL
+        (an `is_incremental()` filter selecting from `{{ this }}`) before any DML is generated.
+
+        Substituting the stored name and quoting it makes the reference resolve exactly. Quoting is
+        the operative part: the stored name often matches the configured name character for
+        character (both `t_orders`) and still fails, because unquoted `t_orders` folds to `T_ORDERS`.
+
+        Applies only where the stored case is known, which is only ever recorded for catalog-linked
+        databases and only once a schema has been listed. Before that -- at parse time, and on a
+        first run when the relation does not exist -- the relation is returned unchanged, so nothing
+        about creation changes.
+        """
+        relation = super().create_from(quoting, relation_config, **kwargs)
+        key = cls._stored_case_key(relation)
+        if key is None or key in cls._ambiguous_case:
+            return relation
+        stored = cls._stored_case.get(key)
+        if stored is None:
+            return relation
+        schema, identifier = stored
+        return relation.incorporate(path={"schema": schema, "identifier": identifier}).quote(
+            schema=True, identifier=True
+        )
 
     @classmethod
     def _stored_case_key(cls, relation) -> Optional[Tuple[str, str, str]]:

--- a/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/incremental.sql
+++ b/dbt-snowflake/src/dbt/include/snowflake/macros/materializations/incremental.sql
@@ -123,6 +123,18 @@
 
   {% set existing_relation = load_relation(this) %}
 
+  {#-- An external catalog stores identifiers in its own case. dbt renders the target unquoted, so
+       Snowflake folds it, and the resulting name may not be the one the catalog actually holds --
+       giving 002003 even though the relation was found. Write to the case that exists, quoted so it
+       resolves exactly. Only for catalog-linked databases, and only once the relation exists: first
+       runs still create at dbt's own folded name, so nothing about creation changes. --#}
+  {%- if is_catalog_linked_db and existing_relation is not none -%}
+    {%- set target_relation = target_relation.incorporate(path={
+          "schema": existing_relation.schema,
+          "identifier": existing_relation.identifier,
+        }).quote(schema=True, identifier=True) -%}
+  {%- endif -%}
+
   {#-- The temp relation will be a view (faster) or temp table, depending on upsert/merge strategy --#}
   {%- set unique_key = config.get('unique_key') -%}
   {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}

--- a/dbt-snowflake/tests/unit/test_make_match_catalog_linked.py
+++ b/dbt-snowflake/tests/unit/test_make_match_catalog_linked.py
@@ -106,12 +106,25 @@ def test_variants_recorded_for_a_different_identifier_do_not_block(adapter):
     assert adapter._make_match(relations, LINKED_DB, "SCHEMA_A", "T_ORDERS") == relations
 
 
-def test_unambiguous_case_mismatch_still_raises_at_this_commit(adapter):
-    """Resolving these is the next commit's job; here it must still behave as stock does."""
+def test_resolves_identifier_differing_only_by_case(adapter):
     relations = [relation(LINKED_DB, "SCHEMA_A", "t_orders")]
 
+    assert adapter._make_match(relations, LINKED_DB, "SCHEMA_A", "T_ORDERS") == relations
+
+
+def test_resolves_schema_differing_only_by_case(adapter):
+    """A-08: the schema alone can be the driver, with the relation identifier matching exactly."""
+    relations = [relation(LINKED_DB, "schema_a", "T_ORDERS")]
+
+    assert adapter._make_match(relations, LINKED_DB, "SCHEMA_A", "T_ORDERS") == relations
+
+
+def test_non_linked_database_still_raises_on_a_case_mismatch(adapter):
+    """The contrast with the two tests above: off a catalog-linked database, stock behavior holds."""
+    relations = [relation("OTHER", "SCHEMA_A", "t_orders")]
+
     with pytest.raises(ApproximateMatchError):
-        adapter._make_match(relations, LINKED_DB, "SCHEMA_A", "T_ORDERS")
+        adapter._make_match(relations, "OTHER", "SCHEMA_A", "T_ORDERS")
 
 
 def test_no_match_returns_empty_rather_than_raising(adapter):

--- a/dbt-snowflake/tests/unit/test_make_match_catalog_linked.py
+++ b/dbt-snowflake/tests/unit/test_make_match_catalog_linked.py
@@ -1,0 +1,120 @@
+from multiprocessing import get_context
+
+import pytest
+from dbt_common.exceptions import DbtRuntimeError
+
+from dbt.adapters.base.relation import ApproximateMatchError
+from dbt.adapters.snowflake import SnowflakeAdapter
+from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+from .utils import config_from_parts_or_dicts
+
+LINKED_DB = "CLD"
+
+
+@pytest.fixture
+def adapter():
+    profile_cfg = {
+        "outputs": {
+            "test": {
+                "type": "snowflake",
+                "account": "test_account",
+                "user": "test_user",
+                "database": "test_database",
+                "warehouse": "test_warehouse",
+                "schema": "public",
+            },
+        },
+        "target": "test",
+    }
+    project_cfg = {
+        "name": "X",
+        "version": "0.1",
+        "profile": "test",
+        "project-root": "/tmp/dbt/does-not-exist",
+        "quoting": {"identifier": False, "schema": False, "database": False},
+        "config-version": 2,
+    }
+    config = config_from_parts_or_dicts(project_cfg, profile_cfg)
+    adapter = SnowflakeAdapter(config, get_context("spawn"))
+    adapter._catalog_linked_databases.add(LINKED_DB)
+    return adapter
+
+
+def relation(database, schema, identifier):
+    return SnowflakeRelation.create(
+        database=database,
+        schema=schema,
+        identifier=identifier,
+        quote_policy={"database": True, "schema": True, "identifier": True},
+    )
+
+
+def record_variants(adapter, database, schema, identifier):
+    adapter._case_variant_relations.add(
+        (database.casefold(), schema.casefold(), identifier.casefold())
+    )
+
+
+def test_non_linked_database_is_untouched(adapter):
+    """The gate: a database not backed by an external catalog keeps stock behavior exactly."""
+    relations = [relation("OTHER", "SCHEMA_A", "T_ORDERS")]
+    record_variants(adapter, "OTHER", "SCHEMA_A", "T_ORDERS")
+
+    assert adapter._make_match(relations, "OTHER", "SCHEMA_A", "T_ORDERS") == relations
+
+
+def test_raises_on_case_variants_even_when_one_matches_exactly(adapter):
+    """A-05. Stock dbt binds to the folded name and ignores its twin; we refuse instead.
+
+    The exact match is not a safe answer: the twin is equally plausible as the model's target,
+    so choosing either could read or overwrite the wrong object.
+    """
+    relations = [
+        relation(LINKED_DB, "SCHEMA_A", "T_ORDERS"),
+        relation(LINKED_DB, "SCHEMA_A", "t_orders"),
+    ]
+    record_variants(adapter, LINKED_DB, "SCHEMA_A", "T_ORDERS")
+
+    with pytest.raises(DbtRuntimeError, match="differs only by case"):
+        adapter._make_match(relations, LINKED_DB, "SCHEMA_A", "T_ORDERS")
+
+
+def test_raises_before_matching_is_attempted(adapter):
+    """The refusal precedes the match, so it fires even when nothing matches exactly."""
+    relations = [
+        relation(LINKED_DB, "SCHEMA_A", "Orders"),
+        relation(LINKED_DB, "SCHEMA_A", "orders"),
+    ]
+    record_variants(adapter, LINKED_DB, "SCHEMA_A", "ORDERS")
+
+    with pytest.raises(DbtRuntimeError, match="differs only by case"):
+        adapter._make_match(relations, LINKED_DB, "SCHEMA_A", "ORDERS")
+
+
+def test_exact_match_still_wins_when_unambiguous(adapter):
+    exact = relation(LINKED_DB, "SCHEMA_A", "T_ORDERS")
+    other = relation(LINKED_DB, "SCHEMA_A", "T_OTHER")
+
+    assert adapter._make_match([exact, other], LINKED_DB, "SCHEMA_A", "T_ORDERS") == [exact]
+
+
+def test_variants_recorded_for_a_different_identifier_do_not_block(adapter):
+    relations = [relation(LINKED_DB, "SCHEMA_A", "T_ORDERS")]
+    record_variants(adapter, LINKED_DB, "SCHEMA_A", "T_CUSTOMERS")
+
+    assert adapter._make_match(relations, LINKED_DB, "SCHEMA_A", "T_ORDERS") == relations
+
+
+def test_unambiguous_case_mismatch_still_raises_at_this_commit(adapter):
+    """Resolving these is the next commit's job; here it must still behave as stock does."""
+    relations = [relation(LINKED_DB, "SCHEMA_A", "t_orders")]
+
+    with pytest.raises(ApproximateMatchError):
+        adapter._make_match(relations, LINKED_DB, "SCHEMA_A", "T_ORDERS")
+
+
+def test_no_match_returns_empty_rather_than_raising(adapter):
+    relations = [relation(LINKED_DB, "SCHEMA_A", "T_ORDERS")]
+
+    assert adapter._make_match(relations, LINKED_DB, "SCHEMA_A", "T_MISSING") == []

--- a/dbt-snowflake/tests/unit/test_relation_stored_case.py
+++ b/dbt-snowflake/tests/unit/test_relation_stored_case.py
@@ -1,0 +1,83 @@
+import pytest
+
+from dbt.adapters.snowflake.relation import SnowflakeRelation
+
+
+@pytest.fixture(autouse=True)
+def clear_stored_case():
+    """The stored-case map is class-level state, so each test starts and ends empty."""
+    SnowflakeRelation._stored_case.clear()
+    SnowflakeRelation._ambiguous_case.clear()
+    yield
+    SnowflakeRelation._stored_case.clear()
+    SnowflakeRelation._ambiguous_case.clear()
+
+
+def listed(database, schema, identifier):
+    """A relation as list_relations_without_caching returns it: names in their stored case."""
+    return SnowflakeRelation.create(
+        database=database,
+        schema=schema,
+        identifier=identifier,
+        quote_policy={"database": True, "schema": True, "identifier": True},
+    )
+
+
+def test_records_the_stored_case_of_each_relation_identifier():
+    SnowflakeRelation.record_stored_case([listed("db", "MY_SCHEMA", "My_Table")])
+
+    assert SnowflakeRelation._stored_case == {
+        ("db", "my_schema", "my_table"): ("MY_SCHEMA", "My_Table")
+    }
+
+
+def test_records_the_schema_from_the_listed_relation():
+    """The searched schema carries the project's case; only the listing knows the stored case.
+
+    Recording the searched schema would store a name that does not exist on a case-sensitive catalog.
+    """
+    SnowflakeRelation.record_stored_case([listed("db", "PPRUETT_PROBE", "T_ORDERS")])
+
+    ((stored_schema, _),) = SnowflakeRelation._stored_case.values()
+    assert stored_schema == "PPRUETT_PROBE"
+
+
+def test_key_is_casefolded_in_every_part():
+    SnowflakeRelation.record_stored_case([listed("DB", "SCHEMA_A", "Table_A")])
+
+    assert ("db", "schema_a", "table_a") in SnowflakeRelation._stored_case
+
+
+def test_flags_identifiers_that_differ_only_by_case():
+    SnowflakeRelation.record_stored_case(
+        [listed("db", "my_schema", "my_table"), listed("db", "my_schema", "MY_TABLE")]
+    )
+
+    assert SnowflakeRelation._ambiguous_case == {("db", "my_schema", "my_table")}
+
+
+def test_does_not_flag_repeats_of_one_identifier():
+    """Listing the same relation twice is not a case collision."""
+    SnowflakeRelation.record_stored_case(
+        [listed("db", "my_schema", "MyTable"), listed("db", "my_schema", "MyTable")]
+    )
+
+    assert SnowflakeRelation._ambiguous_case == set()
+
+
+def test_skips_relations_missing_a_part():
+    schema_only = SnowflakeRelation.create(database="db", schema="my_schema")
+
+    SnowflakeRelation.record_stored_case([schema_only])
+
+    assert SnowflakeRelation._stored_case == {}
+
+
+def test_stored_case_key_is_none_when_a_part_is_missing():
+    assert SnowflakeRelation._stored_case_key(SnowflakeRelation.create(database="db")) is None
+
+
+def test_stored_case_key_strips_quotes():
+    relation = listed('"db"', '"my_schema"', '"my_table"')
+
+    assert SnowflakeRelation._stored_case_key(relation) == ("db", "my_schema", "my_table")

--- a/dbt-snowflake/tests/unit/test_relation_stored_case.py
+++ b/dbt-snowflake/tests/unit/test_relation_stored_case.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from dbt.adapters.snowflake.relation import SnowflakeRelation
@@ -21,6 +23,21 @@ def listed(database, schema, identifier):
         identifier=identifier,
         quote_policy={"database": True, "schema": True, "identifier": True},
     )
+
+
+def configured(database, schema, identifier, quoting=None):
+    """A relation built from project config, the way `this` / `ref()` / `source()` are."""
+    relation_config = SimpleNamespace(
+        database=database,
+        schema=schema,
+        identifier=identifier,
+        quoting_dict={},
+        config={},
+    )
+    has_quoting = SimpleNamespace(
+        quoting=quoting or {"database": False, "schema": False, "identifier": False}
+    )
+    return SnowflakeRelation.create_from(has_quoting, relation_config)
 
 
 def test_records_the_stored_case_of_each_relation_identifier():
@@ -81,3 +98,56 @@ def test_stored_case_key_strips_quotes():
     relation = listed('"db"', '"my_schema"', '"my_table"')
 
     assert SnowflakeRelation._stored_case_key(relation) == ("db", "my_schema", "my_table")
+
+
+def test_create_from_is_unchanged_when_nothing_recorded():
+    """Nothing recorded means not a catalog-linked database, so the relation is untouched."""
+    relation = configured("db", "my_schema", "my_table")
+
+    assert relation.schema == "my_schema"
+    assert relation.identifier == "my_table"
+    assert relation.quote_policy.schema is False
+    assert relation.quote_policy.identifier is False
+
+
+def test_create_from_applies_the_stored_case_and_quotes():
+    SnowflakeRelation.record_stored_case([listed("db", "MY_SCHEMA", "My_Table")])
+
+    relation = configured("db", "my_schema", "my_table")
+
+    assert relation.schema == "MY_SCHEMA"
+    assert relation.identifier == "My_Table"
+    assert relation.quote_policy.schema is True
+    assert relation.quote_policy.identifier is True
+
+
+def test_create_from_quotes_even_when_the_case_already_matches():
+    """Quoting is the operative part: unquoted `my_table` folds to MY_TABLE and misses."""
+    SnowflakeRelation.record_stored_case([listed("db", "my_schema", "my_table")])
+
+    relation = configured("db", "my_schema", "my_table")
+
+    assert relation.identifier == "my_table"
+    assert relation.quote_policy.identifier is True
+    assert relation.render() == 'db."my_schema"."my_table"'
+
+
+def test_create_from_leaves_ambiguous_identifiers_alone():
+    """No single stored form can be chosen; the adapter's lookup raises on these instead."""
+    SnowflakeRelation.record_stored_case(
+        [listed("db", "my_schema", "my_table"), listed("db", "my_schema", "MY_TABLE")]
+    )
+
+    relation = configured("db", "my_schema", "my_table")
+
+    assert relation.identifier == "my_table"
+    assert relation.quote_policy.identifier is False
+
+
+def test_create_from_ignores_relations_that_were_not_recorded():
+    SnowflakeRelation.record_stored_case([listed("db", "MY_SCHEMA", "Recorded")])
+
+    relation = configured("db", "MY_SCHEMA", "not_recorded")
+
+    assert relation.identifier == "not_recorded"
+    assert relation.quote_policy.identifier is False


### PR DESCRIPTION
## Summary

- recognize Snowflake catalog-linked databases and retain catalog-stored relation casing
- refuse ambiguous case-only relation matches before DML
- apply the stored identity to relation lookup, `this`/`ref`/`source`, and incremental targets

This is intentionally scoped to relation identity (database/schema/table), not column-identifier casing.

## Validation

- unit coverage for catalog-linked matching and stored-case relation creation
- functional, lifecycle, concurrency, and cache-mode coverage is still needed

## Review status

Draft: the current implementation has correctness findings that need resolution before merge; they will be attached as review comments.