### PR TITLE
fix(redshift): unconditionally type cast during sync_all_columns

### DIFF
--- a/dbt-redshift/.changes/unreleased/Fixes-20260904-120000.yaml
+++ b/dbt-redshift/.changes/unreleased/Fixes-20260904-120000.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Cast explicitly when migrating a column type in `redshift__alter_column_type`, so
+    `on_schema_change='sync_all_columns'` can apply type changes across type categories
+    (e.g. varchar to bigint) instead of failing on an uncasted copy
+time: 2026-09-04T12:00:00.000000-07:00
+custom:
+    Author: trouze
+    Issue: "2159"

--- a/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
+++ b/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql
@@ -462,13 +462,13 @@
 {% macro redshift__alter_column_type(relation, column_name, new_column_type) -%}
   {#
     Redshift ALTER COLUMN TYPE only supports VARCHAR and VARBYTE (size changes).
-    For those, use native ALTER; for any other type change, fall back to
-    default add/copy/drop/rename.
+    For those, use native ALTER; for any other type change, migrate the column
+    with add/copy/drop/rename.
 
     The native ALTER TABLE ALTER COLUMN cannot run inside a transaction block.
     It is only safe to use when `redshift_skip_autocommit_transaction_statements`
     is enabled (i.e. we are not wrapping statements in BEGIN/COMMIT).
-    When the flag is off, always use the default migration path.
+    When the flag is off, always use the migration path.
   #}
   {% set type_lower = (new_column_type | lower) | trim %}
   {% set skip_txn = adapter.behavior.redshift_skip_autocommit_transaction_statements.no_warn %}
@@ -477,7 +477,28 @@
       alter table {{ relation.render() }} alter column {{ adapter.quote(column_name) }} type {{ new_column_type }}
     {% endcall %}
   {% else %}
-    {{ default__alter_column_type(relation, column_name, new_column_type) }}
+    {#
+      1. Create a new column (w/ temp name and correct type)
+      2. Copy data over to it, casting explicitly
+      3. Drop the existing column (cascade!)
+      4. Rename the new column to existing column
+
+      This mirrors `default__alter_column_type`, except the copy step casts
+      instead of relying on an implicit assignment cast. Redshift only has
+      implicit assignment casts within a type category, so an uncasted copy
+      fails outright for pairs like varchar -> bigint even when every value
+      would convert cleanly. The explicit cast lets the warehouse's own cast
+      rules decide, so the migration succeeds whenever the data is actually
+      convertible and otherwise fails with the offending value in the error.
+    #}
+    {%- set tmp_column = column_name + "__dbt_alter" -%}
+
+    {% call statement('alter_column_type') %}
+      alter table {{ relation.render() }} add column {{ adapter.quote(tmp_column) }} {{ new_column_type }};
+      update {{ relation.render() }} set {{ adapter.quote(tmp_column) }} = cast({{ adapter.quote(column_name) }} as {{ new_column_type }});
+      alter table {{ relation.render() }} drop column {{ adapter.quote(column_name) }} cascade;
+      alter table {{ relation.render() }} rename column {{ adapter.quote(tmp_column) }} to {{ adapter.quote(column_name) }}
+    {% endcall %}
   {% endif %}
 {% endmacro %}
 

--- a/dbt-redshift/tests/functional/adapter/cross_database/test_incremental.py
+++ b/dbt-redshift/tests/functional/adapter/cross_database/test_incremental.py
@@ -65,6 +65,22 @@ class TestIncrementalCrossDatabaseColumnType(CrossDatabaseMixin, _BaseColumnType
             project.adapter, project.test_schema, "incremental_int_to_bigint"
         )
 
+    def test_incremental_varchar_to_bigint_succeeds_and_matches_target(self, project):
+        select = "incremental_varchar_to_bigint incremental_varchar_to_bigint_target"
+        run_dbt(["run", "--select", select])
+        run_dbt(["run", "--select", select])
+        assert_cross_db_relation_exists(
+            project.adapter, project.test_schema, "incremental_varchar_to_bigint"
+        )
+
+    def test_incremental_varchar_to_timestamp_succeeds_and_matches_target(self, project):
+        select = "incremental_varchar_to_timestamp incremental_varchar_to_timestamp_target"
+        run_dbt(["run", "--select", select])
+        run_dbt(["run", "--select", select])
+        assert_cross_db_relation_exists(
+            project.adapter, project.test_schema, "incremental_varchar_to_timestamp"
+        )
+
 
 class TestIncrementalCrossDatabaseSpecialChars(CrossDatabaseMixin, _BaseSpecialCharsTest):
     """Test incremental append/sync with special character column names

--- a/dbt-redshift/tests/functional/adapter/incremental/test_incremental_on_schema_change.py
+++ b/dbt-redshift/tests/functional/adapter/incremental/test_incremental_on_schema_change.py
@@ -90,6 +90,68 @@ with source_data as (
 select id, counter::bigint as counter from source_data
 """
 
+# varchar -> bigint has no implicit assignment cast in Redshift, so the copy
+# step of the migration path has to cast explicitly. See #2159.
+_INCREMENTAL_VARCHAR_TO_BIGINT = """
+{{
+    config(
+        materialized='incremental',
+        unique_key='id',
+        on_schema_change='sync_all_columns'
+    )
+}}
+with source_data as (
+    select 1 as id, '123' as amount
+    union all select 2, '456'
+)
+{% if is_incremental() %}
+select id, amount::bigint as amount from source_data where id not in (select id from {{ this }})
+{% else %}
+select id, cast(amount as varchar(50)) as amount from source_data
+{% endif %}
+"""
+
+_INCREMENTAL_VARCHAR_TO_BIGINT_TARGET = """
+{{
+    config(materialized='table')
+}}
+with source_data as (
+    select 1 as id, '123' as amount
+    union all select 2, '456'
+)
+select id, amount::bigint as amount from source_data
+"""
+
+_INCREMENTAL_VARCHAR_TO_TIMESTAMP = """
+{{
+    config(
+        materialized='incremental',
+        unique_key='id',
+        on_schema_change='sync_all_columns'
+    )
+}}
+with source_data as (
+    select 1 as id, '2026-01-01 12:00:00' as event_at
+    union all select 2, '2026-01-02 13:30:00'
+)
+{% if is_incremental() %}
+select id, event_at::timestamp as event_at from source_data where id not in (select id from {{ this }})
+{% else %}
+select id, cast(event_at as varchar(50)) as event_at from source_data
+{% endif %}
+"""
+
+_INCREMENTAL_VARCHAR_TO_TIMESTAMP_TARGET = """
+{{
+    config(materialized='table')
+}}
+with source_data as (
+    select 1 as id, '2026-01-01 12:00:00' as event_at
+    union all select 2, '2026-01-02 13:30:00'
+)
+select id, event_at::timestamp as event_at from source_data
+"""
+
 # Test fixtures for special character column names
 _MODEL_A_SPECIAL_CHARS = """
 {{
@@ -283,7 +345,9 @@ class TestIncrementalOnSchemaChangeColumnType(BaseIncrementalOnSchemaChangeSetup
     """Test incremental schema change when column *type* changes (redshift__alter_column_type).
 
     - VARCHAR expand: expand_target_column_types -> native ALTER COLUMN TYPE.
-    - INTEGER -> BIGINT: process_schema_changes -> default add/copy/drop/rename.
+    - INTEGER -> BIGINT: process_schema_changes -> add/copy/drop/rename.
+    - VARCHAR -> BIGINT / TIMESTAMP: same migration path, but across type
+      categories, so the copy step only works because it casts explicitly.
     """
 
     @pytest.fixture(scope="class")
@@ -293,6 +357,10 @@ class TestIncrementalOnSchemaChangeColumnType(BaseIncrementalOnSchemaChangeSetup
             "incremental_varchar_expand_target.sql": _INCREMENTAL_VARCHAR_EXPAND_TARGET,
             "incremental_int_to_bigint.sql": _INCREMENTAL_INT_TO_BIGINT,
             "incremental_int_to_bigint_target.sql": _INCREMENTAL_INT_TO_BIGINT_TARGET,
+            "incremental_varchar_to_bigint.sql": _INCREMENTAL_VARCHAR_TO_BIGINT,
+            "incremental_varchar_to_bigint_target.sql": _INCREMENTAL_VARCHAR_TO_BIGINT_TARGET,
+            "incremental_varchar_to_timestamp.sql": _INCREMENTAL_VARCHAR_TO_TIMESTAMP,
+            "incremental_varchar_to_timestamp_target.sql": _INCREMENTAL_VARCHAR_TO_TIMESTAMP_TARGET,
         }
 
     def test_incremental_varchar_expand_succeeds_and_matches_target(self, project):
@@ -315,4 +383,26 @@ class TestIncrementalOnSchemaChangeColumnType(BaseIncrementalOnSchemaChangeSetup
         check_relations_equal(
             project.adapter,
             ["incremental_int_to_bigint", "incremental_int_to_bigint_target"],
+        )
+
+    def test_incremental_varchar_to_bigint_succeeds_and_matches_target(self, project):
+        select = "incremental_varchar_to_bigint incremental_varchar_to_bigint_target"
+        # First run - creates initial table with a varchar column
+        run_dbt(["run", "--select", select])
+        # Second run - crosses type categories, so the copy step must cast
+        run_dbt(["run", "--select", select])
+        check_relations_equal(
+            project.adapter,
+            ["incremental_varchar_to_bigint", "incremental_varchar_to_bigint_target"],
+        )
+
+    def test_incremental_varchar_to_timestamp_succeeds_and_matches_target(self, project):
+        select = "incremental_varchar_to_timestamp incremental_varchar_to_timestamp_target"
+        # First run - creates initial table with a varchar column
+        run_dbt(["run", "--select", select])
+        # Second run - crosses type categories, so the copy step must cast
+        run_dbt(["run", "--select", select])
+        check_relations_equal(
+            project.adapter,
+            ["incremental_varchar_to_timestamp", "incremental_varchar_to_timestamp_target"],
         )

--- a/dbt-redshift/tests/unit/test_alter_column_type_macro.py
+++ b/dbt-redshift/tests/unit/test_alter_column_type_macro.py
@@ -1,0 +1,83 @@
+from types import SimpleNamespace
+
+import jinja2
+
+
+def _render_alter_column_type(column_name, new_column_type, skip_txn=False):
+    """Render redshift__alter_column_type and return the SQL it would execute."""
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader("src/dbt/include/redshift/macros"),
+        extensions=["jinja2.ext.do"],
+    )
+    template = env.get_template("adapters.sql")
+
+    statements = []
+
+    # jinja passes a `{% call %}` block's body as `caller`, which is how we
+    # capture the SQL the macro would have executed.
+    def statement_macro(name, caller=None, **kwargs):
+        statements.append(caller())
+        return ""
+
+    behavior = SimpleNamespace(
+        redshift_skip_autocommit_transaction_statements=SimpleNamespace(no_warn=skip_txn)
+    )
+    adapter = SimpleNamespace(behavior=behavior, quote=lambda value: f'"{value}"')
+    relation = SimpleNamespace(render=lambda: "my_db.my_schema.my_table")
+
+    macros = template.make_module({"adapter": adapter, "statement": statement_macro})
+    macros.redshift__alter_column_type(relation, column_name, new_column_type)
+    return "\n".join(statements)
+
+
+def test_varchar_uses_native_alter_when_skipping_transactions():
+    rendered = _render_alter_column_type("my_col", "varchar(500)", skip_txn=True)
+    assert "alter column" in rendered
+    assert "type varchar(500)" in rendered
+    assert "__dbt_alter" not in rendered
+    assert "cast(" not in rendered
+
+
+def test_varbyte_uses_native_alter_when_skipping_transactions():
+    rendered = _render_alter_column_type("my_col", "varbyte(128)", skip_txn=True)
+    assert "alter column" in rendered
+    assert "__dbt_alter" not in rendered
+
+
+def test_character_varying_uses_native_alter_when_skipping_transactions():
+    rendered = _render_alter_column_type("my_col", "character varying(500)", skip_txn=True)
+    assert "alter column" in rendered
+    assert "__dbt_alter" not in rendered
+
+
+def test_varchar_migrates_with_cast_when_not_skipping_transactions():
+    # Native ALTER COLUMN TYPE cannot run inside a transaction block, so even
+    # varchar takes the migration path when the behavior flag is off.
+    rendered = _render_alter_column_type("my_col", "varchar(500)")
+    assert 'add column "my_col__dbt_alter" varchar(500)' in rendered
+    assert 'set "my_col__dbt_alter" = cast("my_col" as varchar(500))' in rendered
+
+
+def test_cross_category_change_casts_explicitly():
+    rendered = _render_alter_column_type("my_col", "bigint")
+    assert 'set "my_col__dbt_alter" = cast("my_col" as bigint)' in rendered
+    # the uncasted copy from default__alter_column_type is what #2159 fixes
+    assert 'set "my_col__dbt_alter" = "my_col"' not in rendered
+
+
+def test_multi_word_type_casts_explicitly():
+    rendered = _render_alter_column_type("my_ts_col", "timestamp without time zone")
+    assert (
+        'set "my_ts_col__dbt_alter" = cast("my_ts_col" as timestamp without time zone)' in rendered
+    )
+
+
+def test_migration_emits_full_add_copy_drop_rename_sequence():
+    rendered = _render_alter_column_type("my_col", "bigint")
+    statements = [line.strip() for line in rendered.splitlines() if line.strip()]
+    assert statements == [
+        'alter table my_db.my_schema.my_table add column "my_col__dbt_alter" bigint;',
+        'update my_db.my_schema.my_table set "my_col__dbt_alter" = cast("my_col" as bigint);',
+        'alter table my_db.my_schema.my_table drop column "my_col" cascade;',
+        'alter table my_db.my_schema.my_table rename column "my_col__dbt_alter" to "my_col"',
+    ]


### PR DESCRIPTION
resolves #2159 
no docs changes needed

### Problem

`redshift__alter_column_type` handles varchar/varbyte size changes [with a native](https://github.com/dbt-labs/dbt-adapters/blob/2d5a9cef960651178bb66bb068eb0efaca8c7c59/dbt-redshift/src/dbt/include/redshift/macros/adapters.sql#L477) `ALTER COLUMN ... TYPE` and falls through to `default__alter_column_type` for everything else. That [fallthrough](https://github.com/dbt-labs/dbt-adapters/blob/2d5a9cef960651178bb66bb068eb0efaca8c7c59/dbt-adapters/src/dbt/include/global_project/macros/adapters/columns.sql#L124) copies the old column into the new one with no cast.

```sql
update {{ relation }} set "{{ col }}__dbt_alter" = "{{ col }}";
```

Redshift only has implicit assignment casts within a type category, so cross-catagory changes are rejected outright:

```
column "my_int_col__dbt_alter is of type bigint but expression is of type character varying
```

This is a type-level failure of the SQL being issued, not necessarily indicative of what Redshift can and can't do. `on_schema_change: sync_all_columns` can detect the change, but will fail to apply a cast due to the above. This forces customers on Redshift to migrate data types by hand and, as I call out in the [issue](https://github.com/dbt-labs/dbt-adapters/issues/2159), we have precedents for unconditionally type casting with BigQuery, Athena (when using iceberg tables), and we delegate this to Snowflake and Spark who have native rules when issuing `ALTER COLUMN ... TYPE / SET DATA TYPE` statements.

### Solution

I propose we replace the fallback to `default__alter_column_type` with something similar, just casting to the new column type instead.

```sql
update {{ relation }} set "{{ col }}__dbt_alter" = cast("{{ col }}" as {{ new_column_type }});
```

Alternatives considered:
- We could do nothing at all and put it on users to explicitly cast in their models, override this themselves, or full refresh/manually alter column types by hand. While I think there's precedent for unconditionally casting, at a minimum we should improve the error messaging to suggest that there's a data type mismatch and users should perform a full refresh to resolve the error
- We could attempt to whitelist a set of "safe pairs", but this would put burden on us to keep it in-sync rather than simply delegating to the database, and BigQuery doesn't do this

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-adapters/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
