### PR TITLE
fix(redshift): create introspection shortcut for datashare consumer temp relations

### DIFF
--- a/dbt-redshift/.changes/unreleased/Fixes-20260903-150000.yaml
+++ b/dbt-redshift/.changes/unreleased/Fixes-20260903-150000.yaml
@@ -3,7 +3,7 @@ body: With `datasharing` enabled, describe an incremental model's temporary rela
     the driver directly instead of trying the catalog first. The catalog lookups cannot see
     a temporary relation on a datashare consumer database, so they cost roughly 90 seconds
     per temporary relation to return nothing -- one of them expands every late-binding view
-    in the session
+    in the session.
 time: 2026-09-03T15:00:00.000000-05:00
 custom:
     Author: trouze

--- a/dbt-redshift/.changes/unreleased/Fixes-20260903-150000.yaml
+++ b/dbt-redshift/.changes/unreleased/Fixes-20260903-150000.yaml
@@ -1,0 +1,10 @@
+kind: Fixes
+body: With `datasharing` enabled, describe an incremental model's temporary relation from
+    the driver directly instead of trying the catalog first. The catalog lookups cannot see
+    a temporary relation on a datashare consumer database, so they cost roughly 90 seconds
+    per temporary relation to return nothing -- one of them expands every late-binding view
+    in the session
+time: 2026-09-03T15:00:00.000000-05:00
+custom:
+    Author: trouze
+    Issue: "2156"

--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -249,9 +249,34 @@ class RedshiftAdapter(SQLAdapter):
         target. Only unqualified relations can take the fallback, since the driver query
         has no database or schema to qualify itself with.
 
+        With ``datasharing`` enabled, a relation dbt minted as a temporary table
+        (``is_temporary``, set by ``redshift__make_temp_relation``) skips the catalog
+        entirely. The catalog queries cost ~90s per temp relation on a datashare consumer
+        and cannot return rows there: neither ``information_schema.columns`` nor
+        ``pg_get_late_binding_view_cols()`` -- which the legacy path calls, expanding every
+        late-binding view in the session -- can see a temp table, and a temp table is never
+        a late-binding view anyway. The driver answers the same question in ~50ms.
+
+        The marker is deliberately gated on ``datasharing`` rather than applied to every
+        connection. Without it the catalog can see temp relations, so the first query
+        returns and the expensive late-binding lookup is never reached -- there is little to
+        win, and the driver path would be describing columns the catalog already describes
+        correctly. Its type names are ground truth for the OIDs it maps, but an unmapped OID
+        falls back to the driver's own label (see ``_temp_relation_data_type``), which is
+        worth risking only where the alternative is no columns at all.
+
+        Relations that are merely unqualified keep the existing behavior on both kinds of
+        connection: describe from the catalog, fall back to the driver only if that comes
+        back empty. That is what still covers a consumer database reached without
+        ``datasharing`` set.
+
         In an override rather than in the macro so that ``@supports_replay`` records the
-        fallback under the existing ``AdapterGetColumnsInRelationRecord``.
+        fallback under the existing ``AdapterGetColumnsInRelationRecord``, and because
+        ``get_columns_in_temp_relation`` is not ``@available`` to Jinja.
         """
+        if getattr(relation, "is_temporary", False) and self.use_show_apis():
+            return self.get_columns_in_temp_relation(relation)
+
         columns = super().get_columns_in_relation(relation)
 
         if not columns and not relation.database and not relation.schema:

--- a/dbt-redshift/src/dbt/adapters/redshift/impl.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/impl.py
@@ -270,19 +270,42 @@ class RedshiftAdapter(SQLAdapter):
         back empty. That is what still covers a consumer database reached without
         ``datasharing`` set.
 
+        Both routes require the relation to be unqualified, marker or not -- see
+        ``_is_addressable_unqualified``. Every producer of a marked relation strips schema
+        and database today, so the check never fires; it is here because the driver query
+        cannot express a qualification, so a marked-but-qualified relation would silently
+        describe whatever ``search_path`` resolved the identifier to.
+
         In an override rather than in the macro so that ``@supports_replay`` records the
         fallback under the existing ``AdapterGetColumnsInRelationRecord``, and because
         ``get_columns_in_temp_relation`` is not ``@available`` to Jinja.
         """
-        if getattr(relation, "is_temporary", False) and self.use_show_apis():
+        if (
+            getattr(relation, "is_temporary", False)
+            and self.use_show_apis()
+            and self._is_addressable_unqualified(relation)
+        ):
             return self.get_columns_in_temp_relation(relation)
 
         columns = super().get_columns_in_relation(relation)
 
-        if not columns and not relation.database and not relation.schema:
+        if not columns and self._is_addressable_unqualified(relation):
             return self.get_columns_in_temp_relation(relation)
 
         return columns
+
+    @staticmethod
+    def _is_addressable_unqualified(relation: BaseRelation) -> bool:
+        """Whether ``get_columns_in_temp_relation`` can address this relation at all.
+
+        It queries ``select * from <identifier>`` with no database or schema, so a
+        qualified relation would resolve through ``search_path`` to whatever object
+        happens to share the identifier -- describing the wrong thing rather than
+        failing. Both routes to the driver check this: ``is_temporary`` records that dbt
+        minted the relation, which is not the same claim as it still being addressable
+        unqualified.
+        """
+        return not relation.database and not relation.schema
 
     def get_columns_in_temp_relation(self, relation: BaseRelation) -> List[BaseColumn]:
         """Describe a temporary relation from the driver instead of the catalog.

--- a/dbt-redshift/src/dbt/adapters/redshift/relation.py
+++ b/dbt-redshift/src/dbt/adapters/redshift/relation.py
@@ -47,6 +47,17 @@ class RedshiftRelation(BaseRelation):
         )
     )
 
+    # Marks a relation dbt itself minted as a temporary table; set by
+    # redshift__make_temp_relation. There is no temp-flavored RelationType and no
+    # is_temporary on BaseRelation, so the flag has to live here. It lets
+    # RedshiftAdapter.get_columns_in_relation go straight to the driver instead of
+    # spending two slow catalog queries proving that the catalog cannot see the
+    # relation -- on a datashare consumer database it never can.
+    #
+    # A declared dataclass field survives incorporate() (to_dict(omit_none=True) ->
+    # deep_merge -> from_dict), and False is not None, so omit_none does not drop it.
+    is_temporary: bool = False
+
     def __post_init__(self):
         # Check for length of Redshift table/view names.
         # Check self.type to exclude test relation identifiers

--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
@@ -123,9 +123,29 @@
 {% endmacro %}
 
 
+{% macro redshift__make_temp_relation(base_relation, suffix) %}
+  {#
+    Same relation postgres__make_temp_relation builds -- fully unqualified, with both
+    schema and database stripped to none -- but flagged as one dbt minted itself, so
+    RedshiftAdapter.get_columns_in_relation can describe it from the driver directly when
+    `datasharing` is enabled. Without the flag we could only infer "temporary" from the
+    absence of a database and schema, which is a negative signal shared with any other
+    unqualified caller.
+
+    The flag is set unconditionally; whether it is acted on is decided in Python, so the
+    marker stays a plain statement of what the relation is.
+  #}
+  {% set temp_relation = postgres__make_temp_relation(base_relation, suffix) %}
+  {{ return(temp_relation.incorporate(is_temporary=True)) }}
+{% endmacro %}
+
+
 {% macro redshift__get_columns_in_relation(relation) -%}
-  {# relation from temp tables does not have a database or schema. #}
-  {# use legacy pattern until SHOW COLUMNS supports temp tables #}
+  {# With `datasharing` enabled, relations dbt minted as temp tables do not reach here: #}
+  {# RedshiftAdapter.get_columns_in_relation recognises their is_temporary marker and #}
+  {# describes them from the driver instead, because no catalog view on a datashare consumer #}
+  {# can see them. Everything else -- including temp relations on an ordinary connection, #}
+  {# where information_schema can see them -- comes through the branches below. #}
 
   {% if not relation.database and not relation.schema %}
     {{ return(redshift__get_columns_in_relation_unqualified(relation)) }}
@@ -138,9 +158,9 @@
 
 
 {% macro redshift__get_columns_in_relation_unqualified(relation) -%}
-  {# An unqualified relation is a temp table, which can never be a late-binding or #}
-  {# external view, so skip pg_get_late_binding_view_cols() -- it expands every #}
-  {# late-binding view in the session and dominates the legacy query's runtime. #}
+  {# An unqualified relation is most likely a temp table, which can never be a late-binding #}
+  {# or external view, so try without pg_get_late_binding_view_cols() first -- it expands #}
+  {# every late-binding view in the session and dominates the legacy query's runtime. #}
   {# Fall back to the legacy query if nothing matches, for any other caller. #}
   {% call statement('get_columns_in_relation', fetch_result=True) %}
       select

--- a/dbt-redshift/tests/functional/adapter/incremental/test_temp_relation_introspection.py
+++ b/dbt-redshift/tests/functional/adapter/incremental/test_temp_relation_introspection.py
@@ -1,0 +1,139 @@
+"""
+How an incremental run describes its temp relation, in each datasharing mode.
+
+redshift__make_temp_relation marks the relation is_temporary, and with `datasharing`
+enabled RedshiftAdapter.get_columns_in_relation routes marked relations straight to the
+driver. Before that, introspecting a temp relation ran information_schema."columns" and
+then, when that came back empty, the legacy query -- whose unbound_views CTE calls
+pg_get_late_binding_view_cols(), expanding every late-binding view in the session
+(dbt-labs/dbt-adapters#2156). Measured on a datashare consumer, where neither query can ever
+match a temp relation:
+
+    information_schema."columns"             46.993s  -> 0 rows
+    legacy w/ pg_get_late_binding_view_cols  44.596s  -> 0 rows
+    select * from <tmp> limit 0               0.071s  -> the actual answer
+
+With datasharing off the catalog can see temp relations, so information_schema answers on
+the first query and the late-binding lookup is never reached. The marker is deliberately
+not acted on there, and the test below pins that down: this change is meant to be confined
+to datashare consumers, and a future refactor that quietly extended the driver path to
+every connection should fail here rather than in someone's warehouse.
+
+These tests do not need a datashare consumer database -- they assert which queries dbt
+issues, which is decided by the `datasharing` config alone. The correctness tests that do
+need one live in tests/functional/adapter/datashare_consumer/.
+"""
+
+import re
+
+from dbt.tests.util import run_dbt, run_dbt_and_capture
+import pytest
+
+_MODEL = """
+{{
+    config(
+        materialized='incremental',
+        unique_key='id',
+        on_schema_change='sync_all_columns'
+    )
+}}
+
+with source_data as (
+    select 1 as id, 'aaa'::varchar(50) as field_1, 2.5::numeric(18,2) as field_2
+    union all select 2 as id, 'bbb'::varchar(50) as field_1, 3.5::numeric(18,2) as field_2
+)
+
+select * from source_data
+
+{% if is_incremental() %}
+where id not in (select id from {{ this }})
+{% endif %}
+"""
+
+_TEMP_IDENTIFIER = re.compile(r"create temporary table\s+\"?(\w*__dbt_tmp\d+)\"?", re.IGNORECASE)
+
+
+class _TempRelationIntrospection:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"incremental_temp_introspection.sql": _MODEL}
+
+    def _incremental_run(self, project):
+        """Build the model, then run it again so it takes the incremental path.
+
+        Returns the debug logs of the second run and the temp relation's identifier, so
+        assertions can be scoped to the temp relation. The target relation is still
+        described from the catalog in the same run, so asserting on query text alone would
+        either pass trivially or fail spuriously.
+        """
+        run_dbt(["run", "--select", "incremental_temp_introspection"])
+        results, logs = run_dbt_and_capture(
+            ["--debug", "run", "--select", "incremental_temp_introspection"]
+        )
+        assert len(results) == 1
+
+        match = _TEMP_IDENTIFIER.search(logs)
+        assert match, "expected the incremental run to create a temp relation"
+        return logs, match.group(1)
+
+    def _lines_mentioning(self, logs, temp_identifier):
+        return [line for line in logs.splitlines() if temp_identifier in line]
+
+    def test_column_types_agree_with_the_target_across_runs(self, project):
+        """Whatever describes the source, it has to name types the way the target's describer does.
+
+        Otherwise a disagreement reads as a type change and dbt rewrites the column on every
+        run. varchar and numeric are here specifically because their reported type carries a
+        size. This has to hold in both modes, so it lives on the shared base.
+        """
+        run_dbt(["run", "--select", "incremental_temp_introspection"])
+
+        for _ in range(2):
+            _, logs = run_dbt_and_capture(
+                ["--debug", "run", "--select", "incremental_temp_introspection"]
+            )
+            assert "Data types changed: []" in logs
+
+
+class TestTempRelationIntrospectionWithDatasharing(_TempRelationIntrospection):
+    """Datasharing on: the temp relation is described from the driver, catalog untouched."""
+
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target, unique_schema):
+        return {
+            "test": {
+                "outputs": {
+                    "default": {**dbt_profile_target, "schema": unique_schema, "datasharing": True}
+                },
+                "target": "default",
+            }
+        }
+
+    def test_temp_relation_is_described_from_the_driver(self, project):
+        logs, temp_identifier = self._incremental_run(project)
+
+        # The driver probe: cheap, and the only thing that can answer for a temp relation on
+        # a datashare consumer.
+        assert f'select * from "{temp_identifier}" limit 0' in logs
+
+        # The queries the marker exists to skip.
+        for line in self._lines_mentioning(logs, temp_identifier):
+            assert "pg_get_late_binding_view_cols" not in line
+            assert 'from information_schema."columns"' not in line
+            assert "svv_columns" not in line
+            assert "SHOW COLUMNS" not in line
+
+
+class TestTempRelationIntrospectionWithoutDatasharing(_TempRelationIntrospection):
+    """Datasharing off: unchanged behavior -- information_schema still describes the temp relation."""
+
+    def test_temp_relation_is_described_from_information_schema(self, project):
+        logs, temp_identifier = self._incremental_run(project)
+
+        lines = self._lines_mentioning(logs, temp_identifier)
+        assert any('from information_schema."columns"' in line for line in lines)
+
+        # information_schema answers on the first query, so the expensive lookup that
+        # motivated this change is still never reached here either.
+        for line in lines:
+            assert "pg_get_late_binding_view_cols" not in line

--- a/dbt-redshift/tests/functional/adapter/incremental/test_temp_relation_introspection.py
+++ b/dbt-redshift/tests/functional/adapter/incremental/test_temp_relation_introspection.py
@@ -52,6 +52,22 @@ where id not in (select id from {{ this }})
 
 _TEMP_IDENTIFIER = re.compile(r"create temporary table\s+\"?(\w*__dbt_tmp\d+)\"?", re.IGNORECASE)
 
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_ENTRY_START = re.compile(r"^\d{2}:\d{2}:\d{2}  ", re.MULTILINE)
+
+
+def _log_entries(logs):
+    """Split debug logs into entries, each starting with a timestamp.
+
+    A SQL statement is logged as a single entry spanning several physical lines, so
+    filtering the logs line by line cannot work here: the table a query reads and the
+    identifier it filters on land on different lines. Asserting that no line contains
+    both would pass no matter what dbt ran.
+    """
+    plain = _ANSI.sub("", logs)
+    starts = [match.start() for match in _ENTRY_START.finditer(plain)]
+    return [plain[start:end] for start, end in zip(starts, starts[1:] + [len(plain)])]
+
 
 class _TempRelationIntrospection:
     @pytest.fixture(scope="class")
@@ -76,8 +92,8 @@ class _TempRelationIntrospection:
         assert match, "expected the incremental run to create a temp relation"
         return logs, match.group(1)
 
-    def _lines_mentioning(self, logs, temp_identifier):
-        return [line for line in logs.splitlines() if temp_identifier in line]
+    def _entries_mentioning(self, logs, temp_identifier):
+        return [entry for entry in _log_entries(logs) if temp_identifier in entry]
 
     def test_column_types_agree_with_the_target_across_runs(self, project):
         """Whatever describes the source, it has to name types the way the target's describer does.
@@ -85,6 +101,11 @@ class _TempRelationIntrospection:
         Otherwise a disagreement reads as a type change and dbt rewrites the column on every
         run. varchar and numeric are here specifically because their reported type carries a
         size. This has to hold in both modes, so it lives on the shared base.
+
+        Asserted on check_for_schema_changes' message, which every run logs. The one from
+        sync_column_schemas ("Data types changed: ...") is not usable here: it is only
+        reached when schema_changed is true, so on a healthy run it is absent -- an
+        assertion that it reads `[]` fails exactly when the code is behaving.
         """
         run_dbt(["run", "--select", "incremental_temp_introspection"])
 
@@ -92,7 +113,8 @@ class _TempRelationIntrospection:
             _, logs = run_dbt_and_capture(
                 ["--debug", "run", "--select", "incremental_temp_introspection"]
             )
-            assert "Data types changed: []" in logs
+            assert "Schema changed: False" in logs
+            assert "New column types: []" in logs
 
 
 class TestTempRelationIntrospectionWithDatasharing(_TempRelationIntrospection):
@@ -117,11 +139,11 @@ class TestTempRelationIntrospectionWithDatasharing(_TempRelationIntrospection):
         assert f'select * from "{temp_identifier}" limit 0' in logs
 
         # The queries the marker exists to skip.
-        for line in self._lines_mentioning(logs, temp_identifier):
-            assert "pg_get_late_binding_view_cols" not in line
-            assert 'from information_schema."columns"' not in line
-            assert "svv_columns" not in line
-            assert "SHOW COLUMNS" not in line
+        for entry in self._entries_mentioning(logs, temp_identifier):
+            assert "pg_get_late_binding_view_cols" not in entry
+            assert 'from information_schema."columns"' not in entry
+            assert "svv_columns" not in entry
+            assert "SHOW COLUMNS" not in entry
 
 
 class TestTempRelationIntrospectionWithoutDatasharing(_TempRelationIntrospection):
@@ -130,10 +152,10 @@ class TestTempRelationIntrospectionWithoutDatasharing(_TempRelationIntrospection
     def test_temp_relation_is_described_from_information_schema(self, project):
         logs, temp_identifier = self._incremental_run(project)
 
-        lines = self._lines_mentioning(logs, temp_identifier)
-        assert any('from information_schema."columns"' in line for line in lines)
+        entries = self._entries_mentioning(logs, temp_identifier)
+        assert any('from information_schema."columns"' in entry for entry in entries)
 
         # information_schema answers on the first query, so the expensive lookup that
         # motivated this change is still never reached here either.
-        for line in lines:
-            assert "pg_get_late_binding_view_cols" not in line
+        for entry in entries:
+            assert "pg_get_late_binding_view_cols" not in entry

--- a/dbt-redshift/tests/unit/test_make_temp_relation_macro.py
+++ b/dbt-redshift/tests/unit/test_make_temp_relation_macro.py
@@ -1,0 +1,164 @@
+"""
+Unit tests for redshift__make_temp_relation and the is_temporary marker it sets.
+
+The marker exists so RedshiftAdapter.get_columns_in_relation can recognise a relation dbt
+itself minted as a temporary table and describe it straight from the driver, instead of
+first spending two slow catalog queries on a lookup that cannot return rows on a datashare
+consumer database (dbt-labs/dbt-adapters#2156; the invisibility itself is #1947, #1991).
+"Unqualified" is a negative signal shared with other callers; this is the positive one.
+
+Relations here are real RedshiftRelations, because the load-bearing question is whether a
+declared dataclass field survives incorporate() -- which round-trips through
+to_dict(omit_none=True) -> deep_merge -> from_dict.
+
+postgres__make_temp_relation is stubbed rather than rendered: it lives in another package's
+adapters.sql, and jinja binds a template's own macros at compile time, so a bare render
+cannot give the postgres macros dbt's `return()` semantics when they call each other. The
+stub mirrors it exactly (suffix the identifier, then strip schema and database to none) and
+the tests assert the resulting shape, so a change to either macro that stopped producing a
+fully-unqualified relation still shows up here.
+"""
+
+import os
+
+import jinja2
+import pytest
+
+import dbt.include.redshift
+from dbt.adapters.contracts.relation import RelationType
+from dbt.adapters.redshift.relation import RedshiftRelation
+
+
+class MacroReturn(Exception):
+    """Mirrors dbt's `return()`, which unwinds the macro rather than emitting a value."""
+
+    def __init__(self, value):
+        self.value = value
+
+
+def _postgres_make_temp_relation(base_relation, suffix):
+    """Stand-in for postgres__make_temp_relation, the macro redshift's override delegates to.
+
+    Mirrors postgres__make_relation_with_suffix(dstring=True) followed by the incorporate
+    that nulls schema and database. The timestamp the real macro appends is fixed here so
+    assertions can be exact.
+    """
+    identifier = base_relation.identifier + suffix + "145430123456"
+    temp_relation = base_relation.incorporate(path={"identifier": identifier})
+    return temp_relation.incorporate(path={"schema": None, "database": None})
+
+
+def _load_macros():
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(os.path.join(dbt.include.redshift.PACKAGE_PATH, "macros")),
+        extensions=["jinja2.ext.do"],
+    )
+    template = env.get_template("adapters.sql")
+
+    def fake_return(value):
+        raise MacroReturn(value)
+
+    return template.make_module(
+        {
+            "return": fake_return,
+            "postgres__make_temp_relation": _postgres_make_temp_relation,
+        }
+    )
+
+
+def _make_temp_relation(base_relation, suffix="__dbt_tmp"):
+    macros = _load_macros()
+    try:
+        macros.redshift__make_temp_relation(base_relation, suffix)
+    except MacroReturn as macro_return:
+        return macro_return.value
+    raise AssertionError("macro did not return")
+
+
+@pytest.fixture
+def base_relation():
+    return RedshiftRelation.create(
+        database="my_db",
+        schema="my_schema",
+        identifier="my_model",
+        type=RelationType.Table,
+    )
+
+
+def test_temp_relation_is_marked_temporary(base_relation):
+    assert _make_temp_relation(base_relation).is_temporary is True
+
+
+def test_temp_relation_is_still_fully_unqualified(base_relation):
+    """The override must not change the shape postgres__make_temp_relation produces.
+
+    Both parts are load-bearing: the identifier suffix keeps the temp table from colliding
+    with the target, and stripping schema and database is what makes `create temporary
+    table` and the unqualified driver probe address the right relation. It is also the
+    condition the pre-existing empty-result fallback tests, which stays in place for
+    callers that are unqualified without being temp relations.
+    """
+    temp_relation = _make_temp_relation(base_relation)
+
+    assert temp_relation.database is None
+    assert temp_relation.schema is None
+    assert temp_relation.identifier == "my_model__dbt_tmp145430123456"
+
+
+def test_suffix_is_passed_through(base_relation):
+    # Microbatch appends a batch id to the suffix, and snapshots pass their own.
+    temp_relation = _make_temp_relation(base_relation, "__dbt_tmp_2024-01-01")
+
+    assert temp_relation.identifier.startswith("my_model__dbt_tmp_2024-01-01")
+    assert temp_relation.is_temporary is True
+
+
+def test_marker_is_false_by_default(base_relation):
+    # Anything dbt did not mint as a temp relation keeps the catalog path, so the default
+    # has to be falsey -- and a real bool rather than None, or omit_none would drop it from
+    # every incorporate() and from_dict would just reinstate the default anyway.
+    assert base_relation.is_temporary is False
+
+
+def test_marker_survives_incorporate(base_relation):
+    """incorporate() round-trips through to_dict(omit_none=True) -> deep_merge -> from_dict.
+
+    The temp relation is incorporated again downstream -- the materializations re-path it,
+    and quoting/limit changes go through the same call -- so a marker that did not survive
+    would silently put the slow catalog path back.
+    """
+    temp_relation = _make_temp_relation(base_relation)
+
+    reincorporated = temp_relation.incorporate(path={"identifier": "renamed__dbt_tmp"})
+
+    assert reincorporated.is_temporary is True
+    assert reincorporated.identifier == "renamed__dbt_tmp"
+    # ...and the rest of the shape is still intact after the round trip.
+    assert reincorporated.database is None
+    assert reincorporated.schema is None
+
+
+def test_marker_is_not_set_by_the_relation_helpers_that_keep_qualification(base_relation):
+    """Only temp relations get the marker; intermediate and backup relations must not.
+
+    postgres__make_intermediate_relation and postgres__make_backup_relation keep their
+    schema and database, so they are describable from the catalog normally and must not be
+    routed to the unqualified driver probe. They build their relation with the same
+    incorporate() calls, hence the field default is what governs.
+    """
+    intermediate = base_relation.incorporate(path={"identifier": "my_model__dbt_tmp"})
+    backup = base_relation.incorporate(
+        path={"identifier": "my_model__dbt_backup"}, type=RelationType.Table
+    )
+
+    assert intermediate.is_temporary is False
+    assert backup.is_temporary is False
+    assert (intermediate.database, intermediate.schema) == ("my_db", "my_schema")
+    assert (backup.database, backup.schema) == ("my_db", "my_schema")
+
+
+def test_unqualified_lookup_macro_is_still_defined():
+    # The marker makes the driver path reachable sooner; it does not remove the catalog
+    # lookup that other unqualified callers rely on.
+    macros = _load_macros()
+    assert hasattr(macros, "redshift__get_columns_in_relation_unqualified")

--- a/dbt-redshift/tests/unit/test_temp_relation_columns.py
+++ b/dbt-redshift/tests/unit/test_temp_relation_columns.py
@@ -144,15 +144,82 @@ class _StubAdapter:
 class TestGetColumnsInRelationFallback:
     """When the catalog result falls back to the driver, and when it must not."""
 
-    def _adapter(self):
+    def _adapter(self, datasharing=False):
         # Bypass __init__: the override needs only a real RedshiftAdapter for zero-arg super().
         adapter = RedshiftAdapter.__new__(RedshiftAdapter)
         adapter.get_columns_in_temp_relation = mock.Mock(return_value=["from_driver"])
+        adapter.use_show_apis = mock.Mock(return_value=datasharing)
         return adapter
+
+    def test_marked_temp_relation_skips_the_catalog_when_datasharing_is_on(self):
+        # The whole point of the marker: the two catalog queries cost ~90s per temp relation
+        # on a datashare consumer and cannot return rows there, so they must not run at all.
+        adapter = self._adapter(datasharing=True)
+        relation = mock.Mock(
+            database=None, schema=None, identifier="model__dbt_tmp123", is_temporary=True
+        )
+
+        with mock.patch.object(
+            SQLAdapter, "get_columns_in_relation", return_value=["from_catalog"]
+        ) as from_catalog:
+            assert RedshiftAdapter.get_columns_in_relation(adapter, relation) == ["from_driver"]
+
+        from_catalog.assert_not_called()
+        adapter.get_columns_in_temp_relation.assert_called_once_with(relation)
+
+    def test_marked_temp_relation_still_uses_the_catalog_when_datasharing_is_off(self):
+        # Without datasharing the catalog can see temp relations, so the first query returns
+        # and the expensive late-binding lookup is never reached -- there is nothing to win,
+        # and the driver's type names are only ground truth for the OIDs it maps. Keeping the
+        # catalog here is what confines this change to datashare consumers.
+        adapter = self._adapter(datasharing=False)
+        relation = mock.Mock(
+            database=None, schema=None, identifier="model__dbt_tmp123", is_temporary=True
+        )
+
+        with mock.patch.object(
+            SQLAdapter, "get_columns_in_relation", return_value=["from_catalog"]
+        ) as from_catalog:
+            assert RedshiftAdapter.get_columns_in_relation(adapter, relation) == ["from_catalog"]
+
+        from_catalog.assert_called_once()
+        adapter.get_columns_in_temp_relation.assert_not_called()
+
+    def test_marked_temp_relation_invisible_without_datasharing_still_falls_back(self):
+        # A consumer database reached without `datasharing` set: the marker is not acted on,
+        # so the empty-result net is the only thing standing between the user and
+        # sync_all_columns dropping every target column. It has to still fire.
+        adapter = self._adapter(datasharing=False)
+        relation = mock.Mock(
+            database=None, schema=None, identifier="model__dbt_tmp123", is_temporary=True
+        )
+
+        with mock.patch.object(SQLAdapter, "get_columns_in_relation", return_value=[]):
+            assert RedshiftAdapter.get_columns_in_relation(adapter, relation) == ["from_driver"]
+
+        adapter.get_columns_in_temp_relation.assert_called_once_with(relation)
+
+    def test_relation_without_the_marker_still_uses_the_catalog(self):
+        # Relations reach this method from dbt-core and from other adapters' Relation classes
+        # too, so a missing attribute has to read as "not a temp relation" rather than raise.
+        adapter = self._adapter(datasharing=True)
+        relation = mock.Mock(spec=["database", "schema", "identifier"])
+        relation.database = "db"
+        relation.schema = "sch"
+        relation.identifier = "my_model"
+
+        with mock.patch.object(
+            SQLAdapter, "get_columns_in_relation", return_value=["from_catalog"]
+        ):
+            assert RedshiftAdapter.get_columns_in_relation(adapter, relation) == ["from_catalog"]
+
+        adapter.get_columns_in_temp_relation.assert_not_called()
 
     def test_catalog_result_is_returned_without_touching_the_driver(self):
         adapter = self._adapter()
-        relation = mock.Mock(database=None, schema=None, identifier="model__dbt_tmp123")
+        relation = mock.Mock(
+            database=None, schema=None, identifier="model__dbt_tmp123", is_temporary=False
+        )
 
         with mock.patch.object(
             SQLAdapter, "get_columns_in_relation", return_value=["from_catalog"]
@@ -162,8 +229,12 @@ class TestGetColumnsInRelationFallback:
         adapter.get_columns_in_temp_relation.assert_not_called()
 
     def test_invisible_temp_relation_falls_back_to_the_driver(self):
+        # Unmarked but unqualified: the pre-existing net, for callers other than
+        # redshift__make_temp_relation. Describe from the catalog first, driver only if empty.
         adapter = self._adapter()
-        relation = mock.Mock(database=None, schema=None, identifier="model__dbt_tmp123")
+        relation = mock.Mock(
+            database=None, schema=None, identifier="model__dbt_tmp123", is_temporary=False
+        )
 
         with mock.patch.object(SQLAdapter, "get_columns_in_relation", return_value=[]):
             assert RedshiftAdapter.get_columns_in_relation(adapter, relation) == ["from_driver"]
@@ -173,7 +244,9 @@ class TestGetColumnsInRelationFallback:
     def test_qualified_relation_with_no_columns_does_not_fall_back(self):
         # The driver query is unqualified, so it would resolve to the wrong relation.
         adapter = self._adapter()
-        relation = mock.Mock(database="db", schema="sch", identifier="my_model")
+        relation = mock.Mock(
+            database="db", schema="sch", identifier="my_model", is_temporary=False
+        )
 
         with mock.patch.object(SQLAdapter, "get_columns_in_relation", return_value=[]):
             assert RedshiftAdapter.get_columns_in_relation(adapter, relation) == []

--- a/dbt-redshift/tests/unit/test_temp_relation_columns.py
+++ b/dbt-redshift/tests/unit/test_temp_relation_columns.py
@@ -167,6 +167,25 @@ class TestGetColumnsInRelationFallback:
         from_catalog.assert_not_called()
         adapter.get_columns_in_temp_relation.assert_called_once_with(relation)
 
+    def test_marked_relation_that_is_qualified_does_not_take_the_driver_path(self):
+        # get_columns_in_temp_relation queries `select * from <identifier>` with no database
+        # or schema, so a qualified relation would resolve through search_path and describe
+        # whatever else answers to that identifier -- quietly, since it would return columns.
+        # No producer of a marked relation qualifies it today; this pins the precondition so
+        # that stays true, and matches the check the empty-result fallback already makes.
+        adapter = self._adapter(datasharing=True)
+        relation = mock.Mock(
+            database="db", schema="sch", identifier="model__dbt_tmp123", is_temporary=True
+        )
+
+        with mock.patch.object(
+            SQLAdapter, "get_columns_in_relation", return_value=["from_catalog"]
+        ) as from_catalog:
+            assert RedshiftAdapter.get_columns_in_relation(adapter, relation) == ["from_catalog"]
+
+        from_catalog.assert_called_once()
+        adapter.get_columns_in_temp_relation.assert_not_called()
+
     def test_marked_temp_relation_still_uses_the_catalog_when_datasharing_is_off(self):
         # Without datasharing the catalog can see temp relations, so the first query returns
         # and the expensive late-binding lookup is never reached -- there is nothing to win,


### PR DESCRIPTION
resolves #2156 

### Problem

- In #2097 we created a shortcut to column introspect on a temp relation. We needed this path because for temporary relations created when the connection's database is a datashare consumer database, they are absent from every catalog view. So, we utilized the redshift driver's `cursor.description` to build the column list.
-  #2110 then moved that fallback out of the macro into the Python `get_columns_in_relation` override, which is the structure this PR extends.
- #2104 created a third path to introspect columns in redshift, specifically for the case where we are introspecting on an unqualified relation. This meant unqualified relations now use the bound-table lookup, falling back to the full legacy query when nothing matches to keep previous behavior in other callers.

We had a customer test this exact scenario: incremental model (which creates a temp relation) selecting from a datashare database upstream, they opened a ticket after testing (zendesk #135439).

They expected these jobs to execute quite quickly, but instead found them running for over 30 minutes. They shared their debug logs, and here's what I found happening on one thread trying to describe a single temp relation:

| query | time | rows | Related PR |
|---|---|---|---|
| `information_schema."columns"` | 46.993s | 0 | #2104  |
| legacy w/ `pg_get_late_binding_view_cols()` | 44.596s | 0 | Predates monorepo |
| `select * from <tmp> limit 0` | 0.071s | the actual answer | #2097, moved by #2110 |
| `SHOW COLUMNS` (target relation, for scale) | 0.034s | — | #1673 |

This is something of a performance regression because the legacy query cost 45s but now it pays 91s. The intended fix in #2097 simply takes too long to reach and makes for an unusable experience. 

### Solution

So, I believe we need to create a shortcut for the scenario where dbt creates a temporary unqualified relation. I prefer using a positive signal where we know we're dealing with this exact case and allow a shortcut introspection. To do that we need an additional "marker" from the relation class to be certain.

- **`RedshiftRelation.is_temporary`**: a new declared field, defaulting to `False`. There is no `is_temporary` on `BaseRelation` and no temp-flavoured `RelationType`, so the field has to be added. A declared dataclass field survives `incorporate()` (`to_dict(omit_none=True)` → `deep_merge` → `from_dict`), and `False` is not `None`, so `omit_none` does not drop it.
- **`redshift__make_temp_relation`**: a new override that delegates to `postgres__make_temp_relation` (the only code in dbt-adapters / dbt-postgres / dbt-redshift that strips both schema and database to `none`) and then incorporates the marker. The relation's shape is unchanged.
- **`RedshiftAdapter.get_columns_in_relation`**: marked relations go straight to `get_columns_in_temp_relation` when `use_show_apis()` is true. Everything else, including relations that are merely unqualified, keeps the existing behaviour: describe from the catalog, fall back to the driver only if that comes back empty.

Some considerations:

- The branch is in Python rather than in the macro because `get_columns_in_temp_relation` is not `@available`, and because keeping it in the override means `@supports_replay` records the fallback under the existing `AdapterGetColumnsInRelationRecord`.
- "Unqualified" is a negative signal, and it is shared with any other caller that arrives without a database or schema. Deleting the fallthrough would change what those callers get; a positive marker means the fast path is only taken for relations dbt minted as temp tables, and the existing empty-result net stays exactly as it is.
- Without `datasharing`, `information_schema` *can* see temp relations, so the first query returns and the expensive late-binding lookup is never reached, this is a `datasharing`-specific issue.


There is a scenario where a consumer database reached *without* `datasharing` set
still pays the ~90s. It stays correct, because the empty-result net still calls the
driver, and `datasharing` is already what gates the SHOW / SVV_* APIs needed for
cross-database work on a consumer database. Happy to widen the gate if reviewers
disagree.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
